### PR TITLE
Run the pipeline against a live Kusto emulator; fix the defects it surfaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ script names, sourcetypes, field names, and app layouts included.
 
 ## [Unreleased]
 
+### Fixed — first run against a live Kusto emulator
+
+- **The Kusto backend has now been run end-to-end against the real
+  `kustainer-linux` engine** (deploy → apply → ingest → `CarCoverage()`), with
+  data processed from the Digital Corpora sample URLs. It surfaced four defects
+  that were invisible until first contact, all fixed:
+  - `network` is a **reserved word** in the engine grammar, so
+    `.create database network volatile` failed with `General_BadRequest`.
+    Database names in `00-databases.kql` are now bracket-quoted
+    (`.create database ["network"] volatile`), and the two places that parse
+    names back out (`apply-kusto-schema.sh`, `tests/run-checks.sh`) strip the
+    brackets.
+  - `CarCoverage()` used the `0L` typed-integer-literal suffix, which this
+    emulator build rejects (`SEM0100`). Replaced with `long(0)`.
+  - `CarFile()` left 260 of 1240 real Plaso rows with an empty `action`: its
+    `modify` regex matched only `content modification`, but a real NTFS image
+    emits `Metadata Modification Time` and `File Last Modification Time` too.
+    Broadened to `(?i)modification|mtime`; all rows now classify.
+- **`pid` hex conversion verified** ([issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14)
+  item 6): `tolong()` accepts a `0x`-prefixed string at run time, so
+  `CarProcess.pid` is populated. Comment in `40-mitre.kql` updated from
+  "unverified" to the confirmed behaviour.
+- **Processed three real `.E01` images with Plaso** and validated the `L2tCsv`
+  schema/mapping, `datetime` parsing, header handling, and the
+  `source_long → CAR-object` routing. Zeek `conn` and EvtxECmd ingest paths
+  (and `CarFlow`/`CarProcess`/`CarUserSession`/`CarService`) were validated
+  against the live engine with format-accurate fixtures, since the Zeek image
+  and standalone `.evtx` are blocked by egress policy here. Full field and
+  source-type breakdown: [docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
+
 ### Removed — the Splunk stack. The SIEM is the Data Explorer emulator now.
 
 - **The project pivoted: the Kusto emulator is the analysis backend, and the

--- a/docs/Kusto-Port.md
+++ b/docs/Kusto-Port.md
@@ -1,9 +1,18 @@
 # 🧊 The Kusto emulator — the analysis backend
 
-> **Status: built, unverified.** Stages 1-5 are implemented; three sources are
-> not wired up — see [What is not done](#what-is-not-done). Nothing has run
-> against a real emulator, because there is no Docker in the environment this
-> was written in.
+> **Status: run against a live emulator.** Stages 1-3 (deploy, apply, ingest)
+> and the five sourced CAR objects have now been exercised end-to-end on the
+> real `kustainer-linux` engine — see
+> [docs/Runtime-Validation.md](/docs/Runtime-Validation.md). That run fixed four
+> "parsed in review, failed on first contact" defects (reserved-word `network`
+> database name, the `0L` literal in `CarCoverage`, the two name parsers, and an
+> unmapped-`action` gap in `CarFile`) and resolved the `pid` hex-conversion
+> unknown ([issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14) item 6).
+> Plaso was run for real on three `.E01` images; the Zeek and EvtxECmd **engines**
+> remain unrun here (egress policy blocks the `zeek/zeek` image and there is no
+> standalone `.evtx` in the corpus), so their ingest/mapping/CAR paths were
+> proven with format-accurate fixtures. Three sources are still not wired up —
+> see [What is not done](#what-is-not-done).
 >
 > **This began as a port alongside Splunk and is now the SIEM.** The Splunk
 > stack was retired; the emulator is the only analysis backend. The
@@ -178,9 +187,13 @@ Stated plainly so it is not mistaken for working:
   alongside driver/module/thread.
 - **Only `conn.log` of Zeek's 69 log types is ingested.** It is the one
   `car_flow` needs. The generic `Zeek` table exists for the rest.
-- **Nothing has been run against a real emulator.** No Docker here. The full
-  list of unverified assumptions, ranked by blast radius, is
-  [issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14).
+- **Deploy/apply/ingest and five CAR objects have now run against a real
+  emulator** — see [docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
+  What is *still* unverified: the Zeek and EvtxECmd **engines** producing that
+  input (fixtures stood in for them), a Windows disk image through Plaso (only
+  filesystem test images were run, so `CarProcess`-from-Plaso is unexercised),
+  and the two unimplemented loaders below. The remaining list, ranked by blast
+  radius, is [issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14).
 
   An earlier version of this document claimed the scripts were "verified"
   against a fake HTTP endpoint. That was an overclaim: the fake returned
@@ -195,9 +208,11 @@ Stated plainly so it is not mistaken for working:
   `.execute database script`; and the Zeek column-order guard run against three
   fixtures (correct, swapped, headerless). Everything else remains unverified.
 
-- **`pid` conversion is unverified.** Windows writes PIDs as hex strings and
-  KQL has no base-16 string parser. `pid_hex` is always correct; `pid` relies on
-  `tolong()` accepting a `0x` prefix, which is untested. See the note in
+- **`pid` conversion is now verified.** `tolong()` accepts a `0x`-prefixed
+  string at run time on the live emulator (`tolong("0x1a4")` = 420), so `pid` is
+  populated for EvtxECmd 4688/4689 rows. `pid_hex` stays as the always-correct
+  raw form because the un-prefixed form (`tolong("1a4")`) is null. See
+  [docs/Runtime-Validation.md](/docs/Runtime-Validation.md) and the note in
   `40-mitre.kql`.
 
 ### Stage 1 detail

--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -1,0 +1,202 @@
+# 🧪 Runtime validation — fields, source types, and CAR coverage
+
+This is the first record of the pipeline **run against a live Kusto emulator**
+with data processed from the [Digital Corpora](https://digitalcorpora.org/)
+sample URLs in [`dev-scripts/samples-manifest.tsv`](/dev-scripts/samples-manifest.tsv).
+It establishes the fields each source actually emits, how one piece of evidence
+breaks down into ADX *source types*, and which MITRE CAR objects those source
+types populate. It also records the defects the live run surfaced — every one
+of them a "parsed in review, failed the moment it ran" bug that no fake could
+have caught.
+
+> **What ran against real tooling vs. what was validated with a fixture.**
+> This distinction is load-bearing and is kept honest throughout:
+>
+> | Lane | Input produced by | ADX ingest + mapping + CAR |
+> |:---|:---|:---|
+> | **Plaso → `host.L2tCsv`** | ✅ real `psteal` on three real `.E01` images | ✅ verified live |
+> | **Zeek → `network.ZeekConn`** | ⚠️ format-accurate `conn.log` fixture¹ | ✅ verified live |
+> | **EvtxECmd → `host.EvtxEcmdJson`** | ⚠️ format-accurate JSON fixture¹ | ✅ verified live |
+>
+> ¹ The Zeek image (`zeek/zeek`) and the OpenSUSE OBS Zeek packages are both
+> refused at the network egress proxy (`403` on CONNECT), and there is no
+> standalone `.evtx` in the corpus (real event logs live only inside the
+> multi-GB Windows disk images — LoneWolf, Narcos). So the Zeek and EvtxECmd
+> **engines** could not be run here. Their **output formats are deterministic**,
+> so a byte-accurate fixture of what each tool emits was used to drive the ADX
+> side — which is the half this project had never exercised. Plaso *was* run for
+> real: it installs from PyPI (`pip install plaso`, pulling the compiled libyal
+> readers), which the proxy allows.
+
+The emulator image (`mcr.microsoft.com/azuredataexplorer/kustainer-linux`)
+pulls from Microsoft Container Registry, which the proxy allows — so the ADX
+backend itself is fully real.
+
+---
+
+## The headline: `CarCoverage()` against real + fixture data
+
+Deploy → apply → ingest, from a clean container:
+
+```
+Object         Rows
+file           1240     <- Plaso, three real .E01 images
+flow              4     <- Zeek conn.log fixture
+user_session      1     <- EvtxECmd 4624 fixture
+service           1     <- EvtxECmd 7045 fixture
+process           1     <- EvtxECmd 4688 fixture
+registry          0     <- unsourced (awaits Velociraptor/EZ-Tools)
+driver            0     <- unsourced (needs Sysmon/live agent)
+module            0     <- unsourced
+thread            0     <- unsourced
+```
+
+Five of nine CAR objects now carry data end-to-end; the four zeros are the
+honest, documented gaps, not failures. The README's "envisioned endstate"
+query returns a real row now:
+
+```kusto
+CarProcess() | where isnotempty(command_line)
+| project dtg = Timestamp, hostname, user, command_line, artifact = Origin
+```
+```
+dtg                          hostname  user       command_line                                         artifact
+2025-01-01T10:14:29.123Z     WKS-1     analyst01  powershell.exe -nop -exec bypass Invoke-Mimikatz.ps1 evtx:4688
+```
+
+---
+
+## Defects the live run surfaced (all fixed)
+
+| # | File | Symptom on the live emulator | Fix |
+|:--|:--|:--|:--|
+| 1 | `kusto/schema/00-databases.kql` | `.create database network volatile` → **`General_BadRequest`**. `network` is a reserved word in the engine grammar; a bare name that read fine and failed on first contact. `host` created only because it happened to be first. | Bracket-quote every name: `.create database ["network"] volatile`. Downstream `database("network")` refs were already string-quoted. |
+| 2 | `scripts/apply-kusto-schema.sh`, `tests/run-checks.sh` | The two places that parse database names out of the `.kql` expected the bare form and would have read every DB as absent once #1 was bracketed. | Bracket-tolerant regex that strips `["…"]` back to the plain name; command construction brackets the name too. |
+| 3 | `kusto/schema/40-mitre.kql` — `CarCoverage()` | `print Object="registry", Rows = 0L` → **`SEM0100: Failed to resolve … '0L'`**. This emulator build rejects the typed-integer-literal suffix (`0L`), though it is valid in the cloud grammar. | `long(0)` — accepted by both, keeps the column a `long`. |
+| 4 | `kusto/schema/40-mitre.kql` — `CarFile()` | 260 of 1240 real Plaso rows got an **empty `action`**. The `modify` regex matched only `content modification`, but a real NTFS image emits three modification descriptions. | Broaden the branch to `(?i)modification\|mtime`, capturing `Content`, `Metadata` and `File Last` modification times. All 1240 rows now classify. |
+
+And one **unknown resolved rather than a bug** — [issue #14, item 6](https://github.com/Get-Sybers/DX_DFIR/issues/14):
+
+> **`pid` hex conversion works.** `CarProcess` sets `pid = tolong(NewProcessId)`
+> where `NewProcessId` is a hex string like `"0x1a4"`. Whether `tolong()`
+> accepts a `0x` string *at runtime* (as opposed to a `0x` integer literal) was
+> flagged untested. It does: `tolong("0x1a4")` → `420`, `tolong("0x1234")` →
+> `4660`. Confirmed both in isolation and on the ingested 4688 row (`pid=420`,
+> `pid_hex="0x1a4"`). Note `tolong("1a4")` *without* the prefix → `null`, so the
+> `pid_hex` raw fallback is still worth keeping — but EvtxECmd always emits the
+> `0x` form, so `pid` is populated.
+
+---
+
+## Fields established, per source
+
+### Plaso — `host.L2tCsv` (real)
+
+`psteal --output-format dynamic` with the 23-field list in
+`process-log2timeline-Dynamic.sh`. The emitted CSV **header order matches the
+`--fields` list and the `L2tCsvMapping` ordinals exactly** (verified column by
+column), so the ordinal mapping is correct:
+
+```
+0 date        1 datetime(->Timestamp)  2 description   3 description_short
+4 display_name 5 filename  6 host  7 hostname  8 inode  9 macb
+10 message  11 message_short  12 source  13 sourcetype  14 source_long
+15 tag  16 time  17 timestamp_desc  18 timezone  19 type  20 user
+21 username  22 zone
+```
+
+- **`datetime` format** is `2008-12-31T22:44:02.215500+00:00` (microseconds +
+  `+00:00` offset). Kusto parses it as `datetime` with **zero nulls** across
+  1240 rows. Unset MACB times surface as `0001-01-01T00:00:00Z`, which is
+  forensically correct (no timestamp), not a parse failure.
+- **`ignoreFirstRecord=true` works**: the header row is dropped, no junk
+  null-timestamp row leaks into `CarFile()`/`CarProcess()`.
+- **The dynamic CSV quoted correctly**: every one of 1240 rows parsed to exactly
+  23 fields; no embedded-comma column shift.
+
+**How one image breaks into ADX source types.** Three filesystem test images
+(`ntfs1-gen0.E01`, `exfat1.E01`, `imageformat_mmls_1.E01`) produced:
+
+| `source` | `sourcetype` / `source_long` | Rows | CarFile regex `\bfs\b\|ntfs\|file` |
+|:--|:--|--:|:--:|
+| `FILE` | `NTFS file stat` | 752 | ✅ |
+| `FILE` | `File stat` | 486 | ✅ |
+| `FILE` | `MacOS File System Events Disk Log Stream` | 2 | ✅ |
+
+`timestamp_desc` — the field that makes the CAR `action` derivable — took five
+distinct values, now **all** mapped after fix #4:
+
+| `timestamp_desc` | CarFile `action` |
+|:--|:--|
+| `Creation Time` | `create` |
+| `Content Modification Time` | `modify` |
+| `Metadata Modification Time` | `modify` *(was unmapped)* |
+| `File Last Modification Time` | `modify` *(was unmapped)* |
+| `Last Access Time` | `read` |
+
+> These are filesystem-only test images, so they exercise the `CarFile` lane
+> only — `CarProcess`-from-Plaso (Prefetch/Amcache/AppCompatCache) needs a
+> Windows image. The value proved here is the **L2tCsv schema, mapping, datetime
+> parsing, header handling, and the `source_long → CAR-object` routing** — the
+> mechanics every Plaso source shares. On a Windows image the *same* `L2tCsv`
+> table additionally carries `sourcetype` values like `WinPrefetch`,
+> `Amcache`, and registry sources, which the same regexes fan out to
+> `CarProcess`/`CarFile`.
+
+### Zeek — `network.ZeekConn` (fixture-driven ADX validation)
+
+`conn.log` after `zeek-cut -C -U "%Y-%m-%dT%H:%M:%S%z"`: TSV, `#`-prefixed
+headers, 21 columns (ordinals 0–20 = `ZeekConnMapping`).
+
+- **`ts` renders ISO8601 as `2008-07-22T02:51:23+0000`** (offset *without* a
+  colon). Kusto parses it as `datetime` → `…Z`. This was an open question about
+  the ISO8601 story; it holds.
+- `ingest-kusto.sh`'s Zeek path did its job live: the `#fields` order guard
+  passed, `#`-lines were stripped, and the 21 columns landed in the right typed
+  columns (`SrcIp`, `SrcPort`, `DestIp`, `DestPort`, `Proto`, `Service`,
+  `ConnState` all correct).
+- **`CarFlow()`** derived `action` from `ConnState` (`SF`→`end`, `REJ`→`end`),
+  `packet_count = orig_pkts + resp_pkts` (6+5=11, 20+18=38 ✓), and
+  `end_time = ts + duration` (`02:52:10` + 12s = `02:52:22` ✓).
+
+### EvtxECmd — `host.EvtxEcmdJson` (fixture-driven ADX validation)
+
+EvtxECmd `--json`, one object per line (`multijson`). Mapping is by JSON path;
+the 25 columns landed, and `TimeCreated` parsed even with 7-digit fractional
+seconds (`2025-01-01T10:14:29.1234567+00:00`).
+
+- **`Payload` XML extraction** via `EvtxPayload(Payload, "Name")` works: from a
+  4688 record it pulled `NewProcessName`, `ParentProcessName`, `CommandLine`,
+  `NewProcessId`, and the *creator* `ProcessId` (not the top-level column) into
+  `CarProcess`.
+- **`CarProcess`** — `pid=420` (`0x1a4`), `ppid=4` (`0x4`), full command line.
+- **`CarUserSession`** — a 4624 `LogonType=10` became `action="rdp"`, with
+  `src_ip`/`src_port`/`logon_id` pulled from the payload.
+- **`CarService`** — a 7045 became `action="create"`, `name="EvilSvc"`,
+  `module_path="C:\Windows\Temp\evil.exe"`.
+
+---
+
+## Reproducing this
+
+```bash
+# 1. Plaso (real) — installs from PyPI; the corpus URLs are in the manifest
+python3 -m venv /tmp/plaso-venv && . /tmp/plaso-venv/bin/activate && pip install plaso
+#    fetch three small images (see samples-manifest.tsv) into
+#    data_store/raw/disk_images/, then run psteal with the exact --fields from
+#    process-log2timeline-Dynamic.sh (the script itself uses the Docker image,
+#    which is blocked here; native psteal takes the same arguments).
+
+# 2. Backend (real)
+./scripts/deploy-kusto.sh -y
+./scripts/apply-kusto-schema.sh
+./scripts/ingest-kusto.sh            # l2t + zeek + evtx
+
+# 3. Check
+#    CarCoverage() in the mitre database
+```
+
+The Zeek/EvtxECmd fixtures used here are format-accurate stand-ins for the
+engines that egress policy blocks; swap in real `conn.log` / EvtxECmd JSON on a
+network that permits `zeek/zeek` and where a real `.evtx` is available, and the
+ADX side is already proven to accept them.

--- a/kusto/schema/00-databases.kql
+++ b/kusto/schema/00-databases.kql
@@ -12,9 +12,19 @@
 //
 // In ephemeral mode (the default, and Microsoft's recommendation) the volatile
 // form is used instead — no paths, nothing on disk outside the container.
+//
+// ⚠️ NAMES ARE BRACKET-QUOTED. `network` is a reserved word in the engine's
+//    grammar, and `.create database network volatile` is rejected with
+//    General_BadRequest against a live emulator — a bare name that parsed fine
+//    in review and failed the moment it ran. `["network"]` is the documented
+//    way to use a keyword as an entity name; the other four are bracketed too
+//    so a future engine keyword cannot reintroduce the same trap. Downstream
+//    `database("network")` references are already string-quoted, so only the
+//    creation site needed the fix. apply-kusto-schema.sh parses the plain name
+//    back out of the brackets.
 
-.create database host   volatile
-.create database network volatile
-.create database memory volatile
-.create database misc   volatile
-.create database mitre  volatile
+.create database ["host"]    volatile
+.create database ["network"] volatile
+.create database ["memory"]  volatile
+.create database ["misc"]    volatile
+.create database ["mitre"]   volatile

--- a/kusto/schema/40-mitre.kql
+++ b/kusto/schema/40-mitre.kql
@@ -149,11 +149,12 @@ CarUserSession() {
 // value is 4660. Both the raw hex and a best-effort numeric form are exposed:
 // pid_hex is always correct, pid is what CAR asks for.
 //
-// ⚠️ Whether tolong() accepts a "0x"-prefixed string is UNVERIFIED — KQL
-//    accepts 0x integer *literals*, but that is not the same as run-time
-//    string conversion. If pid comes back null against a real emulator, the
-//    fix is a conversion expression here, not a change to the model.
-//    Tracked in issue #14 (Kusto runtime verification), item 6.
+// ✅ VERIFIED against the live emulator (issue #14, item 6): tolong() DOES
+//    accept a "0x"-prefixed string at run time, not just a 0x integer literal —
+//    tolong("0x1a4") = 420, tolong("0x1234") = 4660, and pid=420 on the
+//    ingested 4688 row. Note tolong("1a4") without the prefix = null, so pid_hex
+//    stays the always-correct raw form; EvtxECmd emits the "0x" form, so pid is
+//    populated. See docs/Runtime-Validation.md.
 //
 // ppid comes from EventData's ProcessId (the creating process), NOT from the
 // table's top-level ProcessId column — that is the Execution ProcessID of
@@ -246,8 +247,18 @@ CarFile() {
         database("host").L2tCsv
         | where SourceLong matches regex @"(?i)\bfs\b|ntfs|file"
         | extend
+            // MACB -> CAR action. The modify branch matches "modification"
+            // broadly, not just "content modification": against real Plaso
+            // output an NTFS image emits THREE modification descriptions —
+            // "Content Modification Time" (mtime, the M), "Metadata
+            // Modification Time" (the MFT metadata-change time, the C in MACB)
+            // and "File Last Modification Time". The original regex caught only
+            // the first, leaving 260 of 1240 rows on real images with an empty
+            // action. Metadata change (permissions/MFT record) is still a file
+            // modification for CAR's purposes, so all three map to "modify".
+            // create is tested first, so any overlap resolves in its favour.
             action = case(TimestampDesc matches regex @"(?i)creation|crtime|birth", "create",
-                          TimestampDesc matches regex @"(?i)content modification|mtime", "modify",
+                          TimestampDesc matches regex @"(?i)modification|mtime", "modify",
                           TimestampDesc matches regex @"(?i)last access|atime", "read",
                           TimestampDesc matches regex @"(?i)deletion|deleted", "delete",
                           ""),
@@ -282,10 +293,14 @@ CarCoverage() {
         (CarProcess()     | summarize Rows = count() | extend Object = "process"),
         (CarService()     | summarize Rows = count() | extend Object = "service"),
         (CarFile()        | summarize Rows = count() | extend Object = "file"),
-        (print Object = "registry", Rows = 0L),
-        (print Object = "driver", Rows = 0L),
-        (print Object = "module", Rows = 0L),
-        (print Object = "thread", Rows = 0L)
+        // long(0), not 0L: the emulator's parser rejects the typed-literal
+        // suffix form (`0L`) with a semantic error, though it is valid in the
+        // cloud grammar. long(0) is accepted by both and keeps these branches'
+        // Rows column a long, matching the count() branches above.
+        (print Object = "registry", Rows = long(0)),
+        (print Object = "driver", Rows = long(0)),
+        (print Object = "module", Rows = long(0)),
+        (print Object = "thread", Rows = long(0))
     | project Object, Rows
     | order by Rows desc
 }

--- a/project-progress.md
+++ b/project-progress.md
@@ -31,9 +31,9 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 
 | Processing Tool / Artefact                                    | Automate Data | File Type      | Kusto Ingest | CAR Functions |
 |:--------------------------------------------------------------|:-------------:|:---------------|:------------:|:-------------:|
-| [Log2timeline](https://github.com/log2timeline/plaso)         | ✅            | csv             | ◑            |     ◑        |
-| [Zeek](https://zeek.org/)                                     | ✅            | tsv             | ◑ (`conn` only) | ◑         |
-| [WinEvent Logs](https://www.sans.org/white-papers/32949/) (EvtxECmd) | ⚠️     | evtx → json     | ◑            |     ◑        |
+| [Log2timeline](https://github.com/log2timeline/plaso)         | ✅            | csv             | ✅           |     ✅ (`file`) |
+| [Zeek](https://zeek.org/)                                     | ✅            | tsv             | ✅ (`conn` only) | ✅ (`flow`) |
+| [WinEvent Logs](https://www.sans.org/white-papers/32949/) (EvtxECmd) | ⚠️     | evtx → json     | ✅           |     ✅ (`process`/`user_session`/`service`) |
 | Velociraptor offline collectors ([EZ Tools](https://ericzimmerman.github.io/)) | ❌ planned — replaces the removed KAPE path | json | ❌ | ❌ |
 | [Velociraptor](https://github.com/Velocidex/velociraptor)     | ⚠️            | json            | ❌ loader not implemented | ❌ |
 | [Rekall](https://github.com/google/rekall)                    | ⚠️            | json            | ❌ loader not implemented | ❌ |
@@ -44,20 +44,25 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 | [Hayabusa](https://github.com/Yamato-Security/hayabusa)       |               |                 |              |               |
 | [Chainsaw](https://github.com/countercept/chainsaw)           |               |                 |              |               |
 
-**The CAR column is ◑, not ✅.** The MITRE CAR data model is expressed as KQL
-functions in the `mitre` database — `CarFlow()`, `CarUserSession()`,
-`CarProcess()`, `CarService()`, `CarFile()`, with `CarCoverage()` reporting
-what has data. Five of the nine CAR objects have a source. `registry` lost its
+**The CAR column has now run against a live emulator.** The MITRE CAR data
+model is expressed as KQL functions in the `mitre` database — `CarFlow()`,
+`CarUserSession()`, `CarProcess()`, `CarService()`, `CarFile()`, with
+`CarCoverage()` reporting what has data. All five sourced objects returned real
+rows on the live engine (`file`=1240 from three real `.E01` images, plus
+`flow`/`process`/`user_session`/`service`) — see
+[docs/Runtime-Validation.md](/docs/Runtime-Validation.md). `registry` lost its
 only source when the KAPE path was removed and awaits the Velociraptor/EZ-Tools
 collectors; `driver`, `module` and `thread` have none, because nothing
 dead-box produces driver loads, image loads or thread creation — those need
 Sysmon or a live agent.
 
-**None of it has been run against a live emulator.** ◑ means built and
-internally consistent, not working. Turning those into ✅ is what stands
-between this and `1.0.0`, and it needs a real deploy, not more code. The
-runtime checklist is
-[issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14).
+**What the live run still does not cover.** Plaso was run for real, but only on
+filesystem test images — a Windows image (for `CarProcess`-from-Plaso via
+Prefetch/Amcache) has not been run. The Zeek and EvtxECmd **engines** could not
+run here (egress policy blocks the `zeek/zeek` image and there is no standalone
+`.evtx` in the corpus), so their ingest/mapping/CAR paths were proven with
+format-accurate fixtures rather than live tool output. The remaining runtime
+checklist is [issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14).
 
 ---
 
@@ -138,6 +143,30 @@ Things that are broken or unsafe right now.
 ---
 
 ## ✅ Done
+
+### 🔹 **First run against a live Kusto emulator** — *the blocker, broken*
+✅ Deploy → apply → ingest → `CarCoverage()` executed end-to-end on the real
+`kustainer-linux` engine, with data processed from the Digital Corpora sample
+URLs. Five of nine CAR objects returned real rows. Full write-up, including the
+field/source-type breakdown, in
+[docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
+✅ Processed three real `.E01` images with Plaso (`psteal --output-format
+dynamic`) — 1240 filesystem events. Confirmed the 23-field CSV header order
+matches the `L2tCsvMapping` ordinals, the `datetime` field parses with zero
+nulls, and `ignoreFirstRecord` drops the header cleanly.
+✅ Fixed four defects the live run surfaced, each invisible until first contact:
+`network` is a **reserved database name** (bracket-quoted now); the `0L` long
+literal in `CarCoverage()` is rejected by this build (`long(0)` now); the two
+database-name parsers updated to match; and `CarFile()` left 260/1240 real rows
+with an empty `action` because its `modify` regex missed `Metadata`/`File Last`
+modification times (broadened now — all rows classify).
+✅ Resolved [issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14) item 6:
+`tolong()` **does** parse a `0x` hex string at run time, so `CarProcess.pid` is
+populated (`0x1a4` → 420).
+✅ Validated the Zeek `conn` and EvtxECmd ingest/mapping/CAR paths (including
+`CarProcess`/`CarUserSession`/`CarService` and the Payload-XML extraction)
+against the live engine with format-accurate fixtures — the tool engines
+themselves are blocked by egress policy here.
 
 ### 🔹 **The pivot: Splunk → Data Explorer emulator**
 ✅ Ported the SIEM layer to the Kusto emulator — 5 databases, typed tables and

--- a/scripts/apply-kusto-schema.sh
+++ b/scripts/apply-kusto-schema.sh
@@ -122,8 +122,13 @@ DB_FILE="$SCHEMA_DIR/00-databases.kql"
 [[ -f "$DB_FILE" ]] || { echo "❌ Missing $DB_FILE"; exit 1; }
 
 # Parse the database names out of the file rather than hardcoding them here,
-# so the .kql stays the single source of truth.
-mapfile -t DATABASES < <(grep -oE '^\.create database [A-Za-z_][A-Za-z0-9_]*' "$DB_FILE" | awk '{print $3}')
+# so the .kql stays the single source of truth. Names are bracket-quoted there
+# (`["network"]`) because `network` is a reserved engine keyword — the plain
+# name is stripped back out so existence checks and command construction below
+# work with `network`, not `["network"]`. The optional-bracket regex still
+# accepts the legacy bare form.
+mapfile -t DATABASES < <(grep -oE '^\.create database +\[?"?[A-Za-z_][A-Za-z0-9_]*"?\]?' "$DB_FILE" \
+    | sed -E 's/^\.create database +//; s/^\["?//; s/"?\]$//')
 [[ ${#DATABASES[@]} -gt 0 ]] || { echo "❌ No databases declared in $DB_FILE"; exit 1; }
 
 echo "📚 Databases: ${DATABASES[*]}"
@@ -148,10 +153,14 @@ for db in "${DATABASES[@]}"; do
         echo "   ⏭️  $db already exists — skipping creation"
         continue
     fi
+    # Bracket-quote the name in the command too: `network` is a reserved word,
+    # so `.create database network ...` is rejected. The path literals in the
+    # persist form take the plain name — they are string arguments, not entity
+    # identifiers.
     if [[ "$KUSTO_PERSIST" == "1" ]]; then
-        cmd=".create database $db persist (@\"/kustodata/dbs/$db/md\", @\"/kustodata/dbs/$db/data\")"
+        cmd=".create database [\"$db\"] persist (@\"/kustodata/dbs/$db/md\", @\"/kustodata/dbs/$db/data\")"
     else
-        cmd=".create database $db volatile"
+        cmd=".create database [\"$db\"] volatile"
     fi
     resp=$(kusto_mgmt "NetDefaultDB" "$cmd")
     if kusto_failed "$resp"; then

--- a/tests/run-checks.sh
+++ b/tests/run-checks.sh
@@ -331,7 +331,11 @@ if [[ ! -d kusto/schema ]]; then fail "kusto/schema is missing"; else
 
     # Databases in 00-databases.kql must match what the CAR functions reference.
     if [[ -f kusto/schema/00-databases.kql ]]; then
-        declared=$(grep -oE '^\.create database [A-Za-z_][A-Za-z0-9_]*' kusto/schema/00-databases.kql | awk '{print $3}' | sort -u)
+        # Names are bracket-quoted (`["network"]`) because `network` is a
+        # reserved engine keyword; strip the brackets/quotes back to the plain
+        # name. The optional-bracket regex still accepts the legacy bare form.
+        declared=$(grep -oE '^\.create database +\[?"?[A-Za-z_][A-Za-z0-9_]*"?\]?' kusto/schema/00-databases.kql \
+            | sed -E 's/^\.create database +//; s/^\["?//; s/"?\]$//' | sort -u)
         referenced=$(grep -hoE 'database\("[a-z]+"\)' kusto/schema/[1-9]*.kql 2>/dev/null | sed 's/database("\(.*\)")/\1/' | sort -u)
         missing=""
         for r in $referenced; do


### PR DESCRIPTION
Processes Digital Corpora sample data through the pipeline and drives it into the real `kustainer-linux` engine for the first time (`deploy → apply → ingest → CarCoverage()`) — the runtime verification tracked in #14. Establishes the fields each source emits and how one piece of evidence fans out into ADX source types and MITRE CAR objects, and fixes four "parsed in review, failed on first contact" defects the run surfaced.

> **Base of a 3-PR stack.** This is the core validation + fixes. On top of it:
> - #20 — memory lane (Volatility 3), based on this branch
> - #21 — Android + macOS, based on #20
>
> Merge order: **this → #20 → #21**.

## What ran, honestly

| Lane | Input | ADX ingest + mapping + CAR |
|:--|:--|:--|
| Plaso → `host.L2tCsv` | ✅ real `psteal` on three real `.E01` images (1240 events) | ✅ verified live |
| Zeek → `network.ZeekConn` | ⚠️ format-accurate `conn.log` fixture | ✅ verified live |
| EvtxECmd → `host.EvtxEcmdJson` | ⚠️ format-accurate JSON fixture | ✅ verified live |

The Zeek/EvtxECmd Docker images and standalone `.evtx` are blocked by egress policy, so those **engines** were driven by deterministic format-accurate fixtures — the ADX side (never exercised before) is real. Plaso installs from PyPI and ran for real.

## Defects fixed (each invisible until first contact)

1. **`network` is a reserved database name** — `.create database network volatile` → `General_BadRequest`. Bracket-quoted all names; updated the two name parsers (`apply-kusto-schema.sh`, `run-checks.sh`) + command construction.
2. **`CarCoverage()`'s `0L` long-literal suffix** rejected by this build (`SEM0100`) → `long(0)`.
3. **`CarFile()` left 260/1240 real Plaso rows with an empty `action`** — the `modify` regex missed `Metadata`/`File Last` modification times. Broadened to `(?i)modification|mtime`.
4. Resolved #14 item 6: **`tolong()` parses a `0x` hex string at run time**, so `CarProcess.pid` is populated (`0x1a4` → 420).

## Result

`CarCoverage()` on the live engine: `file`=1240, `flow`=4, `process`/`user_session`/`service`=1, four unsourced objects correctly `0`. The README's "envisioned endstate" query returns a real row.

## Files

- `docs/Runtime-Validation.md` (new) — fields + source-type breakdown + reproduction.
- `kusto/schema/00-databases.kql`, `kusto/schema/40-mitre.kql` — the three schema/CAR fixes.
- `scripts/apply-kusto-schema.sh`, `tests/run-checks.sh` — bracket-tolerant DB-name parsing.
- `docs/Kusto-Port.md`, `project-progress.md`, `CHANGELOG.md` — status updated, honestly scoped.

All 91 repo checks pass. No evidence committed (`data_store/` stays deny-by-default).

## Related

Addresses #14 (verified checklist + image digest posted there; left open for the remaining guard-rail items + a large-CSV memory stress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)