### PR TITLE
Add memory processing lane: Volatility 3 → memory.VolatilityJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ script names, sourcetypes, field names, and app layouts included.
 
 ## [Unreleased]
 
+### Added — memory processing lane (Volatility 3)
+
+- **Memory is processed with [Volatility 3](https://github.com/volatilityfoundation/volatility3)
+  now**, replacing the archived Rekall as the forward path. New
+  `scripts/process-volatility.sh` runs a plugin set (`pslist`, `pstree`,
+  `netscan`, `cmdline`, `malfind`, …) per image and writes one `-r json` file
+  per plugin. A `VolatilityJson` table + `VolatilityPlugins()`/`VolatilityPslist()`
+  views were added to `kusto/schema/30-memory.kql`, and a `volatility` loader to
+  `ingest-kusto.sh`.
+- **The loader injects the `Plugin`/`SourceFile` constant columns that `.ingest`
+  cannot** — a `volatility_prepare` hook wraps each row as `{Plugin, SourceFile,
+  Record}` JSON Lines. This is the same wrapper the Velociraptor (`Artefact`)
+  and Rekall (`Plugin`) loaders were blocked on, so it unblocks that pattern.
+- Verified against the live emulator: real `banners.Banners` output from a
+  511 MB dump plus `pslist`/`netscan` fixtures (Windows symbols aren't
+  reachable through the egress proxy here). Details in
+  [docs/Runtime-Validation.md](/docs/Runtime-Validation.md). Tracks #16.
+- Rekall's `RekallJson` table/mapping are kept for historical data; only the
+  forward path changed.
+
 ### Fixed — first run against a live Kusto emulator
 
 - **The Kusto backend has now been run end-to-end against the real

--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -17,6 +17,14 @@ have caught.
 > | **Plaso → `host.L2tCsv`** | ✅ real `psteal` on three real `.E01` images | ✅ verified live |
 > | **Zeek → `network.ZeekConn`** | ⚠️ format-accurate `conn.log` fixture¹ | ✅ verified live |
 > | **EvtxECmd → `host.EvtxEcmdJson`** | ⚠️ format-accurate JSON fixture¹ | ✅ verified live |
+> | **Volatility 3 → `memory.VolatilityJson`** | ◐ real `banners.Banners` on a real 511 MB dump + fixtures for symbol-blocked plugins² | ✅ verified live |
+>
+> ² Volatility 3 (`pip install volatility3`) ran for real on a 511 MB memory
+> image and its `banners.Banners` output — the ntoskrnl PDB GUID — is ingested.
+> Its Windows *symbol tables* download from the Volatility / Microsoft symbol
+> servers, both `403`/unreachable through the egress proxy, so the
+> symbol-dependent plugins (`pslist`, `netscan`, …) can't resolve here; those
+> were validated with format-accurate `vol -r json` fixtures.
 >
 > ¹ The Zeek image (`zeek/zeek`) and the OpenSUSE OBS Zeek packages are both
 > refused at the network egress proxy (`403` on CONNECT), and there is no
@@ -175,6 +183,43 @@ seconds (`2025-01-01T10:14:29.1234567+00:00`).
 - **`CarService`** — a 7045 became `action="create"`, `name="EvilSvc"`,
   `module_path="C:\Windows\Temp\evil.exe"`.
 
+### Volatility 3 — `memory.VolatilityJson` (real tool, mixed data)
+
+Rekall's upstream is archived, so memory is now processed with **Volatility 3**
+(`process-volatility.sh`). Its `-r json` renderer emits one JSON *array* of row
+objects per plugin, with tree-plugin descendants nested under `__children`.
+
+- **Real:** Volatility 3 ran on the 511 MB `pat-2009-12-05.winddramimage` and
+  `banners.Banners` returned the kernel banner
+  `ntoskrnl.pdb|1B2D0DFE2FB942758D615C901BE04692|2` — ingested and queryable.
+  The **Windows symbol tables** needed by `pslist`/`netscan`/etc. download from
+  the Volatility and Microsoft symbol servers, both blocked here, so those
+  plugins error offline (`symbol table requirement was not fulfilled`) and were
+  driven by fixtures.
+- **Loader — constant-column injection.** `Plugin` and `SourceFile` are per-file
+  constants and `.ingest` cannot inject a constant column — the exact reason the
+  Velociraptor/Rekall loaders were "NOT IMPLEMENTED." `ingest-kusto.sh`'s
+  `volatility_prepare` hook wraps each row as `{Plugin, SourceFile, Record}`
+  JSON Lines, so `VolatilityJson` lands with `Plugin`/`SourceFile` populated and
+  the plugin-specific fields reachable as `Record.Field`:
+
+  ```
+  VolatilityPslist()   ->  Timestamp             pid   ppid  name
+                           2009-12-05T11:58:02Z   4     0     System
+                           2009-12-05T11:58:05Z   624   4     smss.exe
+                           2009-12-05T11:59:10Z   1180  624   explorer.exe
+                           2009-12-05T12:03:44Z   1740  1180  outlook.exe
+  ```
+  `CreateTime` parses as `datetime`; `netscan` rows correlate to `pslist` by PID
+  (`outlook.exe` 1740 → `74.125.19.104:80`). This is the same wrapper the
+  Velociraptor (`Artefact`) and Rekall (`Plugin`) loaders need — proven here.
+
+> Memory is deliberately **not** a CAR object: MITRE CAR's dead-box objects are
+> file/flow/process/user_session/service/registry/driver/module/thread, and
+> live process/registry/driver/module/thread state from RAM is a different
+> fidelity than dead-box artefacts. `memory.VolatilityJson` is queried directly
+> (`VolatilityPlugins()`, `VolatilityPslist()`), not folded into `CarProcess()`.
+
 ---
 
 ## Reproducing this
@@ -187,10 +232,16 @@ python3 -m venv /tmp/plaso-venv && . /tmp/plaso-venv/bin/activate && pip install
 #    process-log2timeline-Dynamic.sh (the script itself uses the Docker image,
 #    which is blocked here; native psteal takes the same arguments).
 
+# 1b. Memory (real tool) — Volatility 3 also installs from PyPI
+pip install volatility3
+#    fetch a small memory image (e.g. drives-nps-2009-patents *dramimage) into
+#    data_store/raw/memory/, then: ./scripts/process-volatility.sh
+#    (Windows plugins need symbol-server egress; banners works offline.)
+
 # 2. Backend (real)
 ./scripts/deploy-kusto.sh -y
 ./scripts/apply-kusto-schema.sh
-./scripts/ingest-kusto.sh            # l2t + zeek + evtx
+./scripts/ingest-kusto.sh            # l2t + zeek + evtx + volatility
 
 # 3. Check
 #    CarCoverage() in the mitre database

--- a/kusto/schema/30-memory.kql
+++ b/kusto/schema/30-memory.kql
@@ -1,11 +1,22 @@
-// Database: memory — Rekall
+// Database: memory — Volatility 3 (and legacy Rekall)
 //
-// Rekall output is per-plugin and wildly inconsistent: pslist, netscan, malfind
-// and the rest share almost no columns. The Splunk era never completed field
-// extraction for it either (project-progress.md marks it ⚠️ with extraction ❌).
+// Memory-plugin output is per-plugin and wildly inconsistent: pslist, netscan,
+// malfind and the rest share almost no columns. The Splunk era never completed
+// field extraction for it either (project-progress.md marks it ⚠️, extraction ❌).
 //
 // Semi-structured is the honest representation here rather than a guess at a
-// common schema. Rekall upstream is archived, so this is unlikely to grow.
+// common schema — a `dynamic` Record column per row, accessed as Record.Field.
+//
+// TWO SOURCES, one shape:
+//   VolatilityJson  the forward path. Rekall's upstream is archived, so memory
+//                   is processed with Volatility 3 (process-volatility.sh),
+//                   whose `-r json` renderer emits an array of row objects per
+//                   plugin. ingest-kusto.sh wraps each row as
+//                   {Plugin, SourceFile, Record} — Plugin/SourceFile are
+//                   per-file constants .ingest cannot inject, so the loader
+//                   derives them from the source path, exactly as the
+//                   Velociraptor path will.
+//   RekallJson      kept for historical Rekall output; loader unchanged.
 
 .create-merge table RekallJson (
     Plugin:     string,
@@ -24,4 +35,45 @@ RekallPlugins() {
     RekallJson
     | summarize Rows = count() by Plugin
     | order by Rows desc
+}
+
+//=============================================================================
+// VolatilityJson — Volatility 3, one row per plugin-output row.
+//
+// process-volatility.sh runs `vol -r json` per plugin; ingest-kusto.sh wraps
+// each row object as {Plugin, SourceFile, Record}. Volatility's json renderer
+// nests tree-plugin descendants under a "__children" array inside each Record,
+// which survives fine in a dynamic column (Record.__children[0].PID ...).
+//=============================================================================
+.create-merge table VolatilityJson (
+    Plugin:     string,
+    SourceFile: string,
+    Record:     dynamic
+)
+
+.create-or-alter table VolatilityJson ingestion json mapping "VolatilityJsonMapping"
+```[
+  {"Column":"Plugin",     "Properties":{"Path":"$.Plugin"}},
+  {"Column":"SourceFile", "Properties":{"Path":"$.SourceFile"}},
+  {"Column":"Record",     "Properties":{"Path":"$.Record"}}
+]```
+
+.create-or-alter function
+with (docstring = "Distinct Volatility 3 plugins present, with row counts", folder = "Views")
+VolatilityPlugins() {
+    VolatilityJson
+    | summarize Rows = count() by Plugin
+    | order by Rows desc
+}
+
+.create-or-alter function
+with (docstring = "Volatility windows.pslist rows projected to common process fields", folder = "Views")
+VolatilityPslist() {
+    VolatilityJson
+    | where Plugin == "windows.pslist"
+    | project Timestamp = todatetime(Record.CreateTime),
+              pid   = tolong(Record.PID),
+              ppid  = tolong(Record.PPID),
+              name  = tostring(Record.ImageFileName),
+              SourceFile
 }

--- a/project-progress.md
+++ b/project-progress.md
@@ -36,7 +36,8 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 | [WinEvent Logs](https://www.sans.org/white-papers/32949/) (EvtxECmd) | ⚠️     | evtx → json     | ✅           |     ✅ (`process`/`user_session`/`service`) |
 | Velociraptor offline collectors ([EZ Tools](https://ericzimmerman.github.io/)) | ❌ planned — replaces the removed KAPE path | json | ❌ | ❌ |
 | [Velociraptor](https://github.com/Velocidex/velociraptor)     | ⚠️            | json            | ❌ loader not implemented | ❌ |
-| [Rekall](https://github.com/google/rekall)                    | ⚠️            | json            | ❌ loader not implemented | ❌ |
+| [Volatility 3](https://github.com/volatilityfoundation/volatility3) | ✅ `process-volatility.sh` | json (per plugin) | ✅ `memory.VolatilityJson` | n/a (memory ≠ CAR dead-box object) |
+| [Rekall](https://github.com/google/rekall)                    | ⚠️ superseded by Volatility 3 | json | ◑ table kept, loader on Volatility | ❌ |
 | Linux Logs                                                    |               |                 |              |               |
 | [Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon) |    |                 |              |               |
 | [Syslog](https://syslog-ng.github.io)                         |               |                 |              |               |

--- a/scripts/ingest-kusto.sh
+++ b/scripts/ingest-kusto.sh
@@ -37,7 +37,7 @@ Loads data_store/processed into the Kusto emulator. Run after processing
 evidence, and again after any redeploy — the database is ephemeral by default.
 
   --only SOURCE    Ingest one source only:
-                   l2t | zeek | evtx | velociraptor | rekall
+                   l2t | zeek | evtx | volatility | velociraptor | rekall
   --dry-run        List what would be ingested; contact nothing.
   -h, --help       Show this and exit.
 
@@ -65,8 +65,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ONLY" in
-    ""|l2t|zeek|evtx|velociraptor|rekall) ;;
-    *) echo "❌ --only must be one of: l2t zeek evtx velociraptor rekall"; exit 1 ;;
+    ""|l2t|zeek|evtx|volatility|velociraptor|rekall) ;;
+    *) echo "❌ --only must be one of: l2t zeek evtx volatility velociraptor rekall"; exit 1 ;;
 esac
 
 want() { [[ -z "$ONLY" || "$ONLY" == "$1" ]]; }
@@ -271,6 +271,43 @@ zeek_prepare() {
     printf '%s\n' "$staged"
 }
 
+# ------------------------------------------------------------------------------
+# Volatility hook — inject the two constant columns .ingest cannot.
+# ------------------------------------------------------------------------------
+
+# prepare hook: Volatility 3's `-r json` renderer writes ONE JSON ARRAY of row
+# objects per plugin. The memory.VolatilityJson table wants one row per element
+# with Plugin and SourceFile alongside — both per-file constants that
+# `.ingest into` cannot inject. So each array is rewritten to {Plugin,
+# SourceFile, Record} JSON Lines here, and staged as multijson. Plugin is the
+# filename (windows.pslist.json -> "windows.pslist"); SourceFile is the path
+# relative to processed/, so which image and plugin produced a row stays
+# recoverable. rc 1 skips a file that is empty or not the array vol3 emits.
+volatility_prepare() {
+    local f="$1" staged plugin rel
+    plugin="$(basename "$f" .json)"
+    rel="${f#"$PROCESSED_DIR"/}"
+    staged="$STAGING_DIR/$(staged_name "$f")"
+    if [[ $DRY_RUN -eq 0 ]]; then
+        python3 - "$f" "$plugin" "$rel" > "$staged" <<'PY' || { rm -f "$staged"; return 1; }
+import json, sys
+path, plugin, rel = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    data = json.load(open(path))
+except Exception:
+    sys.exit(1)
+if isinstance(data, dict):
+    data = [data]
+if not isinstance(data, list):
+    sys.exit(1)
+for rec in data:
+    sys.stdout.write(json.dumps({"Plugin": plugin, "SourceFile": rel, "Record": rec}) + "\n")
+PY
+        [[ -s "$staged" ]] || { rm -f "$staged"; return 1; }
+    fi
+    printf '%s\n' "$staged"
+}
+
 # post hook: runs after the source's ingest, with every found file as args.
 zeek_post() {
     local non_conn
@@ -306,6 +343,7 @@ SOURCES=(
     "l2t|Plaso (l2t:csv -> host.L2tCsv)|log2timeline/csv|*.csv|host|L2tCsv|L2tCsvMapping|csv|1|-|-"
     "evtx|EvtxECmd (evtxecmd:json -> host.EvtxEcmdJson)|windows_logs|*_EvtxECmd_Output.json|host|EvtxEcmdJson|EvtxEcmdJsonMapping|multijson|0|-|-"
     "zeek|Zeek (-> network.ZeekConn / network.Zeek)|zeek|*.log|network|ZeekConn|ZeekConnMapping|tsv|0|zeek_prepare|zeek_post"
+    "volatility|Volatility 3 (-> memory.VolatilityJson)|volatility|*.json|memory|VolatilityJson|VolatilityJsonMapping|multijson|0|volatility_prepare|-"
     "velociraptor|velociraptor — NOT IMPLEMENTED|-|-|-|-|-|-|-|-|-"
     "rekall|rekall — NOT IMPLEMENTED|-|-|-|-|-|-|-|-|-"
 )

--- a/scripts/process-volatility.sh
+++ b/scripts/process-volatility.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# ==============================================================================
+# Process memory images with Volatility 3 into ingestable per-plugin JSON.
+#
+# Rekall (the project's original memory tool) is archived upstream, so the
+# forward path is Volatility 3. Its `-r json` renderer writes ONE JSON ARRAY of
+# row objects per plugin; ingest-kusto.sh wraps each row as
+# {Plugin, SourceFile, Record} and loads it into memory.VolatilityJson, where
+# the plugin-specific fields are reachable as Record.FieldName in KQL.
+#
+#   data_store/raw/memory/<image>              memory dump (raw/dd/lime/…)
+#   data_store/processed/volatility/<image>/<plugin>.json   one file per plugin
+#
+# ⚠️ SYMBOLS. Volatility 3's Windows plugins resolve the kernel against symbol
+#    tables (ISF) it fetches from the Volatility symbol server / Microsoft's
+#    symbol server on first use. That needs outbound network. On an isolated or
+#    egress-filtered host those downloads fail and the Windows plugins error
+#    with "symbol table requirement was not fulfilled" — pre-seed the symbol
+#    cache (VOLATILITY_SYMBOLS) on a connected host, or run this where the
+#    symbol servers are reachable. Format-agnostic plugins (banners.Banners)
+#    work without symbols.
+#
+# Volatility 3 is Volatility Software License 1.0 (BSD-style) — no restriction
+# on use.
+# ==============================================================================
+set -o pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
+
+MEMORY_DIR="$REPO_ROOT_DIR/data_store/raw/memory"
+OUTPUT_DIR="$REPO_ROOT_DIR/data_store/processed/volatility"
+
+# Volatility 3 runs either from a container image (default, matching the rest of
+# the pipeline) or from a native install (pip install volatility3) if VOL_NATIVE
+# names the executable. The image needs outbound network for symbols on first
+# use; an isolated run must pre-seed VOLATILITY_SYMBOLS.
+VOLATILITY_IMAGE="${VOLATILITY_IMAGE:-sk4la/volatility3:latest}"
+VOL_NATIVE="${VOL_NATIVE:-}"
+VOLATILITY_SYMBOLS="${VOLATILITY_SYMBOLS:-$REPO_ROOT_DIR/data_store/dependencies/volatility3-symbols}"
+
+# The plugins run per image. Kept to the ones the analysis backend has a use for
+# (process tree, network, command lines, injected code); extend as needed.
+PLUGINS=(
+    "banners.Banners"
+    "windows.info"
+    "windows.pslist"
+    "windows.pstree"
+    "windows.cmdline"
+    "windows.netscan"
+    "windows.netstat"
+    "windows.malfind"
+)
+
+################################################################################
+echo ""
+echo " ██████╗ ███████╗████████╗   ███████╗██╗   ██╗██████╗ ███████╗██████╗ ███████╗"
+sleep 0.1
+echo "██╔════╝ ██╔════╝╚══██╔══╝   ██╔════╝╚██╗ ██╔╝██╔══██╗██╔════╝██╔══██╗██╔════╝"
+sleep 0.1
+echo "██║  ███╗█████╗     ██║█████╗███████╗ ╚████╔╝ ██████╔╝█████╗  ██████╔╝███████╗"
+sleep 0.1
+echo "██║   ██║██╔══╝     ██║╚════╝╚════██║  ╚██╔╝  ██╔══██╗██╔══╝  ██╔══██╗╚════██║"
+sleep 0.1
+echo "╚██████╔╝███████╗   ██║      ███████║   ██║   ██████╔╝███████╗██║  ██║███████║"
+sleep 0.1
+echo "╚═════╝ ╚══════╝   ╚═╝      ╚══════╝   ╚═╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝╚══════╝"
+echo ""
+
+echo "$REPO_ROOT_DIR"
+echo ""
+echo "📂 Memory images: $MEMORY_DIR"
+echo "📂 Output:        $OUTPUT_DIR"
+if [[ -n "$VOL_NATIVE" ]]; then
+    echo "🔧 Volatility:    native ($VOL_NATIVE)"
+else
+    echo "🔧 Volatility:    container ($VOLATILITY_IMAGE)"
+fi
+echo ""
+
+mkdir -p "$MEMORY_DIR" "$OUTPUT_DIR" "$VOLATILITY_SYMBOLS"
+
+shopt -s nullglob nocaseglob
+# Memory dumps have no single canonical extension; take common ones plus
+# extensionless raw dumps in a memory/ directory the operator curated.
+images=()
+for pat in "$MEMORY_DIR"/*.raw "$MEMORY_DIR"/*.mem "$MEMORY_DIR"/*.dmp "$MEMORY_DIR"/*.lime \
+           "$MEMORY_DIR"/*.vmem "$MEMORY_DIR"/*dramimage "$MEMORY_DIR"/*.bin; do
+    [[ -f "$pat" ]] && images+=("$pat")
+done
+if [ ${#images[@]} -eq 0 ]; then
+    echo "⚠️  No memory images found in $MEMORY_DIR"
+    echo "    Supported: *.raw *.mem *.dmp *.lime *.vmem *dramimage *.bin"
+    exit 1
+fi
+echo "🗂️  Found ${#images[@]} memory image(s)"
+echo ""
+
+# run_vol <image-abs-path> <plugin> <out-json>
+# stdout of the tool (the JSON array) is captured to the out file; stderr shows.
+run_vol() {
+    local img="$1" plugin="$2" out="$3"
+    if [[ -n "$VOL_NATIVE" ]]; then
+        VOLATILITY3_SYMBOL_DIRECTORIES="$VOLATILITY_SYMBOLS" \
+            "$VOL_NATIVE" -q -r json -f "$img" "$plugin" > "$out" 2>/dev/null
+    else
+        docker run --rm \
+            -v "$(dirname "$img")":/mem:ro \
+            -v "$VOLATILITY_SYMBOLS":/symbols \
+            "$VOLATILITY_IMAGE" \
+            -q -r json -s /symbols -f "/mem/$(basename "$img")" "$plugin" > "$out" 2>/dev/null
+    fi
+}
+
+processed=0
+failed=0
+for img in "${images[@]}"; do
+    name="$(basename "$img")"
+    dest="$OUTPUT_DIR/$name"
+    mkdir -p "$dest"
+    echo "🚀 $name"
+    for plugin in "${PLUGINS[@]}"; do
+        out="$dest/$plugin.json"
+        # Idempotency: a non-empty JSON array already there is left alone.
+        if [[ -s "$out" ]] && python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if isinstance(d,list) and d else 1)' "$out" 2>/dev/null; then
+            echo "   ⏭️  $plugin (already parsed)"
+            continue
+        fi
+        run_vol "$img" "$plugin" "$out"
+        if [[ -s "$out" ]] && python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if isinstance(d,list) else 1)' "$out" 2>/dev/null; then
+            n=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' "$out")
+            echo "   ✓ $plugin — $n row(s)"
+            processed=$((processed+1))
+        else
+            # Empty/failed plugins (often "symbols unavailable" for Windows) are
+            # removed so the ingest glob does not pick up junk and the
+            # skip-guard above does not treat them as done.
+            rm -f "$out"
+            echo "   ⚠️ $plugin — no rows (unsupported plugin or symbols unavailable)"
+            failed=$((failed+1))
+        fi
+    done
+done
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  plugin outputs: $processed   empty/failed: $failed"
+echo "═══════════════════════════════════════════"
+echo "💾 Output in: $OUTPUT_DIR"
+echo ""
+echo "ℹ️  Load into the analysis backend with:  ./scripts/ingest-kusto.sh --only volatility"
+echo "   (JSON arrays -> memory.VolatilityJson, one row per element, with the"
+echo "    plugin name and source path injected. Query: VolatilityPlugins() and"
+echo "    VolatilityPslist() in the memory database.)"
+
+[[ $processed -eq 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
Adds a working **memory → ADX** lane. Rekall's upstream is archived, so memory is processed with [Volatility 3](https://github.com/volatilityfoundation/volatility3) and its per-plugin JSON lands in the `memory` database.

> **Stacked PR.** Based on `claude/process-data-adx-ingestion-bud7gw` (#19), not `main`, so the diff shows only the memory work. Merge #19 first, then this.

## Changes

- **`scripts/process-volatility.sh`** — runs a plugin set (`pslist`, `pstree`, `netscan`, `cmdline`, `malfind`, …) per image, one `-r json` file each (container by default, native via `VOL_NATIVE`).
- **`kusto/schema/30-memory.kql`** — `VolatilityJson` table + mapping, `VolatilityPlugins()` / `VolatilityPslist()` views. `RekallJson` kept for historical data.
- **`scripts/ingest-kusto.sh`** — a `volatility` source + `volatility_prepare` hook that injects the `Plugin`/`SourceFile` constant columns `.ingest` cannot. **This is the same wrapper the Velociraptor (`Artefact`) and Rekall (`Plugin`) loaders were blocked on** — so it unblocks that whole pattern.

## Verified live

Volatility 3 (`pip install volatility3`) ran for real on the 511 MB `pat-2009-12-05.winddramimage`; `banners.Banners` returned the ntoskrnl PDB GUID, ingested and queryable. `VolatilityPslist()` projects the dynamic `Record` to a process tree; `netscan` correlates to `pslist` by PID.

**Environment limit (not a code gap):** Volatility's Windows symbol tables download from the Volatility / Microsoft symbol servers, both blocked by the egress proxy here — the symbol-dependent plugins were validated with format-accurate `vol -r json` fixtures. Details in `docs/Runtime-Validation.md`.

Closes #16.


---
