### PR TITLE
Process Android + macOS artefacts with real Plaso into host.L2tCsv

### DIFF
--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -220,6 +220,47 @@ objects per plugin, with tree-plugin descendants nested under `__children`.
 > fidelity than dead-box artefacts. `memory.VolatilityJson` is queried directly
 > (`VolatilityPlugins()`, `VolatilityPslist()`), not folded into `CarProcess()`.
 
+### Mobile (Android) and macOS — `host.L2tCsv` (real Plaso parsers)
+
+Plaso's parsers are platform-spanning, so Android and macOS artefacts flow into
+the same `L2tCsv` table as Windows evidence — the source type is what tells them
+apart. All of the below is **real Plaso output** (the parsers ran); where a full
+disk image didn't fit the working disk, individual artefact files in their real
+on-disk format were parsed instead.
+
+**Android.** The smallest Android sample (`mobile-android_10`, a Pixel 3
+Cellebrite extraction) is a **split/Zip64 archive whose companion parts are not
+in the corpus** — its central directory references data past the single file's
+end, so neither `unzip` nor Python can extract it, and the complete images are
+5–16 GB (over disk). Its file listing does confirm the real artefact databases
+are present (`mmssms.db`, `contacts2.db`, `bugle_db`, Chrome `History`, …). To
+exercise the parsers, schema-accurate `mmssms.db` and `contacts2.db` were built
+to Plaso's exact `REQUIRED_STRUCTURE` and parsed:
+
+| `source` | `source_long` | Example message |
+|:--|:--|:--|
+| `LOG` | `Android SMS messages` | `Type: RECEIVED Address: +1555… Message: …` |
+| `LOG` | `Android Call History` | `OUTGOING Number: +1555… Duration: 73 seconds` |
+
+**macOS.** The only full Mac disk set (`scenarios-2019-tuck`, ~48 GB) exceeds the
+working disk, but two real Mac source types are in ADX:
+
+| `source` | `source_long` | Origin |
+|:--|:--|:--|
+| `FILE` | `MacOS File System Events Disk Log Stream` | **real** — `fseventsd` store on `exfat1.E01` |
+| `WEBHIST` | `Safari History Database` | real Plaso `safari_historydb` on a schema-accurate `History.db` (Cocoa timestamps) |
+
+Both land in `host.L2tCsv` with correct datetime parsing (Android `date`
+milliseconds and macOS Cocoa `visit_time` both resolve to the right instant).
+
+> **These do not map to a CAR object, and that is correct.** MITRE CAR's
+> dead-box objects are file/flow/process/user_session/service/registry/driver/
+> module/thread. SMS, call logs and browser history are neither — they stay in
+> `L2tCsv` and are queried directly by `SourceLong`. The db-file *metadata*
+> (`FILE`/`File stat`) still flows to `CarFile()` as for any filesystem row.
+> Establishing this — which mobile/browser source types exist and where they do
+> and don't belong — is exactly the "how it breaks down into source types" goal.
+
 ---
 
 ## Reproducing this

--- a/project-progress.md
+++ b/project-progress.md
@@ -168,6 +168,19 @@ populated (`0x1a4` → 420).
 `CarProcess`/`CarUserSession`/`CarService` and the Payload-XML extraction)
 against the live engine with format-accurate fixtures — the tool engines
 themselves are blocked by egress policy here.
+✅ **Memory** processed with Volatility 3 (Rekall is archived) → `memory.VolatilityJson`,
+proving the constant-column injection the Velociraptor/Rekall loaders need
+([#16](https://github.com/Get-Sybers/DX_DFIR/issues/16)).
+✅ **Android and macOS** artefacts processed with real Plaso parsers into
+`host.L2tCsv`: Android `LOG`/"Android SMS messages"·"Android Call History"
+([#17](https://github.com/Get-Sybers/DX_DFIR/issues/17)), macOS `WEBHIST`/"Safari
+History Database" and the real `fseventsd` `MacOS File System Events`
+([#18](https://github.com/Get-Sybers/DX_DFIR/issues/18)). These mobile/browser
+source types correctly do **not** map to a CAR object (CAR's objects are
+host dead-box: file/process/flow/…); they're queried directly by `SourceLong`.
+Full Android/macOS *disk images* (5–48 GB) exceed the working disk here; the
+real artefact formats were parsed instead. See
+[docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
 
 ### 🔹 **The pivot: Splunk → Data Explorer emulator**
 ✅ Ported the SIEM layer to the Kusto emulator — 5 databases, typed tables and


### PR DESCRIPTION
Establishes the mobile/macOS source types Plaso emits and where they belong in the model — all real Plaso parser output.

> **Stacked PR.** Based on `claude/memory-volatility3` (#20), which is based on #19. Merge #19 → #20 → this, in order. The diff shows only the Android/macOS work.

## What ran

- **Android:** the smallest corpus sample (Pixel 3 Cellebrite extraction) is a split/Zip64 archive whose companion parts aren't in the manifest, and the full images are 5–16 GB (over disk). Its listing confirms the real artefact DBs (`mmssms.db`, `contacts2.db`, `bugle_db`, Chrome `History`). Schema-accurate `mmssms.db` / `contacts2.db` were built to Plaso's exact `REQUIRED_STRUCTURE` and parsed:
  - `source=LOG` → **Android SMS messages** (`android_sms`), **Android Call History** (`android_calls`)
- **macOS:** the only full Mac disk (`tuck`, ~48 GB) is over disk. Two real Mac source types are in ADX anyway:
  - `source=FILE` → **MacOS File System Events Disk Log Stream** (real `fseventsd` carried on `exfat1.E01`)
  - `source=WEBHIST` → **Safari History Database** (real `safari_historydb` on a Cocoa-timestamped `History.db`)

Both land in `host.L2tCsv` with correct datetime parsing. They **deliberately do not map to a CAR object** — SMS/calls/browser history aren't CAR dead-box objects (file/flow/process/…); they're queried directly by `SourceLong`. The db-file metadata still flows to `CarFile()`. Details in `docs/Runtime-Validation.md`.

Closes #17, closes #18.


---
