### PR TITLE
Implement Velociraptor loader; re-source the registry CAR object (6/9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ script names, sourcetypes, field names, and app layouts included.
 
 ## [Unreleased]
 
+### Added — Velociraptor loader; `registry` CAR object sourced again (6/9)
+
+- **The `velociraptor` source is implemented**, no longer "NOT IMPLEMENTED".
+  `ingest-kusto.sh` gained a `velociraptor_prepare` hook that wraps each
+  collector record as `{Artefact, SourceFile, Record}` JSON Lines (the same
+  constant-column injection the Volatility loader uses), landing it in
+  `host.VelociraptorJson`. `VelociraptorJsonMapping` now reads all three
+  columns, and a `VelociraptorArtefacts()` view was added.
+- **`CarRegistry()` re-sources the `registry` CAR object** from Velociraptor
+  offline collectors running the EZ Tools (RECmd / Registry Explorer). MITRE CAR
+  coverage goes from **5 of 9 to 6 of 9**; `CarCoverage()` now counts real
+  registry rows instead of the hardcoded 0, leaving only driver/module/thread
+  pinned. The `run-checks.sh` CAR pin was updated to the six-object contract.
+- **`scripts/process-velociraptor.sh`** unpacks an offline-collection ZIP and
+  lays its per-artefact JSON out for ingestion.
+- Verified against the live emulator with a format-accurate Velociraptor/RECmd
+  fixture (Run-key / service / Winlogon-Shell persistence): `CarRegistry()`
+  projects key/value/data/hive with hostname derived from the collection path,
+  and `CarCoverage()` reports `registry` populated. Details in
+  [docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
+
 ### Added — memory processing lane (Volatility 3)
 
 - **Memory is processed with [Volatility 3](https://github.com/volatilityfoundation/volatility3)

--- a/docs/Kusto-Port.md
+++ b/docs/Kusto-Port.md
@@ -165,35 +165,35 @@ later stage is needed to get value from an earlier one.
 |:--|:---|:---|
 | **1** | ✅ `scripts/deploy-kusto.sh` — container lifecycle, isolation, readiness, both-direction reachability check | — |
 | **2** | ✅ `kusto/schema/` — 5 databases, tables, ingestion mappings, applied by `scripts/apply-kusto-schema.sh` | 1 |
-| **3** | ◑ `scripts/ingest-kusto.sh` — Plaso, EvtxECmd and Zeek conn wired; Velociraptor and Rekall are not | 2 |
-| **4** | ✅ `kusto/schema/40-mitre.kql` — 5 of 9 CAR objects as KQL functions over MITRE's `car_data_model.json` | 3 |
+| **3** | ✅ `scripts/ingest-kusto.sh` — Plaso, EvtxECmd, Zeek conn, Volatility 3 and Velociraptor wired; only Rekall is not | 2 |
+| **4** | ✅ `kusto/schema/40-mitre.kql` — 6 of 9 CAR objects as KQL functions over MITRE's `car_data_model.json` | 3 |
 | **5** | ✅ Docs, checks, `THIRD_PARTY_NOTICES.md` entry | 1-4 |
 
 ## What is not done
 
 Stated plainly so it is not mistaken for working:
 
-- **Velociraptor and Rekall are not ingested.** Their tables exist with
-  ingestion mappings, but the loader populates neither. Each needs an
-  `Artefact`/`Plugin` column derived from the source path, and `.ingest into`
-  cannot inject a constant column — that needs either an ingest-time property
-  or a post-ingest update, and picking one without a running emulator to test
-  against is exactly how the `--internal` bug happened.
-- **The `registry` CAR object is unsourced.** Its only source was the removed
-  KAPE path. The planned replacement is **Velociraptor offline collectors
-  running the EZ Tools** — the same Zimmerman parsers with the same field
-  names, so the retired `KapeJson` mapping in git history is the starting
-  point when that lands. Until then `CarCoverage()` pins registry at 0
-  alongside driver/module/thread.
+- **Rekall is not ingested.** Its table exists with an ingestion mapping, but
+  the loader does not populate it. The constant-column problem (`.ingest into`
+  cannot inject the per-file `Plugin`) is now solved for the other JSON sources
+  by a prepare hook that wraps each record as `{Plugin/Artefact…, Record}` JSON
+  Lines — the same wrapper would suit Rekall if its archived output recurs.
+- **`registry` is sourced again.** **Velociraptor offline collectors running the
+  EZ Tools** (RECmd / Registry Explorer) land in `host.VelociraptorJson` via the
+  `velociraptor` loader, and `CarRegistry()` reads the registry artefacts from
+  it — the same Zimmerman field names the retired `KapeJson` mapping used. That
+  takes CAR coverage to **6 of 9**; `CarCoverage()` now counts real registry
+  rows, leaving only driver/module/thread pinned at 0.
 - **Only `conn.log` of Zeek's 69 log types is ingested.** It is the one
   `car_flow` needs. The generic `Zeek` table exists for the rest.
-- **Deploy/apply/ingest and five CAR objects have now run against a real
+- **Deploy/apply/ingest and six CAR objects have now run against a real
   emulator** — see [docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
-  What is *still* unverified: the Zeek and EvtxECmd **engines** producing that
-  input (fixtures stood in for them), a Windows disk image through Plaso (only
-  filesystem test images were run, so `CarProcess`-from-Plaso is unexercised),
-  and the two unimplemented loaders below. The remaining list, ranked by blast
-  radius, is [issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14).
+  What is *still* unverified: the Zeek/EvtxECmd/Volatility-Windows/Velociraptor
+  **engines** producing that input (deterministic fixtures stood in for the
+  parts egress policy blocks), and a Windows disk image through Plaso (only
+  filesystem test images were run, so `CarProcess`-from-Plaso is unexercised).
+  The remaining list, ranked by blast radius, is
+  [issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14).
 
   An earlier version of this document claimed the scripts were "verified"
   against a fake HTTP endpoint. That was an overclaim: the fake returned

--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -18,6 +18,11 @@ have caught.
 > | **Zeek → `network.ZeekConn`** | ⚠️ format-accurate `conn.log` fixture¹ | ✅ verified live |
 > | **EvtxECmd → `host.EvtxEcmdJson`** | ⚠️ format-accurate JSON fixture¹ | ✅ verified live |
 > | **Volatility 3 → `memory.VolatilityJson`** | ◐ real `banners.Banners` on a real 511 MB dump + fixtures for symbol-blocked plugins² | ✅ verified live |
+> | **Velociraptor → `host.VelociraptorJson`** | ⚠️ format-accurate RECmd fixture³ | ✅ verified live |
+>
+> ³ Velociraptor offline collectors run on the endpoint (not here), so a
+> format-accurate RECmd result set stood in; the loader + `CarRegistry()` are
+> real. It re-sources the `registry` CAR object.
 >
 > ² Volatility 3 (`pip install volatility3`) ran for real on a 511 MB memory
 > image and its `banners.Banners` output — the ntoskrnl PDB GUID — is ingested.
@@ -53,13 +58,13 @@ flow              4     <- Zeek conn.log fixture
 user_session      1     <- EvtxECmd 4624 fixture
 service           1     <- EvtxECmd 7045 fixture
 process           1     <- EvtxECmd 4688 fixture
-registry          0     <- unsourced (awaits Velociraptor/EZ-Tools)
+registry          3     <- Velociraptor/RECmd fixture
 driver            0     <- unsourced (needs Sysmon/live agent)
 module            0     <- unsourced
 thread            0     <- unsourced
 ```
 
-Five of nine CAR objects now carry data end-to-end; the four zeros are the
+Six of nine CAR objects now carry data end-to-end; the three zeros are the
 honest, documented gaps, not failures. The README's "envisioned endstate"
 query returns a real row now:
 
@@ -260,6 +265,35 @@ milliseconds and macOS Cocoa `visit_time` both resolve to the right instant).
 > (`FILE`/`File stat`) still flows to `CarFile()` as for any filesystem row.
 > Establishing this — which mobile/browser source types exist and where they do
 > and don't belong — is exactly the "how it breaks down into source types" goal.
+
+### Velociraptor — `host.VelociraptorJson` → `CarRegistry()` (registry re-sourced)
+
+The `registry` CAR object lost its only source when the KAPE path was removed.
+It is sourced again by **Velociraptor offline collectors running the EZ Tools**
+(RECmd / Registry Explorer). Velociraptor runs on the endpoint, so a
+format-accurate RECmd result set drove the validation; the loader and CAR
+function are real.
+
+- **Loader — same constant-column injection as Volatility.** `Artefact` and
+  `SourceFile` are per-file constants `.ingest` can't set, so
+  `velociraptor_prepare` wraps each RECmd record as `{Artefact, SourceFile,
+  Record}` JSON Lines. `VelociraptorArtefacts()` then shows
+  `Windows.Registry.RECmd` populated.
+- **`CarRegistry()`** projects the CAR registry object from the dynamic
+  `Record`, coalescing the EZ-tool field names (`KeyPath`/`ValueName`/
+  `ValueData`/`ValueType`/`HivePath`, `LastWriteTimestamp`):
+
+  ```
+  Timestamp             action  key                                              value    data
+  2025-01-01T09:00:00Z  modify  SOFTWARE\…\CurrentVersion\Run                     Updater  C:\Temp\evil.exe
+  2025-01-01T09:03:12Z  modify  SYSTEM\…\Services\EvilSvc                         ImagePath C:\Windows\Temp\evil.exe
+  2025-01-01T09:05:40Z  modify  SOFTWARE\…\Winlogon                              Shell    explorer.exe,C:\Temp\backdoor.exe
+  ```
+  `hostname` is derived from the per-host collection directory in the path
+  (`velociraptor/<host>/…`), since RECmd output carries none. `action` is
+  `modify`: a hive records a key's *last* write, so a row means created-or-
+  changed, and dead-box can't split the two — the weaker claim is the honest one.
+  `CarCoverage()` now reports `registry` populated → **6 of 9**.
 
 ---
 

--- a/kusto/schema/10-host.kql
+++ b/kusto/schema/10-host.kql
@@ -143,14 +143,19 @@
 // better than inventing a lowest-common-denominator schema that silently
 // drops columns. Access is Record.FieldName in KQL.
 //
-// Artefact is derived from the source path at ingest time.
+// Artefact and SourceFile are per-file constants .ingest cannot inject, so
+// ingest-kusto.sh's velociraptor_prepare hook wraps each collected record as
+// {Artefact, SourceFile, Record} (Artefact from the filename, SourceFile from
+// the path) and the mapping below reads all three — the same shape the
+// Volatility loader uses. Artefact is what CarRegistry() filters on.
 //
 // (A KapeJson twin of this table existed until the KAPE path was removed in
 // favour of Velociraptor offline collectors running the same EZ Tools. One
 // lesson from it survives: a CSV ingestion mapping maps ordinals to columns
 // and CANNOT build a `dynamic` object — so if the collectors emit EZ-tool
 // CSV rather than JSON, the answer is typed per-artefact tables or a
-// JSON-conversion step, never a dynamic-column CSV table.)
+// JSON-conversion step, never a dynamic-column CSV table. The wrapper keeps
+// everything JSON, so this stays a dynamic-column table.)
 //=============================================================================
 
 .create-merge table VelociraptorJson (
@@ -161,8 +166,18 @@
 
 .create-or-alter table VelociraptorJson ingestion json mapping "VelociraptorJsonMapping"
 ```[
-  {"Column":"Record", "Properties":{"Path":"$"}}
+  {"Column":"Artefact",   "Properties":{"Path":"$.Artefact"}},
+  {"Column":"SourceFile", "Properties":{"Path":"$.SourceFile"}},
+  {"Column":"Record",     "Properties":{"Path":"$.Record"}}
 ]```
+
+.create-or-alter function
+with (docstring = "Distinct Velociraptor artefacts present, with row counts", folder = "Views")
+VelociraptorArtefacts() {
+    VelociraptorJson
+    | summarize Rows = count() by Artefact
+    | order by Rows desc
+}
 
 //=============================================================================
 // Convenience views.

--- a/kusto/schema/40-mitre.kql
+++ b/kusto/schema/40-mitre.kql
@@ -23,18 +23,20 @@
 // database("<name>").<Table>. That is why the databases are separate at all —
 // they mirror the data domains, as intended.
 //
-// COVERAGE — 5 of 9 objects
+// COVERAGE — 6 of 9 objects
 //
 //   CarFlow         Zeek conn
 //   CarUserSession  EvtxECmd 4624/4625/4634/4647/4648/4778/4779
 //   CarProcess      EvtxECmd 4688/4689, Plaso execution artefacts
 //   CarService      EvtxECmd 7045/4697
 //   CarFile         Plaso filesystem rows
+//   CarRegistry     Velociraptor registry artefacts (EZ Tools / RECmd)
 //
-//   registry — NO SOURCE right now. Its only source was the removed KAPE
-//   path; the planned replacement is Velociraptor offline collectors running
-//   the EZ Tools (same Zimmerman field names, so the old KapeJson mapping in
-//   git history is the starting point when that lands).
+//   registry is SOURCED AGAIN. It lost its only source when the KAPE path was
+//   removed; the replacement — Velociraptor offline collectors running the EZ
+//   Tools (RECmd / Registry Explorer) — is now wired through host.VelociraptorJson
+//   and read by CarRegistry(). Same Zimmerman field names the old KapeJson
+//   mapping used.
 //
 //   driver, module, thread — NO SOURCE. Nothing dead-box produces driver
 //   loads, image loads or thread creation; those need Sysmon (events 6/7/8) or
@@ -273,16 +275,56 @@ CarFile() {
 }
 
 //=============================================================================
+// CarRegistry — registry key/value activity
+//
+// Source: Velociraptor offline collectors running the EZ Tools (RECmd /
+// Registry Explorer), landed in host.VelociraptorJson. RECmd's per-value output
+// carries KeyPath / ValueName / ValueData / ValueType / HivePath and the key's
+// LastWriteTimestamp — the same Zimmerman field names the retired KapeJson
+// mapping used, so this is a projection, not a translation.
+//
+// The Artefact filter is broad (recmd|registry|regexplorer) so any of the
+// EZ-tool registry artefact names a collector might emit are picked up. action
+// is "modify": a registry hive records a key's LAST write, so a present row
+// means the key was created or changed — dead-box cannot distinguish the two,
+// and defaulting to the weaker claim is the honest choice.
+//
+// hostname is derived from the per-host collection directory in SourceFile
+// (velociraptor/<host>/...), since RECmd output itself carries no hostname.
+//=============================================================================
+.create-or-alter function
+with (docstring = "MITRE CAR 'registry' object", folder = "CAR")
+CarRegistry() {
+    database("host").VelociraptorJson
+    | where Artefact matches regex @"(?i)recmd|registry|regexplorer"
+    | extend
+        Timestamp  = todatetime(coalesce(Record.LastWriteTimestamp, Record.LastWriteTime, Record.Mtime)),
+        action     = "modify",
+        key        = tostring(coalesce(Record.KeyPath, Record.Key)),
+        value      = tostring(coalesce(Record.ValueName, Record.Value)),
+        data       = tostring(coalesce(Record.ValueData, Record.Data)),
+        type       = tostring(coalesce(Record.ValueType, Record.Type)),
+        hive       = tostring(coalesce(Record.HivePath, Record.Hive)),
+        image_path = tostring(Record.ImagePath),
+        pid        = tolong(Record.PID),
+        user       = tostring(Record.User),
+        hostname   = extract(@"(?i)velociraptor/([^/]+)/", 1, SourceFile),
+        fqdn       = extract(@"(?i)velociraptor/([^/]+)/", 1, SourceFile)
+    | project Timestamp, action, key, value, data, type, hive, image_path, pid,
+              user, hostname, fqdn, Artefact, SourceFile
+}
+
+//=============================================================================
 // CarCoverage — which objects actually have data.
 //
 // The equivalent of `| tstats count FROM datamodel=MITRE_CAR BY nodename` on
 // the Splunk era. Run this first after ingesting: an object that should be
 // populated and is not means the mapping is wrong, not that the model is.
 //
-// registry, driver, module and thread are listed with 0 deliberately — they
-// have no source (registry's went with the KAPE path; Velociraptor offline
-// collectors running the EZ Tools are the planned replacement), and showing
-// them absent is the point.
+// driver, module and thread are listed with 0 deliberately — they have no
+// source (nothing dead-box produces driver/image loads or thread creation),
+// and showing them absent is the point. registry is now sourced from
+// Velociraptor (CarRegistry), so it counts real rows like the others.
 //=============================================================================
 .create-or-alter function
 with (docstring = "Row counts per CAR object; the three unsourced objects show 0", folder = "CAR")
@@ -293,11 +335,11 @@ CarCoverage() {
         (CarProcess()     | summarize Rows = count() | extend Object = "process"),
         (CarService()     | summarize Rows = count() | extend Object = "service"),
         (CarFile()        | summarize Rows = count() | extend Object = "file"),
+        (CarRegistry()    | summarize Rows = count() | extend Object = "registry"),
         // long(0), not 0L: the emulator's parser rejects the typed-literal
         // suffix form (`0L`) with a semantic error, though it is valid in the
         // cloud grammar. long(0) is accepted by both and keeps these branches'
         // Rows column a long, matching the count() branches above.
-        (print Object = "registry", Rows = long(0)),
         (print Object = "driver", Rows = long(0)),
         (print Object = "module", Rows = long(0)),
         (print Object = "thread", Rows = long(0))

--- a/project-progress.md
+++ b/project-progress.md
@@ -34,8 +34,8 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 | [Log2timeline](https://github.com/log2timeline/plaso)         | ✅            | csv             | ✅           |     ✅ (`file`) |
 | [Zeek](https://zeek.org/)                                     | ✅            | tsv             | ✅ (`conn` only) | ✅ (`flow`) |
 | [WinEvent Logs](https://www.sans.org/white-papers/32949/) (EvtxECmd) | ⚠️     | evtx → json     | ✅           |     ✅ (`process`/`user_session`/`service`) |
-| Velociraptor offline collectors ([EZ Tools](https://ericzimmerman.github.io/)) | ❌ planned — replaces the removed KAPE path | json | ❌ | ❌ |
-| [Velociraptor](https://github.com/Velocidex/velociraptor)     | ⚠️            | json            | ❌ loader not implemented | ❌ |
+| Velociraptor offline collectors ([EZ Tools](https://ericzimmerman.github.io/)) | ✅ `process-velociraptor.sh` (unpack collection) | json | ✅ `host.VelociraptorJson` | ✅ (`registry`) |
+| [Velociraptor](https://github.com/Velocidex/velociraptor)     | ⚠️            | json            | ✅ `host.VelociraptorJson` | ✅ (`registry`) |
 | [Volatility 3](https://github.com/volatilityfoundation/volatility3) | ✅ `process-volatility.sh` | json (per plugin) | ✅ `memory.VolatilityJson` | n/a (memory ≠ CAR dead-box object) |
 | [Rekall](https://github.com/google/rekall)                    | ⚠️ superseded by Volatility 3 | json | ◑ table kept, loader on Volatility | ❌ |
 | Linux Logs                                                    |               |                 |              |               |
@@ -47,15 +47,15 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 
 **The CAR column has now run against a live emulator.** The MITRE CAR data
 model is expressed as KQL functions in the `mitre` database — `CarFlow()`,
-`CarUserSession()`, `CarProcess()`, `CarService()`, `CarFile()`, with
-`CarCoverage()` reporting what has data. All five sourced objects returned real
-rows on the live engine (`file`=1240 from three real `.E01` images, plus
-`flow`/`process`/`user_session`/`service`) — see
-[docs/Runtime-Validation.md](/docs/Runtime-Validation.md). `registry` lost its
-only source when the KAPE path was removed and awaits the Velociraptor/EZ-Tools
-collectors; `driver`, `module` and `thread` have none, because nothing
-dead-box produces driver loads, image loads or thread creation — those need
-Sysmon or a live agent.
+`CarUserSession()`, `CarProcess()`, `CarService()`, `CarFile()`, `CarRegistry()`,
+with `CarCoverage()` reporting what has data. All **six** sourced objects
+returned real rows on the live engine (`file`=1240 from three real `.E01`
+images, plus `flow`/`process`/`user_session`/`service`, and `registry` from
+Velociraptor/RECmd output) — see
+[docs/Runtime-Validation.md](/docs/Runtime-Validation.md). `registry` is sourced
+again via the Velociraptor offline-collector/EZ-Tools path; `driver`, `module`
+and `thread` still have none, because nothing dead-box produces driver loads,
+image loads or thread creation — those need Sysmon or a live agent.
 
 **What the live run still does not cover.** Plaso was run for real, but only on
 filesystem test images — a Windows image (for `CarProcess`-from-Plaso via

--- a/scripts/ingest-kusto.sh
+++ b/scripts/ingest-kusto.sh
@@ -308,6 +308,48 @@ PY
     printf '%s\n' "$staged"
 }
 
+# prepare hook: Velociraptor offline collectors (running the EZ Tools) emit one
+# result file per artefact — either a JSON array or JSON Lines, depending on the
+# VQL. host.VelociraptorJson wants one row per record with Artefact and
+# SourceFile alongside, both per-file constants .ingest cannot inject. Each file
+# is rewritten to {Artefact, SourceFile, Record} JSON Lines. Artefact is the
+# filename (Windows.Registry.RECmd.json -> "Windows.Registry.RECmd"), which is
+# what CarRegistry() filters on; SourceFile is the path relative to processed/,
+# so the collecting host's directory stays recoverable. rc 1 skips an empty or
+# unparseable file.
+velociraptor_prepare() {
+    local f="$1" staged artefact rel
+    artefact="$(basename "$f" .json)"
+    rel="${f#"$PROCESSED_DIR"/}"
+    staged="$STAGING_DIR/$(staged_name "$f")"
+    if [[ $DRY_RUN -eq 0 ]]; then
+        python3 - "$f" "$artefact" "$rel" > "$staged" <<'PY' || { rm -f "$staged"; return 1; }
+import json, sys
+path, artefact, rel = sys.argv[1], sys.argv[2], sys.argv[3]
+raw = open(path, encoding="utf-8", errors="replace").read()
+recs = []
+try:
+    data = json.loads(raw)                       # a single array or object
+    recs = data if isinstance(data, list) else [data]
+except Exception:
+    for line in raw.splitlines():                # or JSON Lines
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            recs.append(json.loads(line))
+        except Exception:
+            continue
+if not recs:
+    sys.exit(1)
+for rec in recs:
+    sys.stdout.write(json.dumps({"Artefact": artefact, "SourceFile": rel, "Record": rec}) + "\n")
+PY
+        [[ -s "$staged" ]] || { rm -f "$staged"; return 1; }
+    fi
+    printf '%s\n' "$staged"
+}
+
 # post hook: runs after the source's ingest, with every found file as args.
 zeek_post() {
     local non_conn
@@ -331,20 +373,21 @@ zeek_post() {
 #   prepare fn   per file: prints the host path to stage (a rewritten copy is
 #                fine), prints nothing/rc 1 to skip, rc 2 to refuse (counted
 #                as a failure)
-#   db '-'       NOT IMPLEMENTED: announced honestly, nothing ingested. Their
-#                tables and mappings exist, but Artefact/Plugin must be derived
-#                from the source path per file and .ingest cannot inject a
-#                constant column — doing it properly needs an ingest-time
-#                property or a post-ingest update, and guessing at that without
-#                a running emulator to test against is how the --internal bug
-#                happened. See docs/Kusto-Port.md, 'What is not done'.
+#   db '-'       NOT IMPLEMENTED: announced honestly, nothing ingested. The
+#                constant-column problem (.ingest cannot inject Artefact/Plugin,
+#                which must be derived from the source path per file) is now
+#                solved for the JSON sources by a prepare hook that wraps each
+#                record as {Constant..., Record} JSON Lines — see
+#                volatility_prepare / velociraptor_prepare. Only rekall stays
+#                unimplemented (its historical output is unlikely to recur; the
+#                same wrapper would suit it if it does).
 # ------------------------------------------------------------------------------
 SOURCES=(
     "l2t|Plaso (l2t:csv -> host.L2tCsv)|log2timeline/csv|*.csv|host|L2tCsv|L2tCsvMapping|csv|1|-|-"
     "evtx|EvtxECmd (evtxecmd:json -> host.EvtxEcmdJson)|windows_logs|*_EvtxECmd_Output.json|host|EvtxEcmdJson|EvtxEcmdJsonMapping|multijson|0|-|-"
     "zeek|Zeek (-> network.ZeekConn / network.Zeek)|zeek|*.log|network|ZeekConn|ZeekConnMapping|tsv|0|zeek_prepare|zeek_post"
     "volatility|Volatility 3 (-> memory.VolatilityJson)|volatility|*.json|memory|VolatilityJson|VolatilityJsonMapping|multijson|0|volatility_prepare|-"
-    "velociraptor|velociraptor — NOT IMPLEMENTED|-|-|-|-|-|-|-|-|-"
+    "velociraptor|Velociraptor collectors (-> host.VelociraptorJson)|velociraptor|*.json|host|VelociraptorJson|VelociraptorJsonMapping|multijson|0|velociraptor_prepare|-"
     "rekall|rekall — NOT IMPLEMENTED|-|-|-|-|-|-|-|-|-"
 )
 

--- a/scripts/process-velociraptor.sh
+++ b/scripts/process-velociraptor.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# ==============================================================================
+# Lay out Velociraptor offline-collector output for ingestion.
+#
+# Velociraptor offline collectors — the planned replacement for the removed KAPE
+# automation — run on the endpoint and produce a single collection ZIP. The
+# collectors run the EZ Tools (RECmd / Registry Explorer, etc.), so the result
+# files carry Eric Zimmerman's field names. This script is the analyst-side
+# step: unpack each collection and lay its per-artefact JSON out where
+# ingest-kusto.sh expects it.
+#
+#   data_store/raw/velociraptor/<collection>.zip     one ZIP per collection
+#   data_store/processed/velociraptor/<collection>/<Artefact>.json
+#
+# ingest-kusto.sh --only velociraptor then wraps each record as
+# {Artefact, SourceFile, Record} (Artefact = the filename) into
+# host.VelociraptorJson, and CarRegistry() reads the registry artefacts from it.
+#
+# LAYOUT. A Velociraptor offline collection ZIP holds its query results as
+# `results/<Artefact>.json` (JSON Lines). That is the documented layout; if a
+# collection nests them differently, every *.json under results/ is still
+# picked up. Non-results JSON (metadata) is left alone.
+#
+# Velociraptor is AGPL-3.0; it is run, not redistributed here.
+# ==============================================================================
+set -o pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
+
+RAW_DIR="$REPO_ROOT_DIR/data_store/raw/velociraptor"
+OUTPUT_DIR="$REPO_ROOT_DIR/data_store/processed/velociraptor"
+
+################################################################################
+echo ""
+echo " ██████╗ ███████╗████████╗   ███████╗██╗   ██╗██████╗ ███████╗██████╗ ███████╗"
+sleep 0.1
+echo "██╔════╝ ██╔════╝╚══██╔══╝   ██╔════╝╚██╗ ██╔╝██╔══██╗██╔════╝██╔══██╗██╔════╝"
+sleep 0.1
+echo "██║  ███╗█████╗     ██║█████╗███████╗ ╚████╔╝ ██████╔╝█████╗  ██████╔╝███████╗"
+sleep 0.1
+echo "██║   ██║██╔══╝     ██║╚════╝╚════██║  ╚██╔╝  ██╔══██╗██╔══╝  ██╔══██╗╚════██║"
+sleep 0.1
+echo "╚██████╔╝███████╗   ██║      ███████║   ██║   ██████╔╝███████╗██║  ██║███████║"
+sleep 0.1
+echo "╚═════╝ ╚══════╝   ╚═╝      ╚══════╝   ╚═╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝╚══════╝"
+echo ""
+
+echo "$REPO_ROOT_DIR"
+echo ""
+echo "📂 Collections: $RAW_DIR"
+echo "📂 Output:      $OUTPUT_DIR"
+echo ""
+
+mkdir -p "$RAW_DIR" "$OUTPUT_DIR"
+
+shopt -s nullglob nocaseglob
+zips=("$RAW_DIR"/*.zip)
+if [ ${#zips[@]} -eq 0 ]; then
+    echo "⚠️  No Velociraptor collection ZIPs in $RAW_DIR"
+    echo "    Drop offline-collector output there as <collection>.zip"
+    exit 1
+fi
+echo "🗂️  Found ${#zips[@]} collection(s)"
+echo ""
+
+command -v unzip >/dev/null 2>&1 || { echo "❌ unzip not found on PATH."; exit 1; }
+
+processed=0
+failed=0
+for zip in "${zips[@]}"; do
+    name="$(basename "$zip" .zip)"
+    dest="$OUTPUT_DIR/$name"
+    mkdir -p "$dest"
+    echo "🚀 $name"
+
+    tmp="$(mktemp -d)"
+    # Only extract the results tree; uploads can be large and are not ingested.
+    if ! unzip -o -q "$zip" 'results/*' -d "$tmp" 2>/dev/null; then
+        # Some collections store results at the root; fall back to a full extract.
+        unzip -o -q "$zip" -d "$tmp" 2>/dev/null || {
+            echo "   ❌ could not unzip $name"; failed=$((failed+1)); rm -rf "$tmp"; continue
+        }
+    fi
+
+    count=0
+    while IFS= read -r rj; do
+        # Artefact name is the result filename (Velociraptor names them by
+        # artefact). Copy verbatim; the ingest hook does the JSON shaping.
+        base="$(basename "$rj")"
+        cp -f "$rj" "$dest/$base"
+        count=$((count+1))
+    done < <(find "$tmp" -type f -iname '*.json' 2>/dev/null)
+
+    rm -rf "$tmp"
+    if [[ $count -gt 0 ]]; then
+        echo "   ✓ $count artefact result file(s) -> velociraptor/$name/"
+        processed=$((processed+1))
+    else
+        echo "   ⚠️ no JSON result files found in $name"
+        failed=$((failed+1))
+    fi
+done
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  collections laid out: $processed   empty/failed: $failed"
+echo "═══════════════════════════════════════════"
+echo "💾 Output in: $OUTPUT_DIR"
+echo ""
+echo "ℹ️  Load into the analysis backend with:  ./scripts/ingest-kusto.sh --only velociraptor"
+echo "   (-> host.VelociraptorJson; registry artefacts feed CarRegistry() in the"
+echo "    mitre database. Check: VelociraptorArtefacts() and CarCoverage().)"
+
+[[ $processed -eq 0 ]] && exit 1
+exit 0

--- a/tests/run-checks.sh
+++ b/tests/run-checks.sh
@@ -350,25 +350,26 @@ if [[ ! -d kusto/schema ]]; then fail "kusto/schema is missing"; else
 
     # CAR coverage, PINNED. Swapping which CAR object has a source is
     # structurally legal KQL, so it would regress silently. The contract: these
-    # five objects are sourced (registry/driver/module/thread are declared
-    # unsourced in CarCoverage — registry's source left with the KAPE path),
-    # each has its Car<Object>() function in 40-mitre.kql, and every pinned
-    # name exists in MITRE's own car_data_model.json — so the model file stays
-    # load-bearing, not decorative. Change the set deliberately, updating
-    # docs/Kusto-Port.md coverage with it.
+    # six objects are sourced (driver/module/thread are declared unsourced in
+    # CarCoverage — nothing dead-box produces them; registry is sourced again
+    # via the Velociraptor/EZ-Tools path), each has its Car<Object>() function
+    # in 40-mitre.kql, and every pinned name exists in MITRE's own
+    # car_data_model.json — so the model file stays load-bearing, not
+    # decorative. Change the set deliberately, updating docs/Kusto-Port.md
+    # coverage with it.
     _car_missing=$(python3 - <<'PY' 2>/dev/null
 import json
 objs = {o['name'][0] for o in json.load(open('car_data_model.json'))['objects']}
-pinned = {'flow', 'user_session', 'process', 'service', 'file'}
+pinned = {'flow', 'user_session', 'process', 'service', 'file', 'registry'}
 print(' '.join(sorted(pinned - objs)))
 PY
 )
     if [[ -z "$_car_missing" ]]; then
-        pass "all five sourced CAR objects exist in MITRE's model"
+        pass "all six sourced CAR objects exist in MITRE's model"
     else
         fail "pinned CAR object(s) not in car_data_model.json:$_car_missing"
     fi
-    for _fn in CarFlow CarUserSession CarProcess CarService CarFile CarCoverage; do
+    for _fn in CarFlow CarUserSession CarProcess CarService CarFile CarRegistry CarCoverage; do
         if grep -q "^${_fn}()" kusto/schema/40-mitre.kql 2>/dev/null; then
             pass "40-mitre.kql defines ${_fn}()"
         else


### PR DESCRIPTION
The `velociraptor` source was `NOT IMPLEMENTED` and the `registry` CAR object was unsourced (its source left with the removed KAPE path). Both are fixed here by reusing the constant-column injection pattern the Volatility loader proved — taking MITRE CAR coverage from **5/9 to 6/9**.

## Changes
- **`scripts/ingest-kusto.sh`** — `velociraptor_prepare` hook wraps each collector record as `{Artefact, SourceFile, Record}` JSON Lines (Artefact from filename, SourceFile from path) into `host.VelociraptorJson`; the source row is now implemented (only Rekall remains `-`).
- **`kusto/schema/10-host.kql`** — `VelociraptorJsonMapping` reads all three columns; new `VelociraptorArtefacts()` view.
- **`kusto/schema/40-mitre.kql`** — new **`CarRegistry()`** reads Velociraptor registry artefacts (EZ Tools / RECmd), projecting the CAR registry object (key/value/data/type/hive/hostname, `action=modify`). `CarCoverage()` counts it.
- **`scripts/process-velociraptor.sh`** — unpacks an offline-collection ZIP into per-artefact JSON for ingest.
- **`tests/run-checks.sh`** — CAR pin updated to the six-object contract + `CarRegistry`.

## Verified live
A format-accurate Velociraptor/RECmd fixture (Run-key, service `ImagePath`, Winlogon `Shell` persistence) ingests; `CarRegistry()` projects it with hostname derived from the collection path; `CarCoverage()` reports `registry=3`. Schema applies clean (7/7 CAR functions), 94 repo checks pass. Velociraptor collectors run on the endpoint, so the RECmd input is a fixture — the loader + `CarRegistry()` are real. Details in `docs/Runtime-Validation.md`.

Closes #22.


---
