### PR TITLE
Process Linux logs with Plaso; make CarUserSession cross-platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ script names, sourcetypes, field names, and app layouts included.
 
 ## [Unreleased]
 
+### Added — Linux log processing; cross-platform `CarUserSession()`
+
+- **Linux logs are processed with Plaso** (syslog, auditd, utmp). Real CentOS
+  `/var/log` from the `scenarios-2020-linux-threat-analysis` sample produced
+  155k events across `Log File` (syslog), `Audit Log` (auditd) and `UTMP
+  session` source types, ingested into `host.L2tCsv` with sub-second timestamps.
+- **`CarUserSession()` is now cross-platform.** It unions Windows EvtxECmd
+  logons with Linux UTMP-session rows: `USER_PROCESS`→login, `DEAD_PROCESS`→
+  logout, `BOOT_TIME`→boot, parsed from Plaso's rendered message with
+  `extract()`. A `platform` column distinguishes the two; `EventId`/`LogonType`
+  are null for Linux rather than faked. Verified live. Details in
+  [docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
+
 ### Added — Velociraptor loader; `registry` CAR object sourced again (6/9)
 
 - **The `velociraptor` source is implemented**, no longer "NOT IMPLEMENTED".

--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -295,6 +295,38 @@ function are real.
   changed, and dead-box can't split the two — the weaker claim is the honest one.
   `CarCoverage()` now reports `registry` populated → **6 of 9**.
 
+### Linux — `host.L2tCsv` → cross-platform `CarUserSession()` (real logs)
+
+Real Linux logs (a CentOS 7 DNS server's `/var/log` from
+`scenarios-2020-linux-threat-analysis`, fetched from the manifest URLs) through
+Plaso — **155,446 events**:
+
+| `source` | `source_long` | Rows | What |
+|:--|:--|--:|:--|
+| `LOG` | `Log File` | 149,817 | syslog (cron, secure, maillog, journal) |
+| `LOG` | `Audit Log` | 5,423 | Linux auditd |
+| `LOG` | `UTMP session` | 31 | logins (wtmp/utmp) |
+| `FILE` | `File stat` | 174 | file metadata |
+
+Timestamps parse to sub-second precision (auditd `…334Z`, utmp `…572529Z`).
+
+**`CarUserSession()` is now cross-platform.** The UTMP-session rows are Linux
+logins — the same CAR object as Windows 4624. `CarUserSession()` unions the two:
+the Windows branch parses the EvtxECmd payload, the Linux branch parses Plaso's
+rendered UTMP message with `extract()` (`Status:` → action, `User:`, `Terminal:`,
+`IP Address:`). A `platform` column distinguishes them; `EventId`/`LogonType`
+are null for Linux (Windows concepts) rather than faked.
+
+```
+platform  action   user   src_hostname  hostname
+linux     login    root   tty1          localhost     (USER_PROCESS)
+linux     logout   …      …             …             (DEAD_PROCESS)
+linux     boot     …      …             …             (BOOT_TIME)
+```
+
+`auditd` (execve → process) and the `secure` SSH lane are richer `CarProcess` /
+`CarUserSession` sources still on the table; UTMP is the clean first cut.
+
 ---
 
 ## Reproducing this

--- a/kusto/schema/40-mitre.kql
+++ b/kusto/schema/40-mitre.kql
@@ -26,7 +26,8 @@
 // COVERAGE — 6 of 9 objects
 //
 //   CarFlow         Zeek conn
-//   CarUserSession  EvtxECmd 4624/4625/4634/4647/4648/4778/4779
+//   CarUserSession  EvtxECmd 4624/4625/4634/4647/4648/4778/4779 (Windows)
+//                   + Plaso UTMP-session rows (Linux wtmp/utmp)
 //   CarProcess      EvtxECmd 4688/4689, Plaso execution artefacts
 //   CarService      EvtxECmd 7045/4697
 //   CarFile         Plaso filesystem rows
@@ -96,40 +97,77 @@ CarFlow() {
 // 10 RemoteInteractive (RDP). 4624's IpAddress is "-" for a local logon rather
 // than absent, so those are nulled out instead of being stored as "-".
 //=============================================================================
+// Two sources, unioned — the object is cross-platform:
+//   Windows  EvtxECmd 4624/4625/4634/4647/4648/4778/4779
+//   Linux    Plaso UTMP-session rows (wtmp/utmp). Status USER_PROCESS is a
+//            login, DEAD_PROCESS a logout, BOOT_TIME a boot. The fields are
+//            parsed out of Plaso's rendered message with extract(), the same
+//            way the EvtxECmd payload fields are — Plaso does not give them
+//            typed columns. EventId/LogonType are null for Linux (they are
+//            Windows concepts), which is the honest shape rather than a faked 0.
 .create-or-alter function
-with (docstring = "MITRE CAR 'user_session' object", folder = "CAR")
+with (docstring = "MITRE CAR 'user_session' object (Windows logons + Linux utmp)", folder = "CAR")
 CarUserSession() {
-    database("host").EvtxEcmdJson
-    | where EventId in (4624, 4625, 4634, 4647, 4648, 4778, 4779)
-    | extend
-        TargetUserName = EvtxPayload(Payload, "TargetUserName"),
-        TargetLogonId  = EvtxPayload(Payload, "TargetLogonId"),
-        SubjectUserSid = EvtxPayload(Payload, "SubjectUserSid"),
-        LogonType      = toint(EvtxPayload(Payload, "LogonType")),
-        IpAddress      = EvtxPayload(Payload, "IpAddress"),
-        IpPort         = EvtxPayload(Payload, "IpPort"),
-        Workstation    = EvtxPayload(Payload, "WorkstationName")
-    | extend
-        action = case(EventId in (4634, 4647), "logout",
-                      EventId == 4778, "reconnect",
-                      EventId == 4779, "remote",
-                      EventId == 4624 and LogonType == 10, "rdp",
-                      EventId == 4624 and LogonType == 7,  "unlock",
-                      EventId == 4624 and LogonType == 2,  "interactive",
-                      EventId == 4624 and LogonType == 3,  "remote",
-                      EventId in (4624, 4625), "login",
-                      ""),
-        user         = iff(isempty(TargetUserName), UserName, TargetUserName),
-        sid          = iff(isempty(UserId), SubjectUserSid, UserId),
-        logon_id     = TargetLogonId,
-        hostname     = Computer,
-        fqdn         = Computer,
-        src_ip       = iff(IpAddress in ("-", "::1", "127.0.0.1", ""), "", IpAddress),
-        src_port     = iff(IpPort in ("-", "0", ""), int(null), toint(IpPort)),
-        src_hostname = iff(Workstation == "-", "", Workstation)
-    | project Timestamp = TimeCreated, action, user, sid, logon_id, hostname,
-              fqdn, src_ip, src_port, src_hostname, EventId, LogonType,
-              SourceFile
+    let FromEvtx =
+        database("host").EvtxEcmdJson
+        | where EventId in (4624, 4625, 4634, 4647, 4648, 4778, 4779)
+        | extend
+            TargetUserName = EvtxPayload(Payload, "TargetUserName"),
+            TargetLogonId  = EvtxPayload(Payload, "TargetLogonId"),
+            SubjectUserSid = EvtxPayload(Payload, "SubjectUserSid"),
+            LogonType      = toint(EvtxPayload(Payload, "LogonType")),
+            IpAddress      = EvtxPayload(Payload, "IpAddress"),
+            IpPort         = EvtxPayload(Payload, "IpPort"),
+            Workstation    = EvtxPayload(Payload, "WorkstationName")
+        | extend
+            action = case(EventId in (4634, 4647), "logout",
+                          EventId == 4778, "reconnect",
+                          EventId == 4779, "remote",
+                          EventId == 4624 and LogonType == 10, "rdp",
+                          EventId == 4624 and LogonType == 7,  "unlock",
+                          EventId == 4624 and LogonType == 2,  "interactive",
+                          EventId == 4624 and LogonType == 3,  "remote",
+                          EventId in (4624, 4625), "login",
+                          ""),
+            user         = iff(isempty(TargetUserName), UserName, TargetUserName),
+            sid          = iff(isempty(UserId), SubjectUserSid, UserId),
+            logon_id     = TargetLogonId,
+            hostname     = Computer,
+            fqdn         = Computer,
+            src_ip       = iff(IpAddress in ("-", "::1", "127.0.0.1", ""), "", IpAddress),
+            src_port     = iff(IpPort in ("-", "0", ""), int(null), toint(IpPort)),
+            src_hostname = iff(Workstation == "-", "", Workstation),
+            platform     = "windows"
+        | project Timestamp = TimeCreated, action, user, sid, logon_id, hostname,
+                  fqdn, src_ip, src_port, src_hostname, EventId, LogonType,
+                  platform, SourceFile;
+    let FromUtmp =
+        database("host").L2tCsv
+        | where SourceLong == "UTMP session"
+        | extend
+            status = extract(@"Status:\s*(\w+)", 1, Message),
+            ip     = extract(@"IP Address:\s*(\S+)", 1, Message)
+        | extend
+            action       = case(status == "USER_PROCESS", "login",
+                                status == "DEAD_PROCESS",  "logout",
+                                status == "LOGIN_PROCESS", "login",
+                                status == "BOOT_TIME",     "boot",
+                                ""),
+            user         = extract(@"User:\s*(\S+)", 1, Message),
+            sid          = "",
+            logon_id     = "",
+            hostname     = Hostname,
+            fqdn         = "",
+            src_ip       = iff(ip in ("0.0.0.0", "", "::1", "127.0.0.1"), "", ip),
+            src_port     = int(null),
+            src_hostname = extract(@"Terminal:\s*(\S+)", 1, Message),
+            EventId      = int(null),
+            LogonType    = int(null),
+            platform     = "linux"
+        | project Timestamp, action, user, sid, logon_id, hostname, fqdn,
+                  src_ip, src_port, src_hostname, EventId, LogonType, platform,
+                  SourceFile = DisplayName;
+    union FromEvtx, FromUtmp
 }
 
 //=============================================================================

--- a/project-progress.md
+++ b/project-progress.md
@@ -38,7 +38,7 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 | [Velociraptor](https://github.com/Velocidex/velociraptor)     | ⚠️            | json            | ✅ `host.VelociraptorJson` | ✅ (`registry`) |
 | [Volatility 3](https://github.com/volatilityfoundation/volatility3) | ✅ `process-volatility.sh` | json (per plugin) | ✅ `memory.VolatilityJson` | n/a (memory ≠ CAR dead-box object) |
 | [Rekall](https://github.com/google/rekall)                    | ⚠️ superseded by Volatility 3 | json | ◑ table kept, loader on Volatility | ❌ |
-| Linux Logs                                                    |               |                 |              |               |
+| Linux Logs (syslog / auditd / utmp, via Plaso)                | ✅            | csv             | ✅ `host.L2tCsv` | ✅ (`user_session` via utmp) |
 | [Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon) |    |                 |              |               |
 | [Syslog](https://syslog-ng.github.io)                         |               |                 |              |               |
 | [Zimmerman](https://github.com/EricZimmerman)                 |               |                 |              |               |


### PR DESCRIPTION
Brings the **Linux** lane — a "not started" board item — online, and makes `CarUserSession()` cross-platform. All real Plaso output.

## What ran

Real CentOS 7 `/var/log` (a DNS server from `scenarios-2020-linux-threat-analysis`, fetched from the manifest URLs) through Plaso — **155,446 events**:

| `source` | `source_long` | Rows |
|:--|:--|--:|
| `LOG` | `Log File` (syslog: cron/secure/maillog/journal) | 149,817 |
| `LOG` | `Audit Log` (auditd) | 5,423 |
| `LOG` | `UTMP session` (logins) | 31 |
| `FILE` | `File stat` | 174 |

Ingested into `host.L2tCsv` with sub-second timestamps.

## Cross-platform `CarUserSession()`

The UTMP-session rows are Linux logins — the same CAR object as Windows 4624. `CarUserSession()` now unions the two: the Windows branch parses the EvtxECmd payload; the Linux branch parses Plaso's rendered UTMP message with `extract()` (`Status:`→action, `User:`, `Terminal:`, `IP Address:`). `USER_PROCESS`→login, `DEAD_PROCESS`→logout, `BOOT_TIME`→boot. A `platform` column distinguishes them, and `EventId`/`LogonType` are null for Linux (Windows concepts) rather than faked.

Verified live: `CarUserSession()` returns Linux logins (`root@tty1`) with correct timestamps alongside the Windows path.

94 repo checks pass. Details in `docs/Runtime-Validation.md`.

Closes #24.


---
