### PR TITLE
Deepen Linux CAR: CarProcess (cron), cross-platform CarService, PAM sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ script names, sourcetypes, field names, and app layouts included.
 
 ## [Unreleased]
 
+### Added — deeper Linux CAR coverage (process / service / user_session)
+
+- **`CarProcess()` gains a Linux branch** from syslog cron `CMD` executions
+  (`Origin = "linux:cron"`): command line, invoking user and the crond worker
+  pid, with ppid/parent null — the same fidelity as the Plaso execution
+  artefacts. (The sample host had no `execve` audit rule, so cron is the
+  process-execution evidence present; a host auditing `execve` would add a
+  richer branch.)
+- **`CarService()` is now cross-platform** — it unions Windows 7045/4697 with
+  Linux systemd `SERVICE_START`/`SERVICE_STOP` from auditd (unit name → `name`,
+  systemd exe → `module_path`, START→create / STOP→stop).
+- **`CarUserSession()` gains an auditd-PAM branch** (`USER_START`→login,
+  `USER_END`→logout) alongside the utmp branch — richer, carrying `acct`,
+  `addr`, `hostname` and the session id. utmp and auditd are independent
+  evidence for the same sessions, distinguished by `SourceFile`.
+- Verified live on the real CentOS audit/syslog data: `process` +428 (cron),
+  `service` 250 create / 167 stop, `user_session` login 463 / logout 444.
+  Details in [docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
+
 ### Added — Linux log processing; cross-platform `CarUserSession()`
 
 - **Linux logs are processed with Plaso** (syslog, auditd, utmp). Real CentOS

--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -324,8 +324,24 @@ linux     logout   …      …             …             (DEAD_PROCESS)
 linux     boot     …      …             …             (BOOT_TIME)
 ```
 
-`auditd` (execve → process) and the `secure` SSH lane are richer `CarProcess` /
-`CarUserSession` sources still on the table; UTMP is the clean first cut.
+**Deeper Linux CAR — three objects enriched from the same audit/syslog data:**
+
+- **`CarProcess` ← cron.** syslog `CROND` lines record command executions;
+  `Origin = "linux:cron"` carries the command line, invoking user and crond pid
+  (ppid/parent null, like the Plaso artefacts). +428 rows. This host had **no
+  `execve` audit rule** (`syscall=59` count: 0), so cron is the process
+  evidence that is actually present — a host auditing execve would add a
+  richer branch.
+- **`CarService` ← systemd (auditd).** `SERVICE_START`/`SERVICE_STOP` →
+  create/stop, unit name → `name`, systemd exe → `module_path`. 250 create /
+  167 stop. `CarService()` is now **cross-platform** (Windows 7045 + Linux).
+- **`CarUserSession` ← auditd PAM.** `USER_START`→login, `USER_END`→logout,
+  carrying `acct`/`addr`/`hostname`/session-id — richer than utmp, and unioned
+  with it (independent evidence for the same sessions, split by `SourceFile`).
+  login 463 / logout 444.
+
+No SSH logins were in this DNS-server sample (`sshd` accepted/failed: 0); the
+PAM session events are the auth evidence that is present.
 
 ---
 

--- a/kusto/schema/40-mitre.kql
+++ b/kusto/schema/40-mitre.kql
@@ -28,8 +28,8 @@
 //   CarFlow         Zeek conn
 //   CarUserSession  EvtxECmd 4624/4625/4634/4647/4648/4778/4779 (Windows)
 //                   + Plaso UTMP-session rows (Linux wtmp/utmp)
-//   CarProcess      EvtxECmd 4688/4689, Plaso execution artefacts
-//   CarService      EvtxECmd 7045/4697
+//   CarProcess      EvtxECmd 4688/4689, Plaso execution artefacts, Linux cron
+//   CarService      EvtxECmd 7045/4697 (Windows) + Linux systemd (auditd)
 //   CarFile         Plaso filesystem rows
 //   CarRegistry     Velociraptor registry artefacts (EZ Tools / RECmd)
 //
@@ -167,7 +167,41 @@ CarUserSession() {
         | project Timestamp, action, user, sid, logon_id, hostname, fqdn,
                   src_ip, src_port, src_hostname, EventId, LogonType, platform,
                   SourceFile = DisplayName;
-    union FromEvtx, FromUtmp
+    // Linux auditd PAM events — richer than utmp (they carry acct, addr,
+    // hostname and the res=success/failed outcome). USER_START is a session
+    // open, USER_END a close. utmp and auditd are INDEPENDENT evidence for the
+    // same sessions, so both appear, distinguished by SourceFile — the same way
+    // CarProcess unions EvtxECmd and Plaso for one execution.
+    let FromLinuxAudit =
+        database("host").L2tCsv
+        | where SourceLong == "Audit Log"
+              and Message matches regex @"audit_type:\s*(USER_START|USER_END|USER_LOGIN)"
+        | extend
+            atype = extract(@"audit_type:\s*(\w+)", 1, Message),
+            acct  = extract(@'acct=""?([^""\s]+)', 1, Message),
+            addr  = extract(@"addr=(\S+)", 1, Message),
+            hn    = extract(@"hostname=(\S+)", 1, Message),
+            ses   = extract(@"\bses=(\d+)", 1, Message)
+        | extend
+            action       = case(atype == "USER_START", "login",
+                                atype == "USER_END",   "logout",
+                                atype == "USER_LOGIN", "login",
+                                ""),
+            user         = acct,
+            sid          = "",
+            logon_id     = ses,
+            hostname     = Hostname,
+            fqdn         = "",
+            src_ip       = iff(addr in ("?", "", "0.0.0.0", "::1", "127.0.0.1"), "", addr),
+            src_port     = int(null),
+            src_hostname = iff(hn in ("?", ""), "", hn),
+            EventId      = int(null),
+            LogonType    = int(null),
+            platform     = "linux"
+        | project Timestamp, action, user, sid, logon_id, hostname, fqdn,
+                  src_ip, src_port, src_hostname, EventId, LogonType, platform,
+                  SourceFile = DisplayName;
+    union FromEvtx, FromUtmp, FromLinuxAudit
 }
 
 //=============================================================================
@@ -253,25 +287,77 @@ CarProcess() {
         | project Timestamp, action, exe, image_path, parent_exe,
                   parent_image_path, command_line, pid, ppid, pid_hex, ppid_hex,
                   user, hostname, Origin, SourceFile = DisplayName;
-    union FromEvtx, FromPlaso
+    // Linux: cron command execution. syslog CROND lines record THAT a command
+    // ran with its command line and the crond worker's pid — but not ppid or a
+    // parent image, the same shape as the Plaso execution artefacts above.
+    // (This host's auditd had no execve rule, so there are no SYSCALL execve
+    // records; cron is the process-execution evidence that IS present. A host
+    // auditing execve would add a richer branch here with pid/ppid/exe.)
+    let FromLinuxCron =
+        database("host").L2tCsv
+        | where SourceLong == "Log File" and Message matches regex @"CMD \("
+        | extend
+            command_line      = extract(@"CMD \((.*)\)\s*$", 1, Message),
+            cron_user         = extract(@"\(([\w.-]+)\) CMD", 1, Message),
+            cron_pid          = extract(@"pid:\s*(\d+)", 1, Message)
+        | extend
+            action            = "create",
+            exe               = extract(@"^(\S+)", 1, command_line),
+            image_path        = extract(@"^(\S+)", 1, command_line),
+            parent_exe        = "",
+            parent_image_path = "",
+            pid               = tolong(cron_pid),
+            ppid              = long(null),
+            pid_hex           = "",
+            ppid_hex          = "",
+            user              = cron_user,
+            hostname          = Hostname,
+            Origin            = "linux:cron"
+        | project Timestamp, action, exe, image_path, parent_exe,
+                  parent_image_path, command_line, pid, ppid, pid_hex, ppid_hex,
+                  user, hostname, Origin, SourceFile = DisplayName;
+    union FromEvtx, FromPlaso, FromLinuxCron
 }
 
 //=============================================================================
 // CarService — service installation
 //=============================================================================
+// Two sources, unioned — cross-platform:
+//   Windows  EvtxECmd 7045 (service installed) / 4697 (service installed, Security)
+//   Linux    Plaso Audit-Log rows for systemd SERVICE_START/SERVICE_STOP. The
+//            unit name and the systemd exe are parsed out of the audit message.
 .create-or-alter function
-with (docstring = "MITRE CAR 'service' object", folder = "CAR")
+with (docstring = "MITRE CAR 'service' object (Windows 7045/4697 + Linux systemd)", folder = "CAR")
 CarService() {
-    database("host").EvtxEcmdJson
-    | where EventId in (7045, 4697)
-    | extend
-        name        = EvtxPayload(Payload, "ServiceName"),
-        module_path = EvtxPayload(Payload, "ImagePath"),
-        user        = UserName,
-        hostname    = Computer,
-        action      = "create"
-    | project Timestamp = TimeCreated, action, name, module_path, user,
-              hostname, EventId, SourceFile
+    let FromEvtx =
+        database("host").EvtxEcmdJson
+        | where EventId in (7045, 4697)
+        | extend
+            name        = EvtxPayload(Payload, "ServiceName"),
+            module_path = EvtxPayload(Payload, "ImagePath"),
+            user        = UserName,
+            hostname    = Computer,
+            action      = "create",
+            platform    = "windows"
+        | project Timestamp = TimeCreated, action, name, module_path, user,
+                  hostname, EventId, platform, SourceFile;
+    let FromLinux =
+        database("host").L2tCsv
+        | where SourceLong == "Audit Log"
+              and Message matches regex @"audit_type:\s*SERVICE_(START|STOP)"
+        | extend
+            atype = extract(@"audit_type:\s*SERVICE_(\w+)", 1, Message),
+            name  = extract(@"unit=(\S+)", 1, Message),
+            exe   = extract(@'exe=""?([^""\s]+)', 1, Message)
+        | extend
+            action      = iff(atype == "START", "create", "stop"),
+            module_path = exe,
+            user        = UserName,
+            hostname    = Hostname,
+            platform    = "linux"
+        | project Timestamp, action, name, module_path, user, hostname,
+                  EventId = int(null), platform, SourceFile = DisplayName;
+    union FromEvtx, FromLinux
 }
 
 //=============================================================================

--- a/project-progress.md
+++ b/project-progress.md
@@ -38,7 +38,7 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 | [Velociraptor](https://github.com/Velocidex/velociraptor)     | ⚠️            | json            | ✅ `host.VelociraptorJson` | ✅ (`registry`) |
 | [Volatility 3](https://github.com/volatilityfoundation/volatility3) | ✅ `process-volatility.sh` | json (per plugin) | ✅ `memory.VolatilityJson` | n/a (memory ≠ CAR dead-box object) |
 | [Rekall](https://github.com/google/rekall)                    | ⚠️ superseded by Volatility 3 | json | ◑ table kept, loader on Volatility | ❌ |
-| Linux Logs (syslog / auditd / utmp, via Plaso)                | ✅            | csv             | ✅ `host.L2tCsv` | ✅ (`user_session` via utmp) |
+| Linux Logs (syslog / auditd / utmp, via Plaso)                | ✅            | csv             | ✅ `host.L2tCsv` | ✅ (`user_session` utmp+PAM, `process` cron, `service` systemd) |
 | [Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon) |    |                 |              |               |
 | [Syslog](https://syslog-ng.github.io)                         |               |                 |              |               |
 | [Zimmerman](https://github.com/EricZimmerman)                 |               |                 |              |               |


### PR DESCRIPTION
Enriches three CAR objects from the real Linux audit/syslog data already processed (#24). Each is an honest projection of what the sample actually contains.

## What the data had (and didn't)
This CentOS DNS server had **no `execve` audit rule** (`syscall=59` count: 0) and **no SSH logins** (`sshd` accepted/failed: 0) — so the originally-planned "auditd execve + SSH sessions" aren't present. Delivered the equivalent from what *is*:

- **`CarProcess` ← cron.** syslog `CROND` `CMD` executions (`Origin="linux:cron"`): command line, invoking user, crond pid; ppid/parent null — same fidelity as the Plaso execution artefacts. **+428 rows.**
- **`CarService` is now cross-platform.** Unions Windows 7045/4697 with Linux systemd `SERVICE_START`/`SERVICE_STOP` from auditd (unit → `name`, systemd exe → `module_path`, START→create/STOP→stop). **250 create / 167 stop.**
- **`CarUserSession` ← auditd PAM.** `USER_START`→login, `USER_END`→logout, carrying `acct`/`addr`/`hostname`/`ses` — richer than utmp, unioned with it (independent evidence for the same sessions, split by `SourceFile`). **login 463 / logout 444.**

## Verified live
`CarCoverage()` on the real data: `process` +428, `service` 250/167, `user_session` login 463 / logout 444. Schema applies clean (7/7 CAR functions), 94 repo checks pass. Details in `docs/Runtime-Validation.md`.

Closes #26.


---
