### PR TITLE
docs: refresh deployment docs to current pipeline state

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ discovered.
 | Velociraptor offline collectors (EZ Tools) | ❌ Not started | **The planned artefact-collection path, replacing the removed KAPE automation** — same Zimmerman parsers, no Kroll licence constraint |
 | Velociraptor processing | ⚠️ Partial | Normalisation script exists |
 | **Kusto emulator deploy** | ✅ Runs | `deploy-kusto.sh` — localhost-only by default (the emulator has **no auth**), isolated network, real engine health check |
-| **Schema + ingestion** | ✅ Runs | 5 databases; typed tables + ingestion mappings for Plaso CSV, EvtxECmd JSON, Zeek JSON (conn + generic), Volatility, Velociraptor; the live Velociraptor *collection* loader is still the planned piece |
+| **Schema + ingestion** | ✅ Runs | 5 databases; typed tables + ingestion mappings for Plaso json_line (per-parser `L2t*`), EvtxECmd JSON, Zeek JSON (conn + generic), Volatility, Velociraptor; the live Velociraptor *collection* loader is still the planned piece |
 | **MITRE CAR field mapping (KQL)** | ✅ **9/9 validated live** | CAR objects as KQL functions in the `mitre` database — `CarFlow()`, `CarProcess()`, `CarUserSession()`, `CarService()`, `CarFile()`, `CarRegistry()`, `CarDriver()`, `CarModule()`, `CarThread()`, plus `CarCoverage()`. **All 9 objects return real rows** on the live emulator. See [docs/Kusto-Port.md](/docs/Kusto-Port.md) |
-| Syslog, Hayabusa, Chainsaw | ❌ Not started | Directory structure only |
+| **Signature detection (YARA / Suricata / Hayabusa)** | ✅ Works | `process-signatures.sh`; **YARA** (files / mounted disk images / memory via Volatility `vadyarascan`), **Suricata** (pcaps → EVE), **Hayabusa** (EVTX → Sigma — validated 792 detections on LoneWolf). Emit JSONL to `processed/signatures/`; ingest + CAR wiring is a follow-up |
+| Chainsaw | ❌ Not started | Not built |
 
 ### Known limitations
 

--- a/docs/Containers.md
+++ b/docs/Containers.md
@@ -7,10 +7,20 @@ This section lists the required Docker containers for the DFIR automation pipeli
 ## 📦 Pull Required Containers
 
 ```sh
-log2timeline/plaso:latest
-zeek/zeek:latest
-mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest
+log2timeline/plaso:latest                                    # Plaso timelining + image_export (dfVFS)
+zeek/zeek:latest                                             # PCAP → Zeek JSON
+sk4la/volatility3:latest                                     # memory (Volatility 3)
+blacktop/yara:latest                                         # signatures — YARA
+jasonish/suricata:latest                                     # signatures — Suricata
+mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest   # analysis backend (Kusto emulator)
 ```
+
+`save-docker-images.sh` pulls/saves/loads these for offline hosts.
+
+**Not containers:** **Hayabusa** ships as a self-contained Rust binary (no official
+image) — `process-signatures.sh --fetch` downloads the pinned release into
+`data_store/dependencies/hayabusa/`. Disk-image file access uses host tools
+(`ewf-tools`, `sleuthkit`, `ntfs-3g`) installed by `setup-environment.sh`.
 
 ---
 
@@ -18,6 +28,10 @@ mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest
 
 - [Plaso (log2timeline) – Docker Hub](https://hub.docker.com/r/log2timeline/plaso)
 - [Zeek (Network Security Monitor) – Docker Hub](https://hub.docker.com/r/zeek/zeek)
+- [Volatility 3 (sk4la) – Docker Hub](https://hub.docker.com/r/sk4la/volatility3)
+- [YARA (blacktop) – Docker Hub](https://hub.docker.com/r/blacktop/yara)
+- [Suricata (jasonish) – Docker Hub](https://hub.docker.com/r/jasonish/suricata)
+- [Hayabusa (Yamato Security) – GitHub](https://github.com/Yamato-Security/hayabusa)
 - [Azure Data Explorer Kusto emulator – Microsoft Learn](https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview)
 
 Note: starting the Kusto emulator requires accepting Microsoft's Software

--- a/docs/Dir-Structure.md
+++ b/docs/Dir-Structure.md
@@ -47,20 +47,22 @@
             │   └── cron/                             # Daemon Cron Jobs
             │
             └── log2timeline/
-            │   └── csv/                              # Log2timeline Output  -> host.L2tCsv
-            │   │
-            │   └── logs/                             # Log2timeline Job Logs
+            │   └── plaso/                            # Plaso storage files (.plaso) — also re-usable by Timesketch
+            │   └── jsonl/                            # Plaso json_line      -> host.L2t<Parser> (one table per top-level parser)
+            │   └── logs/                             # Job logs
             │
             └── windows_logs/                         # EvtxECmd JSON        -> host.EvtxEcmdJson
             │
             └── zeek/
-            │   └── your-pcap-filename/               # Zeek logs            -> network.ZeekConn (conn.log)
+            │   └── <capture>/                        # Zeek JSON            -> network.ZeekConn (conn) + network.Zeek (all others)
             │
-            └── zimmerman/                            # EZ Tools output (planned: Velociraptor offline collectors)
+            └── volatility/
+            │   └── <image>/                          # Volatility 3 JSONL per plugin -> memory.VolatilityJson
             │
-            └── csv/                                  # Any CSV
+            └── signatures/
+            │   └── yara/ suricata/ hayabusa/         # detection JSONL (YARA matches / Suricata EVE / Hayabusa Sigma)
             │
-            └── json/                                 # Any JSON
+            └── velociraptor/                         # Velociraptor collector output (EZ Tools) -> host.VelociraptorJson
 ```
 
 The Splunk-era tree (`splunk/` with its eight apps, `ansible/` with the

--- a/docs/scripts/Scripts-Overview.md
+++ b/docs/scripts/Scripts-Overview.md
@@ -2,57 +2,94 @@
 
 This directory contains automation scripts for **forensic data processing** and
 for **deploying, schema-loading and ingesting into the Kusto emulator** — the
-DX_DFIR pipeline. Artefact collection is planned via **Velociraptor offline
+DX_DFIR pipeline. Host artefacts are collected with **Velociraptor offline
 collectors running the EZ Tools** (replacing the removed KAPE automation).
 
 ---
 
-## 📂 Script Overview
+## 📂 Processing scripts
 
-Supported scripts — these live in `scripts/` and resolve paths correctly:
+Each processor reads evidence from `data_store/raw/<type>/` and writes
+ingest-ready output to `data_store/processed/<tool>/`. All are container-first and
+resolve their own path, so they can be run from anywhere.
 
-| Script Name                        | Platform | Description                                                                                          |
-|------------------------------------|----------|------------------------------------------------------------------------------------------------------|
-| `setup-environment.sh`             | Linux    | Installs Docker, manages group permissions, and optionally saves images for offline use.             |
-| `process-log2timeline-Dynamic.sh`  | Linux    | Processes **E01 disk images and VMware VM exports** through Plaso, emitting dynamic CSV.             |
-| `process-zeek-ALL.sh`              | Linux    | Processes **all PCAPs** in the dataset using Zeek, preserving ISO8601 timestamps.                    |
-| `process-evtx-EvtxECmd.sh`         | Linux    | Parses raw **Windows Event Logs** (`.evtx`) with EvtxECmd into JSON. ⚠️ Requires operator-supplied EvtxECmd; not runtime-tested. |
-| `deploy-kusto.sh`                  | Linux    | Deploys the **Kusto emulator** — the analysis backend. Localhost-only by default (the emulator has **no auth**), isolated network, ephemeral database by default. ⚠️ Sets `ACCEPT_EULA=Y` on your behalf. `--help` for all flags. |
-| `apply-kusto-schema.sh`            | Linux    | Creates the Kusto databases, tables, ingestion mappings and MITRE CAR functions. Idempotent — safe to re-run. |
-| `ingest-kusto.sh`                  | Linux    | Loads `data_store/processed` into the emulator. Plaso, EvtxECmd and Zeek `conn` only; the Velociraptor loader is not implemented yet. |
+| Script | Reads | Produces |
+|---|---|---|
+| `process-log2timeline-Dynamic.sh` | disk images (E01/VMDK/raw) | Plaso `.plaso` → **JSON Lines** (`psort -o json_line`), split into **one `L2t<Parser>` table per top-level parser** (`scripts/lib/l2t-split.py`); events enriched with hostname / disk id / volume id. |
+| `process-zeek-ALL.sh` | PCAPs | Zeek **JSON** logs, ISO-8601 timestamps — typed `conn` (`network.ZeekConn`) + a generic table for every other log type (`network.Zeek`). |
+| `process-volatility.sh` | memory images | **Volatility 3** (containerised, `sk4la/volatility3`) → one JSONL file per plugin via a custom `jsonl_dfir` renderer. Ships custom plugins `dfir_processes` (psscan → full path/parent/DLLs) and `dfir_registry` (RECmd-style keys from RAM). |
+| `process-evtx-EvtxECmd.sh` | Windows Event Logs (`.evtx`) | EvtxECmd → JSON (`host.EvtxEcmdJson`). ⚠️ needs operator-supplied EvtxECmd. |
+| `process-velociraptor.sh` | Velociraptor offline-collector output (EZ Tools) | JSON for `host.VelociraptorJson` (RECmd registry, etc.). |
+| `process-signatures.sh` | pcaps / files / images / EVTX | Signature/detection lanes — see **Signature detection** below. |
 
-Shared libraries live in `scripts/lib/`: `docker-lifecycle.sh` (container
-replace policy, isolated network, readiness, egress verification, honest
-directory purge) and `kusto-api.sh` (the emulator's REST endpoints, failure
-detection, reachability).
+### Signature detection (`process-signatures.sh`)
 
-The Splunk-era scripts (`deploy-splunk.sh`, `purge-splunk-container.sh`,
-`config-splunk-inputs.sh`) were retired with the Splunk stack, and the KAPE
-PowerShell automation (`Process-Kape-ALL.ps1`, `Setup-Environment-Kape.ps1`)
-was removed in favour of the planned Velociraptor collector path — git
-history and the frozen `deprecated` branch keep them.
+Three standalone lanes under `scripts/signatures/`, each emitting self-describing
+JSONL to `data_store/processed/signatures/<tool>/`. Run all, or `--only <lane>`;
+`--fetch` provisions rules/binaries when online.
+
+| Lane | Input | Output |
+|---|---|---|
+| `suricata.sh` | PCAPs | Suricata EVE JSON, `source_pcap`-tagged, alert+context event types. |
+| `yara.sh` | **files**, **disk images** (mounted in place — `ewfmount`+`ntfs-3g`, never extracts), **memory** (via Volatility `windows.vadyarascan`, matches carry PID context) | one JSON object per match (rule, target, offsets/strings). |
+| `hayabusa.sh` | loose `.evtx` + disk images | Hayabusa Sigma detection timeline (native binary). Disk-image EVTX come from a mount, or a **targeted** `image_export --artifact_filters WindowsEventLogs` pull (event logs only, transient). |
+
+> **Mounting note.** Disk-image mounting needs `/dev/fuse`, which an LXC blocks by
+> default; the lanes skip disk images with a host-fix message until it's enabled.
+> **Hayabusa's `-J` JSON input does not detect** (0 hits vs 792 natively) — real
+> `.evtx` is required, from a mount or the targeted extraction.
+
+---
+
+## 📂 Deployment & ingest scripts
+
+| Script | Description |
+|---|---|
+| `setup-environment.sh` | Installs Docker and userland deps (distro-aware); image seeding split into `save-docker-images.sh`. |
+| `save-docker-images.sh` | Pull / save / load the analysis Docker images for offline / air-gapped hosts. |
+| `deploy-kusto.sh` | Deploys the **Kusto emulator** (analysis backend). Localhost-only by default (the emulator has **no auth**), isolated network, ephemeral database. ⚠️ Sets `ACCEPT_EULA=Y` on your behalf; `--help` for flags. |
+| `apply-kusto-schema.sh` | Creates the Kusto databases, tables, ingestion mappings and the MITRE CAR functions. Idempotent. |
+| `ingest-kusto.sh` | Loads `data_store/processed` into the emulator: **Plaso `L2t*`, EvtxECmd, Zeek (conn + generic), Volatility, Velociraptor**. `--only <source>` to load one. |
+
+Shared libraries in `scripts/lib/`: `docker-lifecycle.sh` (container replace
+policy, isolated network, readiness, egress verification), `kusto-api.sh` (the
+emulator's REST endpoints, failure detection, reachability), and `l2t-split.py`
+(splits Plaso json_line into per-parser `L2t*` tables). Signature-lane helpers live
+in `scripts/signatures/lib/`.
+
+The Splunk-era and KAPE PowerShell scripts were retired (git history and the frozen
+`deprecated` branch keep them).
+
+---
+
+## 🧹 Self-cleanup
+
+The docker-using processors (`process-evtx`, `process-log2timeline`,
+`process-zeek`, `process-signatures`) run a `prune_dangling` trap on exit that
+removes docker layers left dangling when a pulled `:latest` tag moves — only
+untagged, unreferenced images; tool images and live containers are untouched.
 
 ---
 
 ## ⚠️ Licensing before you run
 
 - **`deploy-kusto.sh` accepts Microsoft's Software License Terms for you**
-  (`ACCEPT_EULA=Y`). The emulator is provided *as-is*, without support or
-  warranties, and is documented as generally unsuitable for production
-  workloads.
+  (`ACCEPT_EULA=Y`). The emulator is *as-is*, unsupported, and documented as
+  generally unsuitable for production.
 
 Full detail in [THIRD_PARTY_NOTICES.md](/THIRD_PARTY_NOTICES.md).
 
 ## ⚙️ Usage
 
 - Ensure **Docker** is installed and running.
-- Scripts assume the repository follows the correct **directory structure** (see [`data_store/README.md`](/data_store/README.md) for raw data sources).
-- Scripts resolve their own location, so they can be run from anywhere:
+- Scripts assume the repository's **directory structure** (see
+  [`data_store/README.md`](/data_store/README.md) for raw data sources).
 
 ```bash
 ./scripts/deploy-kusto.sh
+./scripts/process-zeek-ALL.sh
+./scripts/ingest-kusto.sh --only zeek
 ```
 
-> ⚠️ The processing scripts run `chmod -R 777` on their working directories
-> under `data_store/` to work around Docker UID mismatches. Don't run them on a
-> shared host.
+> ⚠️ The processing scripts run `chmod -R 777` on their working directories under
+> `data_store/` to work around Docker UID mismatches. Don't run them on a shared host.

--- a/project-progress.md
+++ b/project-progress.md
@@ -40,10 +40,12 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 | [Log2timeline/Plaso](https://github.com/log2timeline/plaso) (disk images, all formats + VM) | ✅ `process-log2timeline-Dynamic.sh` | json_line (+ `.plaso` db) | ✅ per-parser `host.L2t<Parser>` | ✅ (`file`, `process` prefetch/amcache/cron, `user_session` utmp/ssh) |
 | Linux Logs (syslog / utmp / ssh, via Plaso)                   | ✅            | json_line       | ✅ `host.L2tText`/`L2tUtmp` | ✅ (`user_session` utmp+ssh, `process` cron) |
 | [Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon) | ✅ (via EvtxECmd) | evtx → json | ✅ `host.EvtxEcmdJson` | ✅ (`driver`/`module`/`thread`, + `process`/`flow`/`registry`/`file`) |
-| [Syslog](https://syslog-ng.github.io)                         |               |                 |              |               |
-| [Zimmerman](https://github.com/EricZimmerman)                 |               |                 |              |               |
-| [Hayabusa](https://github.com/Yamato-Security/hayabusa)       |               |                 |              |               |
-| [Chainsaw](https://github.com/countercept/chainsaw)           |               |                 |              |               |
+| [YARA](https://github.com/VirusTotal/yara) (files / mounted disk / memory) | ✅ `process-signatures.sh` (yara.sh) | json (matches) | ⏳ `processed/signatures/yara` | ⏳ detection enrichment (follow-up) |
+| [Suricata](https://suricata.io/) (pcaps → EVE)                | ✅ `process-signatures.sh` (suricata.sh) | json (EVE) | ⏳ `processed/signatures/suricata` | ⏳ |
+| [Hayabusa](https://github.com/Yamato-Security/hayabusa) (EVTX → Sigma) | ✅ `process-signatures.sh` (hayabusa.sh) — validated 792 detections | json (Sigma) | ⏳ `processed/signatures/hayabusa` | ⏳ |
+| [Chainsaw](https://github.com/countercept/chainsaw)           | ❌            |                 |              |               |
+| [Syslog](https://syslog-ng.github.io)                         | ✅ (via Plaso) |                 |              |               |
+| [Zimmerman](https://github.com/EricZimmerman)                 | (via Velociraptor) |            |              |               |
 
 **All nine CAR objects now run against a live emulator.** The MITRE CAR data
 model is expressed as KQL functions in the `mitre` database — `CarFlow()`,
@@ -56,6 +58,14 @@ Security log. Sysmon also strengthens `process` (event 1/5, full pid/ppid/comman
 line), `flow` (3), `registry` (12/13/14) and `file` (11/23). On the live engine
 `CarCoverage()` returned real rows for **all nine** objects — see
 [docs/Runtime-Validation.md](/docs/Runtime-Validation.md).
+
+**The CAR layer has since been refactored into per-artefact views.** Each object
+is now built as one view per artefact — `Car<Object>_<Artefact>()` (e.g.
+`CarProcess_Sysmon`, `CarProcess_Memory`, `CarRegistry_Recmd`) — that keeps the
+source table's native fields and *adds* the canonical CAR fields; the public
+`CarX()` is a `union isfuzzy` roll-up. Every artefact fills every canonical field
+it can supply, strict to `car_data_model.json`. See
+[docs/CAR-Extraction-Rules.md](/docs/CAR-Extraction-Rules.md) and #43.
 
 **What the live run still does not cover.** Plaso was run for real, but only on
 filesystem test images — a Windows image (for `CarProcess`-from-Plaso via


### PR DESCRIPTION
Bring the deployment docs current — they'd drifted badly (Scripts-Overview documented only 2 of 6 processors and called Plaso output "dynamic CSV"; Hayabusa was listed "Not started").

- **Scripts-Overview**: all processors (log2timeline→json_line + per-parser L2t*, zeek, volatility, evtx, velociraptor) + the signature lanes (yara/suricata/hayabusa, with the mount-not-extract and Hayabusa `-J` caveats) + real ingest scope + dangling-layer self-cleanup.
- **Containers**: add volatility/yara/suricata images; note Hayabusa native + disk-access host tools.
- **Dir-Structure**: processed tree now shows volatility/signatures/velociraptor and plaso/+jsonl/.
- **README**: signature-detection row (Hayabusa validated at 792 detections; add YARA/Suricata); Plaso CSV→json_line.
- **project-progress**: signature rows + the per-artefact CAR refactor note.

Docs-only; no evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)