### PR TITLE
dfir_volatility: memory images → Volatility 3 per-plugin JSONL (Python + role)

### DIFF
--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -1,0 +1,21 @@
+# get_sybers.dfir
+
+The DX_DFIR forensic processing pipeline as an Ansible Galaxy collection. The heavy
+logic lives in the `get_sybers_dfir` Python package (`python/`); each Ansible **task
+is one action** that invokes it, and the **playbook** holds every decision — which
+roles run and the `--pipeline adx|sofelk` selection.
+
+Conforms to the Get-Sybers Ansible standards (naming/structuring + one-action-per-task
++ robustness) — see `Get-Sybers/Ludus-Ansible` `docs/standards/ansible/`.
+
+## Roles
+| Role | Source | Status |
+|---|---|---|
+| `dfir_zeek` | PCAPs → Zeek JSON | exemplar (this PR) |
+| `dfir_plaso`, `dfir_volatility`, `dfir_evtx`, `dfir_signatures` | — | planned (#46) |
+| `dfir_ingest_adx`, `dfir_ingest_sofelk`, `dfir_deploy_*` | — | planned (#46) |
+
+## Usage
+```bash
+ansible-playbook playbooks/dfir-process-zeek.yml -e dfir_zeek_pipeline=adx
+```

--- a/ansible/collections/get_sybers.dfir/galaxy.yml
+++ b/ansible/collections/get_sybers.dfir/galaxy.yml
@@ -1,0 +1,20 @@
+---
+namespace: get_sybers
+name: dfir
+version: 0.1.0
+readme: README.md
+authors:
+  - Get-Sybers
+description: >-
+  DX_DFIR forensic processing pipeline as Ansible roles. Each role invokes the
+  get_sybers_dfir Python package as a single action; the playbook decides which
+  roles run and the --pipeline (adx|sofelk) selection.
+license:
+  - MIT
+tags:
+  - dfir
+  - forensics
+  - security
+build_ignore:
+  - molecule
+  - "*.pyc"

--- a/ansible/collections/get_sybers.dfir/meta/runtime.yml
+++ b/ansible/collections/get_sybers.dfir/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.15"

--- a/ansible/collections/get_sybers.dfir/playbooks/dfir-process-volatility.yml
+++ b/ansible/collections/get_sybers.dfir/playbooks/dfir-process-volatility.yml
@@ -1,0 +1,11 @@
+---
+# The playbook holds the decisions. It selects the role and passes the pipeline;
+# the role groups, the tasks act (one-action-per-task).
+- name: "DFIR | process memory images with Volatility 3"
+  hosts: "{{ dfir_hosts | default('localhost') }}"
+  connection: "{{ dfir_connection | default('local') }}"
+  gather_facts: true
+  tasks:
+    - name: "dfir-process-volatility | run the volatility role"
+      ansible.builtin.include_role:
+        name: dfir_volatility

--- a/ansible/collections/get_sybers.dfir/requirements.yml
+++ b/ansible/collections/get_sybers.dfir/requirements.yml
@@ -1,0 +1,5 @@
+---
+# Pinned — never :latest, never a bare branch (ANSIBLE-STANDARDS: infra galaxy §2).
+collections:
+  - name: community.docker
+    version: "3.10.3"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/README.md
@@ -1,0 +1,48 @@
+# dfir_volatility
+
+Process **memory images** with **Volatility 3** into per-plugin JSON Lines for the
+ADX or SOF-ELK pipeline. The role is structure only — it asserts inputs, runs a
+preflight (docker, memory dir, the `jsonl_dfir` renderer, the custom plugins dir),
+then invokes the `get_sybers_dfir.volatility` Python processor as a **single
+action** (one container run per plugin per image happens inside Python). One
+`<plugin>.jsonl` per image, via the custom `jsonl_dfir` renderer.
+
+## Role variables
+| Variable | Default | Description |
+|---|---|---|
+| `dfir_volatility_pipeline` | `adx` | `adx` or `sofelk` — selects the output destination (the **playbook** decides this). |
+| `dfir_volatility_memory_dir` | `<repo>/data_store/raw/memory` | Memory-image tree to process (recursed). |
+| `dfir_volatility_adx_out_dir` | `<repo>/data_store/processed/volatility` | ADX-path output. |
+| `dfir_volatility_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/volatility` | SOF-ELK-path output. |
+| `dfir_volatility_symbols_dir` | `<repo>/data_store/dependencies/volatility3-symbols` | Kernel symbol cache (`VOLATILITY_SYMBOLS`). |
+| `dfir_volatility_renderer` | `<repo>/dev-scripts/volatility/jsonl_dfir_renderer.py` | Custom JSONL renderer. |
+| `dfir_volatility_plugins_dir` | `<repo>/dev-scripts/volatility/plugins` | Custom plugins (`dfir_processes`, `dfir_registry`). |
+| `dfir_volatility_image` | `sk4la/volatility3:latest` | Volatility 3 container image. |
+| `dfir_volatility_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
+| `dfir_volatility_force` | `false` | Rerun plugins that already have valid output. |
+
+## Symbols (network)
+Windows plugins resolve the kernel against ISF symbol tables Volatility fetches from
+the symbol servers on first use — that needs **outbound network**. On an isolated
+host, pre-seed `dfir_volatility_symbols_dir`, or the Windows plugins error with
+"symbol table requirement was not fulfilled". `banners.Banners` needs no symbols.
+
+## Idempotence
+A plugin whose `.jsonl` output exists and whose first line parses as JSON is
+skipped — the skip lives in the Python processor, never in a task `when:`.
+Per-plugin failures (e.g. symbols unavailable) are **normal** and non-fatal: the
+verify gate is "some plugin produced output, or there were no images", not
+`failed == 0`.
+
+## Example
+```bash
+ansible-playbook playbooks/dfir-process-volatility.yml -e dfir_volatility_pipeline=adx
+```
+
+## Testing
+Python unit tests cover the pure logic (image discovery, name folding, JSONL
+validity, no-images path, the CAR plugin set). The **Molecule** scenario needs a
+memory image (large/binary — not shipped) and, for the Windows plugins, symbols:
+```bash
+molecule test -- -e molecule_sample_memory=/path/dump.raw
+```

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# Backend to target; the playbook overrides this to select the pipeline.
+dfir_volatility_pipeline: adx
+
+# Repo root is five levels up from this role
+# (roles/dfir_volatility -> get_sybers.dfir -> collections -> ansible -> repo).
+dfir_volatility_repo_root: "{{ role_path }}/../../../../.."
+
+dfir_volatility_memory_dir: "{{ dfir_volatility_repo_root }}/data_store/raw/memory"
+dfir_volatility_adx_out_dir: "{{ dfir_volatility_repo_root }}/data_store/processed/volatility"
+dfir_volatility_sofelk_out_dir: "{{ dfir_volatility_repo_root }}/data_store/processed/sofelk/volatility"
+# Kernel symbol cache (VOLATILITY_SYMBOLS). Windows plugins fetch ISF tables from
+# the symbol servers on first use — pre-seed this on an isolated host.
+dfir_volatility_symbols_dir: "{{ dfir_volatility_repo_root }}/data_store/dependencies/volatility3-symbols"
+# Custom renderer + plugins live in the repo (dev-scripts), mounted into the run.
+dfir_volatility_renderer: "{{ dfir_volatility_repo_root }}/dev-scripts/volatility/jsonl_dfir_renderer.py"
+dfir_volatility_plugins_dir: "{{ dfir_volatility_repo_root }}/dev-scripts/volatility/plugins"
+dfir_volatility_image: "sk4la/volatility3:latest"
+# In-repo runs use PYTHONPATH; a deployed run installs the package instead.
+dfir_volatility_python_path: "{{ dfir_volatility_repo_root }}/python"
+dfir_volatility_force: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/argument_specs.yml
@@ -1,0 +1,56 @@
+---
+argument_specs:
+  main:
+    short_description: "memory images -> Volatility 3 per-plugin JSON Lines."
+    description:
+      - >-
+        Discovers memory images under dfir_volatility_memory_dir and runs the CAR
+        plugin set (via the container + custom jsonl_dfir renderer), writing one
+        <plugin>.jsonl per image. Idempotent per plugin: a plugin whose valid .jsonl
+        output already exists is skipped. Windows plugins need kernel symbols
+        (outbound network on first use, or a pre-seeded dfir_volatility_symbols_dir).
+    options:
+      dfir_volatility_pipeline:
+        type: str
+        required: false
+        default: adx
+        choices: [adx, sofelk]
+        description: "Which backend to target; selects the output destination."
+      dfir_volatility_memory_dir:
+        type: str
+        required: true
+        description: "Directory tree of memory images to process (recursed)."
+      dfir_volatility_adx_out_dir:
+        type: str
+        required: false
+        description: "ADX-path output dir (default data_store/processed/volatility)."
+      dfir_volatility_sofelk_out_dir:
+        type: str
+        required: false
+        description: "SOF-ELK-path output dir (its Logstash watch dir)."
+      dfir_volatility_symbols_dir:
+        type: str
+        required: false
+        description: "Volatility symbol cache (VOLATILITY_SYMBOLS); pre-seed when offline."
+      dfir_volatility_renderer:
+        type: str
+        required: false
+        description: "Path to the jsonl_dfir_renderer.py (dev-scripts/volatility)."
+      dfir_volatility_plugins_dir:
+        type: str
+        required: false
+        description: "Custom plugins dir (dfir_processes, dfir_registry)."
+      dfir_volatility_image:
+        type: str
+        required: false
+        default: "sk4la/volatility3:latest"
+        description: "Volatility 3 container image."
+      dfir_volatility_python_path:
+        type: str
+        required: false
+        description: "PYTHONPATH to the get_sybers_dfir package (in-repo/dev runs)."
+      dfir_volatility_force:
+        type: bool
+        required: false
+        default: false
+        description: "Rerun plugins that already have valid output."

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: dfir_volatility
+  namespace: get_sybers
+  author: Get-Sybers
+  description: >-
+    Process memory images with Volatility 3 into per-plugin JSON Lines for the ADX
+    or SOF-ELK pipeline. Invokes the get_sybers_dfir.volatility Python processor;
+    one <plugin>.jsonl per image via the custom jsonl_dfir renderer.
+  company: Get-Sybers
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions: [bookworm, trixie]
+  galaxy_tags: [dfir, volatility, memory, forensics]
+
+dependencies: []

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/converge.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/converge.yml
@@ -1,0 +1,12 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: true
+  vars:
+    dfir_volatility_pipeline: adx
+    dfir_volatility_memory_dir: /tmp/dfir_volatility_molecule/mem
+    dfir_volatility_adx_out_dir: /tmp/dfir_volatility_molecule/out
+  tasks:
+    - name: "converge | run dfir_volatility (ADX)"
+      ansible.builtin.include_role:
+        name: dfir_volatility

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/molecule.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: default            # delegated — the role runs the Volatility container itself
+platforms:
+  - name: localhost
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      localhost:
+        ansible_connection: local
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+verifier:
+  name: ansible

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/prepare.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/prepare.yml
@@ -1,0 +1,38 @@
+---
+# A memory image is large/binary and Windows symbols need network, so no fixture
+# ships in-repo. Point this at a memory image to run the scenario:
+#   molecule test -- -e molecule_sample_memory=/path/dump.raw
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_mem_in: /tmp/dfir_volatility_molecule/mem
+    molecule_out: /tmp/dfir_volatility_molecule/out
+    molecule_sample_memory: ""
+  tasks:
+    - name: "molecule-prepare | require a sample memory image"
+      ansible.builtin.assert:
+        that:
+          - molecule_sample_memory | length > 0
+        fail_msg: >-
+          Provide -e molecule_sample_memory=<path/to/memory-image> (large/binary; not
+          shipped). banners.Banners runs without symbols; Windows plugins need a
+          pre-seeded symbol cache or outbound network.
+        quiet: true
+
+    - name: "molecule-prepare | start from a clean output dir"
+      ansible.builtin.file:
+        path: "{{ molecule_out }}"
+        state: absent
+
+    - name: "molecule-prepare | memory input dir exists"
+      ansible.builtin.file:
+        path: "{{ molecule_mem_in }}"
+        state: directory
+        mode: "0755"
+
+    - name: "molecule-prepare | stage the sample memory image"
+      ansible.builtin.copy:
+        src: "{{ molecule_sample_memory }}"
+        dest: "{{ molecule_mem_in }}/sample.raw"
+        mode: "0644"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/verify.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/molecule/default/verify.yml
@@ -1,0 +1,21 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_out: /tmp/dfir_volatility_molecule/out
+  tasks:
+    - name: "molecule-verify | find the produced per-plugin JSONL"
+      ansible.builtin.find:
+        paths: "{{ molecule_out }}"
+        patterns: "*.jsonl"
+        recurse: true
+      register: produced
+
+    - name: "molecule-verify | assert at least banners.Banners produced output"
+      ansible.builtin.assert:
+        that:
+          - produced.matched | int > 0
+          - produced.files | map(attribute='path') | map('basename') | select('search', '^banners\\.Banners\\.jsonl$') | list | length > 0
+        fail_msg: "no plugin JSONL produced from the sample memory image (banners.Banners needs no symbols)"
+        quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/adx.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/adx.yml
@@ -1,0 +1,26 @@
+---
+- name: "volatility-adx | process memory images into per-plugin JSONL"
+  ansible.builtin.command:
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.volatility', '--memory-dir', dfir_volatility_memory_dir, '--out-dir', dfir_volatility_adx_out_dir, '--symbols-dir', dfir_volatility_symbols_dir, '--renderer', dfir_volatility_renderer, '--plugins-dir', dfir_volatility_plugins_dir, '--image', dfir_volatility_image] + (['--force'] if dfir_volatility_force | bool else []) }}"
+  environment:
+    PYTHONPATH: "{{ dfir_volatility_python_path }}"
+  register: dfir_volatility_adx_run
+  changed_when: (dfir_volatility_adx_run.stdout | from_json).processed | int > 0
+
+- name: "volatility-adx | verify per-plugin JSONL on disk"
+  ansible.builtin.find:
+    paths: "{{ dfir_volatility_adx_out_dir }}"
+    patterns: "*.jsonl"
+    recurse: true
+  register: dfir_volatility_adx_verify
+
+# Per-plugin failures are NORMAL (Windows plugins error without symbols), so the
+# gate is "some plugin produced output, or there were no images" — not failed==0.
+- name: "volatility-adx | assert output was produced for the images present"
+  ansible.builtin.assert:
+    that:
+      - dfir_volatility_adx_verify.matched | int > 0 or (dfir_volatility_adx_run.stdout | from_json).images | int == 0
+    fail_msg: >-
+      volatility produced no JSONL at all though memory images were present (symbols
+      unavailable for every plugin?).
+    quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# dfir_volatility: memory images -> per-plugin JSONL. The role GROUPS; the playbook
+# DECIDES. Idempotence (skip plugins with valid output) lives in the Python
+# processor, not in a task's `when:`.
+
+- name: "volatility | assert inputs"
+  ansible.builtin.assert:
+    that:
+      - dfir_volatility_pipeline in ['adx', 'sofelk']
+      - dfir_volatility_memory_dir | length > 0
+    fail_msg: >-
+      dfir_volatility needs dfir_volatility_pipeline (adx|sofelk) and a non-empty
+      dfir_volatility_memory_dir.
+    quiet: true
+  tags: [always]
+
+# Fact-find + preconditions BEFORE any container runs or files are written.
+- name: "volatility | preflight"
+  ansible.builtin.include_tasks:
+    file: preflight.yml
+    apply:
+      tags: [always]
+  tags: [always]
+
+# Pipeline selection is a decision — it sits on the include, never on an action.
+- name: "volatility | ADX pipeline"
+  ansible.builtin.include_tasks: adx.yml
+  when: dfir_volatility_pipeline == 'adx'
+
+- name: "volatility | SOF-ELK pipeline"
+  ansible.builtin.include_tasks: sofelk.yml
+  when: dfir_volatility_pipeline == 'sofelk'

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/preflight.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/preflight.yml
@@ -1,0 +1,57 @@
+---
+# FIND FACTS -> check existence AND location -> (then adx/sofelk MODIFY + VERIFY).
+
+- name: "volatility-preflight | docker daemon reachable"
+  ansible.builtin.command: docker version
+  register: dfir_volatility_docker
+  changed_when: false
+
+- name: "volatility-preflight | stat the memory dir"
+  ansible.builtin.stat:
+    path: "{{ dfir_volatility_memory_dir }}"
+  register: dfir_volatility_mem_stat
+
+- name: "volatility-preflight | memory dir exists and is a directory"
+  ansible.builtin.assert:
+    that:
+      - dfir_volatility_mem_stat.stat.exists
+      - dfir_volatility_mem_stat.stat.isdir is defined and dfir_volatility_mem_stat.stat.isdir
+    fail_msg: >-
+      dfir_volatility_memory_dir ({{ dfir_volatility_memory_dir }}) is missing or is
+      not a directory.
+    quiet: true
+
+- name: "volatility-preflight | stat the jsonl_dfir renderer"
+  ansible.builtin.stat:
+    path: "{{ dfir_volatility_renderer }}"
+  register: dfir_volatility_renderer_stat
+
+- name: "volatility-preflight | the renderer file is present"
+  ansible.builtin.assert:
+    that:
+      - dfir_volatility_renderer_stat.stat.exists
+      - dfir_volatility_renderer_stat.stat.isreg is defined and dfir_volatility_renderer_stat.stat.isreg
+    fail_msg: >-
+      jsonl_dfir renderer not found at {{ dfir_volatility_renderer }}.
+    quiet: true
+
+- name: "volatility-preflight | stat the custom plugins dir"
+  ansible.builtin.stat:
+    path: "{{ dfir_volatility_plugins_dir }}"
+  register: dfir_volatility_plugins_stat
+
+- name: "volatility-preflight | the custom plugins dir is present"
+  ansible.builtin.assert:
+    that:
+      - dfir_volatility_plugins_stat.stat.exists
+      - dfir_volatility_plugins_stat.stat.isdir is defined and dfir_volatility_plugins_stat.stat.isdir
+    fail_msg: >-
+      custom plugins dir not found at {{ dfir_volatility_plugins_dir }}.
+    quiet: true
+
+- name: "volatility-preflight | the get_sybers_dfir.volatility module imports"
+  ansible.builtin.command: python3 -c "import get_sybers_dfir.volatility"
+  environment:
+    PYTHONPATH: "{{ dfir_volatility_python_path }}"
+  register: dfir_volatility_import
+  changed_when: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/sofelk.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/sofelk.yml
@@ -1,0 +1,17 @@
+---
+# The processing is identical, only the destination differs. Whether SOF-ELK
+# consumes Volatility output and delivery into its watch dir is tracked in #45.
+- name: "volatility-sofelk | process memory images into per-plugin JSONL"
+  ansible.builtin.command:
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.volatility', '--memory-dir', dfir_volatility_memory_dir, '--out-dir', dfir_volatility_sofelk_out_dir, '--symbols-dir', dfir_volatility_symbols_dir, '--renderer', dfir_volatility_renderer, '--plugins-dir', dfir_volatility_plugins_dir, '--image', dfir_volatility_image] + (['--force'] if dfir_volatility_force | bool else []) }}"
+  environment:
+    PYTHONPATH: "{{ dfir_volatility_python_path }}"
+  register: dfir_volatility_sofelk_run
+  changed_when: (dfir_volatility_sofelk_run.stdout | from_json).processed | int > 0
+
+- name: "volatility-sofelk | verify per-plugin JSONL on disk"
+  ansible.builtin.find:
+    paths: "{{ dfir_volatility_sofelk_out_dir }}"
+    patterns: "*.jsonl"
+    recurse: true
+  register: dfir_volatility_sofelk_verify

--- a/python/get_sybers_dfir/__init__.py
+++ b/python/get_sybers_dfir/__init__.py
@@ -1,0 +1,8 @@
+"""get_sybers_dfir — the DX_DFIR processing package.
+
+Pure Python processors (zeek, plaso, volatility, evtx, signatures, ingest) and the
+`dfir` CLI. The Ansible collection `get_sybers.dfir` invokes these as single actions;
+the playbook holds the decisions. See docs/CAR-Extraction-Rules.md and epic #46.
+"""
+
+__version__ = "0.1.0"

--- a/python/get_sybers_dfir/volatility.py
+++ b/python/get_sybers_dfir/volatility.py
@@ -1,0 +1,216 @@
+"""Volatility 3 processor — memory images -> per-plugin JSON Lines.
+
+Faithful port of the retired ``process-volatility.sh``: run a fixed set of
+Volatility 3 plugins over each memory image with the custom ``jsonl_dfir`` renderer
+(one flat JSON object per TreeGrid node — one process/connection/artefact per line),
+writing ``<plugin>.jsonl`` per image. ingest-kusto.sh wraps each line as
+``{Plugin, SourceFile, Record}`` into memory.VolatilityJson, where the plugin's
+fields are reachable as ``Record.FieldName`` in KQL.
+
+The renderer isn't built in, so it's imported before the CLI runs (when Volatility
+discovers renderers) via a small ``python3 -c`` wrapper; the renderer file, custom
+plugins dir, symbols dir, memory file and plugin are passed as argv (no path is
+spliced into Python source). Container mode mounts them; a native run
+(``vol_native``) puts them on PYTHONPATH / env instead.
+
+⚠️ SYMBOLS. Windows plugins resolve the kernel against ISF symbol tables Volatility
+fetches from the symbol servers on first use — that needs outbound network. On an
+isolated host, pre-seed ``symbols_dir`` (VOLATILITY_SYMBOLS) or the Windows plugins
+error; format-agnostic plugins (banners.Banners) work without symbols.
+
+Idempotent: a plugin whose ``.jsonl`` output exists and whose first line parses as
+JSON is skipped. Empty/failed plugin outputs are removed (not treated as done).
+Emits a machine-readable summary as JSON on stdout for an honest ``changed_when``
+(``processed > 0`` — processed counts plugin OUTPUTS, matching the shell).
+
+    python -m get_sybers_dfir.volatility --memory-dir RAW/memory --out-dir PROCESSED/volatility \
+        --symbols-dir DEPENDENCIES/volatility3-symbols \
+        --renderer dev-scripts/volatility/jsonl_dfir_renderer.py \
+        --plugins-dir dev-scripts/volatility/plugins
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+_IMAGE = "sk4la/volatility3:latest"
+
+# The plugins run per image — kept to the ones the analysis backend uses (process
+# tree, network, command lines, injected code). Order preserved from the shell.
+DEFAULT_PLUGINS = [
+    "banners.Banners",
+    "windows.info",
+    "dfir_processes.DfirProcesses",   # -> CarProcess (psscan; full path, parent, DLLs)
+    "windows.pslist",
+    "windows.pstree",
+    "windows.dlllist",                # -> CarModule
+    "windows.modules",                # -> CarDriver
+    "windows.netscan",                # -> CarFlow
+    "windows.netstat",                # -> CarFlow
+    "windows.sessions",               # -> CarUserSession
+    "windows.filescan",               # -> CarFile
+    "windows.svcscan",                # -> CarService
+    "windows.thrdscan",               # -> CarThread
+    "dfir_registry.DfirRegistry",     # -> CarRegistry
+    "windows.malfind",
+]
+
+_MEMORY_EXTS = (
+    ".raw", ".mem", ".dmp", ".lime", ".vmem",
+    ".bin", ".dump", ".vmsn", ".crash",
+)
+
+# import the renderer, then hand the CLI its argv (renderer discovered on import).
+_WRAPPER = (
+    "import importlib.util, sys\n"
+    "spec = importlib.util.spec_from_file_location('jsonl_dfir_renderer', sys.argv[1])\n"
+    "mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)\n"
+    "from volatility3.cli import CommandLine\n"
+    "sys.argv = ['vol', '-q', '-p', sys.argv[2], '-s', sys.argv[3],\n"
+    "            '-r', 'jsonl_dfir', '-f', sys.argv[4], sys.argv[5]]\n"
+    "CommandLine().run()\n"
+)
+
+
+def is_memory_image(name: str) -> bool:
+    """Match by common memory-dump extensions plus the M57 corpus '*dramimage'."""
+    low = name.lower()
+    return low.endswith(_MEMORY_EXTS) or low.endswith("dramimage")
+
+
+def discover(memory_dir: str) -> list[str]:
+    """Every memory image under memory_dir (recursed), sorted, absolute."""
+    found = []
+    for root, _dirs, files in os.walk(memory_dir):
+        for name in files:
+            if is_memory_image(name):
+                found.append(os.path.join(root, name))
+    return sorted(found)
+
+
+def clean_name(rel: str) -> str:
+    """Output-folder name from a path relative to the memory dir (dirs+space folded),
+    so two corpora sharing a basename keep distinct output."""
+    return rel.replace("/", "_").replace(" ", "_")
+
+
+def _valid_jsonl(path: str) -> bool:
+    """Non-empty and first line parses as JSON — the shell's done/valid guard."""
+    try:
+        if os.path.getsize(path) <= 0:
+            return False
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            first = fh.readline()
+    except OSError:
+        return False
+    if not first.strip():
+        return False
+    try:
+        json.loads(first)
+        return True
+    except json.JSONDecodeError:
+        return False
+
+
+def _run_vol(img, plugin, out_path, symbols_dir, renderer, plugins_dir, image, native):
+    """Run one plugin over one image, JSONL to out_path (stdout captured; stderr dropped)."""
+    with open(out_path, "w") as out:
+        if native:
+            env = dict(os.environ, VOLATILITY3_SYMBOL_DIRECTORIES=symbols_dir)
+            subprocess.run(
+                [native, "-c", _WRAPPER, renderer, plugins_dir, symbols_dir, img, plugin],
+                stdout=out, stderr=subprocess.DEVNULL, env=env, check=False,
+            )
+        else:
+            subprocess.run(
+                [
+                    "docker", "run", "--rm",
+                    "-v", f"{os.path.dirname(img)}:/mem:ro",
+                    "-v", f"{os.path.realpath(symbols_dir)}:/symbols",
+                    "-v", f"{os.path.realpath(renderer)}:/opt/jsonl_dfir_renderer.py:ro",
+                    "-v", f"{os.path.realpath(plugins_dir)}:/plugins:ro",
+                    "--entrypoint", "python3", image,
+                    "-c", _WRAPPER,
+                    "/opt/jsonl_dfir_renderer.py", "/plugins", "/symbols",
+                    f"/mem/{os.path.basename(img)}", plugin,
+                ],
+                stdout=out, stderr=subprocess.DEVNULL, check=False,
+            )
+
+
+def process(memory_dir, out_dir, symbols_dir, renderer, plugins_dir,
+            image=_IMAGE, plugins=None, native=None, force=False) -> dict:
+    """Run the plugin set over every image under memory_dir. Idempotent per plugin."""
+    memory_dir = os.path.realpath(memory_dir)
+    out_dir = os.path.realpath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    os.makedirs(symbols_dir, exist_ok=True)
+    plugins = plugins or DEFAULT_PLUGINS
+    images = discover(memory_dir)
+
+    processed, skipped, failed, results = 0, 0, 0, []
+    for img in images:
+        rel = os.path.relpath(img, memory_dir)
+        dest = os.path.join(out_dir, clean_name(rel))
+        os.makedirs(dest, exist_ok=True)
+        per_image = {"image": rel, "produced": [], "empty": []}
+        for plugin in plugins:
+            out_path = os.path.join(dest, f"{plugin}.jsonl")
+            if not force and _valid_jsonl(out_path):
+                skipped += 1
+                continue
+            _run_vol(img, plugin, out_path, symbols_dir, renderer, plugins_dir, image, native)
+            if _valid_jsonl(out_path):
+                processed += 1
+                per_image["produced"].append(plugin)
+            else:
+                if os.path.exists(out_path):
+                    os.remove(out_path)
+                failed += 1
+                per_image["empty"].append(plugin)
+        results.append(per_image)
+
+    return {
+        "tool": "volatility",
+        "memory_dir": memory_dir,
+        "out_dir": out_dir,
+        "images": len(images),
+        "plugins": len(plugins),
+        "processed": processed,
+        "skipped": skipped,
+        "failed": failed,
+        "results": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="get_sybers_dfir.volatility",
+        description="memory images -> Volatility 3 per-plugin JSON Lines",
+    )
+    ap.add_argument("--memory-dir", required=True, help="directory tree of memory images")
+    ap.add_argument("--out-dir", required=True, help="output dir; one folder per image")
+    ap.add_argument("--symbols-dir", required=True, help="Volatility symbol cache (VOLATILITY_SYMBOLS)")
+    ap.add_argument("--renderer", required=True, help="path to jsonl_dfir_renderer.py")
+    ap.add_argument("--plugins-dir", required=True, help="custom plugins dir (dfir_processes, dfir_registry)")
+    ap.add_argument("--image", default=_IMAGE, help="Volatility 3 container image")
+    ap.add_argument("--vol-native", default=None, help="native volatility executable (skip container)")
+    ap.add_argument("--plugins", default=None, help="comma-separated plugin override (default: the CAR set)")
+    ap.add_argument("--force", action="store_true", help="rerun plugins that already have valid output")
+    args = ap.parse_args(argv)
+
+    plugins = [p.strip() for p in args.plugins.split(",") if p.strip()] if args.plugins else None
+    summary = process(
+        args.memory_dir, args.out_dir, args.symbols_dir, args.renderer, args.plugins_dir,
+        image=args.image, plugins=plugins, native=args.vol_native, force=args.force,
+    )
+    json.dump(summary, sys.stdout)
+    sys.stdout.write("\n")
+    return 1 if summary["failed"] and not summary["processed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "get-sybers-dfir"
+version = "0.1.0"
+description = "DX_DFIR forensic processing package (zeek, plaso, volatility, evtx, signatures) + CLI"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+
+[project.scripts]
+# CLI (Typer) is a later child issue (#46); processors run via `python -m get_sybers_dfir.<source>` today.
+
+[tool.setuptools.packages.find]
+include = ["get_sybers_dfir*"]

--- a/python/tests/test_volatility.py
+++ b/python/tests/test_volatility.py
@@ -1,0 +1,54 @@
+"""Unit tests for the pure logic of the volatility processor (no docker needed)."""
+import os
+
+from get_sybers_dfir import volatility as vol
+
+
+def test_is_memory_image_extensions():
+    assert vol.is_memory_image("dump.raw")
+    assert vol.is_memory_image("box.MEM")
+    assert vol.is_memory_image("charlie-2009-12-11.mddramimage")  # M57 corpus
+    assert not vol.is_memory_image("notes.txt")
+    assert not vol.is_memory_image("capture.pcap")
+
+
+def test_clean_name_folds_dirs_and_spaces():
+    assert vol.clean_name("lonewolf/mem dump.mem") == "lonewolf_mem_dump.mem"
+
+
+def test_discover_recurses_and_sorts(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "x.raw").write_bytes(b"m")
+    (tmp_path / "b.vmem").write_bytes(b"m")
+    (tmp_path / "readme.txt").write_bytes(b"m")
+    got = [os.path.relpath(p, tmp_path) for p in vol.discover(str(tmp_path))]
+    assert got == ["a/x.raw", "b.vmem"]
+
+
+def test_valid_jsonl(tmp_path):
+    good = tmp_path / "good.jsonl"
+    good.write_text('{"PID": 4}\n{"PID": 8}\n')
+    assert vol._valid_jsonl(str(good)) is True
+
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("")
+    assert vol._valid_jsonl(str(empty)) is False
+
+    junk = tmp_path / "junk.jsonl"
+    junk.write_text("not json at all\n")
+    assert vol._valid_jsonl(str(junk)) is False
+
+
+def test_process_no_images_is_clean(tmp_path):
+    s = vol.process(
+        str(tmp_path / "mem"), str(tmp_path / "out"), str(tmp_path / "sym"),
+        "renderer.py", "plugins",
+    )
+    assert s["images"] == 0 and s["processed"] == 0 and s["failed"] == 0
+    assert s["plugins"] == len(vol.DEFAULT_PLUGINS)
+
+
+def test_default_plugins_include_car_set():
+    assert "dfir_processes.DfirProcesses" in vol.DEFAULT_PLUGINS
+    assert "dfir_registry.DfirRegistry" in vol.DEFAULT_PLUGINS
+    assert vol.DEFAULT_PLUGINS[0] == "banners.Banners"


### PR DESCRIPTION
Slice of epic #46 — the Volatility 3 lane as **Python** + an **Ansible role**, same shape as the `dfir_zeek` exemplar (#49), conforming to the Get-Sybers standards.

- `python/get_sybers_dfir/volatility.py` — port of `process-volatility.sh`: run the CAR plugin set (container + custom `jsonl_dfir` renderer, wrapper-imported) over each memory image into `<plugin>.jsonl`; idempotent per plugin; empty/failed plugin outputs removed; machine-readable summary (`processed` counts plugin **outputs**). Unit-tested (6 tests).
- `dfir_volatility` role: one action per task, `--pipeline adx|sofelk` on the include; preflight (docker; stat memory dir / renderer / plugins-dir → assert; python import). **Per-plugin failures are normal** (Windows plugins need symbols) so the verify gate is "some output, or no images", not `failed==0`. argument_specs, role-prefixed vars, FQCN, defaults, README, Molecule.

**Validated:** rule-8 gate PASSES; unit tests pass (6); ansible syntax OK; preflight chain runs green (`ok=9`). Live Volatility + Molecule need a memory image and (for Windows plugins) symbols — maintainer-run, documented in the role README.

Shared scaffolding byte-identical to the other role branches (clean merge into `dev`). Targets `dev`. Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)