### PR TITLE
dfir_plaso: disk images / VM exports → enriched Plaso JSONL (Python + role)

### DIFF
--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -19,7 +19,7 @@ as a single action. Roles land per source as epic #46 retires the matching
 | `dfir_velociraptor` | Velociraptor collector ZIPs → per-artefact JSON | `get_sybers_dfir.velociraptor` |
 | `dfir_volatility` | Memory images → Volatility 3 per-plugin JSONL | `get_sybers_dfir.volatility` |
 | `dfir_evtx` | Windows Event Logs (`.evtx`) → EvtxECmd JSON | `get_sybers_dfir.evtx` |
-| `dfir_plaso` | Disk images / VM exports → Plaso JSONL | `get_sybers_dfir.plaso` (following) |
+| `dfir_plaso` | Disk images / VM exports → Plaso JSONL | `get_sybers_dfir.plaso` |
 | `dfir_signatures` | YARA / Suricata / Hayabusa detections | `get_sybers_dfir.signatures` (following) |
 
 Ingest and deploy roles (`dfir_ingest_*`, `dfir_deploy_*`) follow as later slices of #46.
@@ -32,4 +32,5 @@ ansible-playbook playbooks/dfir-process-zeek.yml -e dfir_zeek_pipeline=adx
 ansible-playbook playbooks/dfir-process-velociraptor.yml -e dfir_velociraptor_pipeline=adx
 ansible-playbook playbooks/dfir-process-volatility.yml -e dfir_volatility_pipeline=adx
 ansible-playbook playbooks/dfir-process-evtx.yml -e dfir_evtx_pipeline=adx
+ansible-playbook playbooks/dfir-process-plaso.yml -e dfir_plaso_pipeline=adx
 ```

--- a/ansible/collections/get_sybers.dfir/playbooks/dfir-process-plaso.yml
+++ b/ansible/collections/get_sybers.dfir/playbooks/dfir-process-plaso.yml
@@ -1,0 +1,11 @@
+---
+# The playbook holds the decisions. It selects the role and passes the pipeline;
+# the role groups, the tasks act (one-action-per-task).
+- name: "DFIR | process disk images / VM exports with Plaso"
+  hosts: "{{ dfir_hosts | default('localhost') }}"
+  connection: "{{ dfir_connection | default('local') }}"
+  gather_facts: true
+  tasks:
+    - name: "dfir-process-plaso | run the plaso role"
+      ansible.builtin.include_role:
+        name: dfir_plaso

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/README.md
@@ -1,0 +1,51 @@
+# dfir_plaso
+
+Process **forensic disk images** and **VMware VM exports** with **Plaso**
+(log2timeline + psort) into enriched JSON Lines for the ADX or SOF-ELK pipeline. The
+role is structure only — it asserts inputs, runs a preflight (docker, input dir, the
+`l2t_json_dfir` output module), then invokes the `get_sybers_dfir.plaso` Python
+processor as a **single action** (the two-step container work happens inside
+Python). One `<host>.jsonl` per image (named by the resolved `image_hostname`), plus
+the durable `.plaso` storage db and a per-image log.
+
+## Role variables
+| Variable | Default | Description |
+|---|---|---|
+| `dfir_plaso_pipeline` | `adx` | `adx` or `sofelk` — selects the output destination (the **playbook** decides this). |
+| `dfir_plaso_input_dir` | `<repo>/data_store/raw/disk_images` | Disk-image tree (E01/raw/img/dd/vmdk/vhd/vhdx/aff), recursed. |
+| `dfir_plaso_vm_dir` | `<repo>/data_store/raw/VM_files` | VMware VM export folders (one per VM); optional. |
+| `dfir_plaso_adx_out_dir` | `<repo>/data_store/processed/log2timeline` | ADX-path output (`jsonl/`, `plaso/`, `logs/`). |
+| `dfir_plaso_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/log2timeline` | SOF-ELK-path output. |
+| `dfir_plaso_module` | `<repo>/dev-scripts/plaso/l2t_json_dfir.py` | Custom psort output module. |
+| `dfir_plaso_image` | `log2timeline/plaso` | Plaso container image. |
+| `dfir_plaso_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
+| `dfir_plaso_force` | `false` | Reprocess images that already have output. |
+
+## Discovery
+Content-first: each file is identified by magic bytes (EWF/EWF2, VMDK, VHD/VHDX,
+QCOW2), with the extension as a fallback (raw/dd/img/aff carry no signature). Raw
+VMDK extents and EWF continuation segments are never processed on their own. VM
+exports pick the latest snapshot descriptor, else the single base descriptor; an
+ambiguous/missing descriptor is a **warning** (skipped), not a failure.
+
+## Idempotence
+An image whose `.plaso` db AND recorded json_line output both exist is skipped — a
+`.host` marker records the resolved output name, so a prior **failed** psort (db
+present, no marker) is not mistaken for done. The skip lives in the Python
+processor, never in a task `when:`. Per-image failures (a weird image yielding 0
+events) are tolerated: the verify gate is "some timeline was produced, or there were
+no sources".
+
+## Example
+```bash
+ansible-playbook playbooks/dfir-process-plaso.yml -e dfir_plaso_pipeline=adx
+```
+
+## Testing
+Python unit tests cover the pure logic (magic-byte format detection incl. the VHD
+footer path, extension fallback, VM descriptor selection, discovery, the
+`.plaso`+marker+jsonl idempotence guard, hostname sanitisation). The **Molecule**
+scenario needs a small parseable image (large/binary — not shipped):
+```bash
+molecule test -- -e molecule_sample_image=/path/tiny.raw
+```

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# Backend to target; the playbook overrides this to select the pipeline.
+dfir_plaso_pipeline: adx
+
+# Repo root is five levels up from this role
+# (roles/dfir_plaso -> get_sybers.dfir -> collections -> ansible -> repo).
+dfir_plaso_repo_root: "{{ role_path }}/../../../../.."
+
+dfir_plaso_input_dir: "{{ dfir_plaso_repo_root }}/data_store/raw/disk_images"
+dfir_plaso_vm_dir: "{{ dfir_plaso_repo_root }}/data_store/raw/VM_files"
+dfir_plaso_adx_out_dir: "{{ dfir_plaso_repo_root }}/data_store/processed/log2timeline"
+dfir_plaso_sofelk_out_dir: "{{ dfir_plaso_repo_root }}/data_store/processed/sofelk/log2timeline"
+# The custom psort output module lives in the repo (dev-scripts), mounted into psort.
+dfir_plaso_module: "{{ dfir_plaso_repo_root }}/dev-scripts/plaso/l2t_json_dfir.py"
+dfir_plaso_image: "log2timeline/plaso"
+# In-repo runs use PYTHONPATH; a deployed run installs the package instead.
+dfir_plaso_python_path: "{{ dfir_plaso_repo_root }}/python"
+dfir_plaso_force: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/argument_specs.yml
@@ -1,0 +1,52 @@
+---
+argument_specs:
+  main:
+    short_description: "disk images / VM exports -> enriched Plaso JSON Lines."
+    description:
+      - >-
+        Discovers forensic images under dfir_plaso_input_dir (content-first) and VM
+        exports under dfir_plaso_vm_dir, runs the Plaso two-step (log2timeline.py ->
+        .plaso, then psort with the custom l2t_json_dfir output module) per source,
+        and names each json_line output by the resolved image_hostname. Idempotent:
+        an image whose .plaso db and recorded output both exist is skipped.
+    options:
+      dfir_plaso_pipeline:
+        type: str
+        required: false
+        default: adx
+        choices: [adx, sofelk]
+        description: "Which backend to target; selects the output destination."
+      dfir_plaso_input_dir:
+        type: str
+        required: true
+        description: "Disk-image tree (E01/raw/img/dd/vmdk/vhd/vhdx/aff), recursed."
+      dfir_plaso_vm_dir:
+        type: str
+        required: false
+        description: "VMware VM export folders (one sub-folder per VM); optional."
+      dfir_plaso_adx_out_dir:
+        type: str
+        required: false
+        description: "ADX-path output dir (default data_store/processed/log2timeline)."
+      dfir_plaso_sofelk_out_dir:
+        type: str
+        required: false
+        description: "SOF-ELK-path output dir (its Logstash watch dir)."
+      dfir_plaso_module:
+        type: str
+        required: false
+        description: "Path to the l2t_json_dfir.py psort output module (dev-scripts/plaso)."
+      dfir_plaso_image:
+        type: str
+        required: false
+        default: "log2timeline/plaso"
+        description: "log2timeline/plaso container image."
+      dfir_plaso_python_path:
+        type: str
+        required: false
+        description: "PYTHONPATH to the get_sybers_dfir package (in-repo/dev runs)."
+      dfir_plaso_force:
+        type: bool
+        required: false
+        default: false
+        description: "Reprocess images that already have output."

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: dfir_plaso
+  namespace: get_sybers
+  author: Get-Sybers
+  description: >-
+    Process forensic disk images and VMware VM exports with Plaso (log2timeline +
+    psort) into enriched JSON Lines for the ADX or SOF-ELK pipeline. Invokes the
+    get_sybers_dfir.plaso Python processor; one <host>.jsonl per image plus the
+    durable .plaso storage db.
+  company: Get-Sybers
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions: [bookworm, trixie]
+  galaxy_tags: [dfir, plaso, log2timeline, disk, timeline]
+
+dependencies: []

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/converge.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: true
+  vars:
+    dfir_plaso_pipeline: adx
+    dfir_plaso_input_dir: /tmp/dfir_plaso_molecule/in
+    dfir_plaso_vm_dir: /tmp/dfir_plaso_molecule/vm
+    dfir_plaso_adx_out_dir: /tmp/dfir_plaso_molecule/out
+  tasks:
+    - name: "converge | run dfir_plaso (ADX)"
+      ansible.builtin.include_role:
+        name: dfir_plaso

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/molecule.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: default            # delegated — the role runs the Plaso container itself
+platforms:
+  - name: localhost
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      localhost:
+        ansible_connection: local
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+verifier:
+  name: ansible

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/prepare.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/prepare.yml
@@ -1,0 +1,37 @@
+---
+# A parseable forensic image is large/binary, so no fixture ships in-repo. Point
+# this at a small raw/E01 image to run the scenario:
+#   molecule test -- -e molecule_sample_image=/path/tiny.raw
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_in: /tmp/dfir_plaso_molecule/in
+    molecule_out: /tmp/dfir_plaso_molecule/out
+    molecule_sample_image: ""
+  tasks:
+    - name: "molecule-prepare | require a sample disk image"
+      ansible.builtin.assert:
+        that:
+          - molecule_sample_image | length > 0
+        fail_msg: >-
+          Provide -e molecule_sample_image=<path/to/raw-or-E01-image> (large/binary;
+          not shipped). It must contain a filesystem Plaso can parse into events.
+        quiet: true
+
+    - name: "molecule-prepare | start from a clean output dir"
+      ansible.builtin.file:
+        path: "{{ molecule_out }}"
+        state: absent
+
+    - name: "molecule-prepare | image input dir exists"
+      ansible.builtin.file:
+        path: "{{ molecule_in }}"
+        state: directory
+        mode: "0755"
+
+    - name: "molecule-prepare | stage the sample image"
+      ansible.builtin.copy:
+        src: "{{ molecule_sample_image }}"
+        dest: "{{ molecule_in }}/sample.raw"
+        mode: "0644"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/verify.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/molecule/default/verify.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_out: /tmp/dfir_plaso_molecule/out
+  tasks:
+    - name: "molecule-verify | find the produced enriched JSONL"
+      ansible.builtin.find:
+        paths: "{{ molecule_out }}/jsonl"
+        patterns: "*.jsonl"
+      register: produced
+
+    - name: "molecule-verify | find the durable .plaso storage db"
+      ansible.builtin.find:
+        paths: "{{ molecule_out }}/plaso"
+        patterns: "*.plaso"
+      register: dbs
+
+    - name: "molecule-verify | assert a timeline and its .plaso db exist"
+      ansible.builtin.assert:
+        that:
+          - produced.matched | int > 0
+          - dbs.matched | int > 0
+        fail_msg: "no <host>.jsonl and/or .plaso db produced from the sample image"
+        quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/adx.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/adx.yml
@@ -1,0 +1,26 @@
+---
+- name: "plaso-adx | process disk images / VM exports into Plaso JSONL"
+  ansible.builtin.command:
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.plaso', '--input-dir', dfir_plaso_input_dir, '--vm-dir', dfir_plaso_vm_dir, '--out-dir', dfir_plaso_adx_out_dir, '--module', dfir_plaso_module, '--image', dfir_plaso_image] + (['--force'] if dfir_plaso_force | bool else []) }}"
+  environment:
+    PYTHONPATH: "{{ dfir_plaso_python_path }}"
+  register: dfir_plaso_adx_run
+  changed_when: (dfir_plaso_adx_run.stdout | from_json).processed | int > 0
+
+- name: "plaso-adx | verify enriched JSONL on disk"
+  ansible.builtin.find:
+    paths: "{{ dfir_plaso_adx_out_dir }}/jsonl"
+    patterns: "*.jsonl"
+    recurse: false
+  register: dfir_plaso_adx_verify
+
+# Per-image failures (a weird image yielding 0 events) are tolerated by the shell;
+# the gate is "some timeline was produced, or there were no sources" — an ambiguous
+# VM descriptor is a warning, not a failure.
+- name: "plaso-adx | assert a timeline was produced for the sources present"
+  ansible.builtin.assert:
+    that:
+      - dfir_plaso_adx_verify.matched | int > 0 or ((dfir_plaso_adx_run.stdout | from_json).images | int + (dfir_plaso_adx_run.stdout | from_json).vms | int) == 0
+    fail_msg: >-
+      plaso produced no JSONL at all though disk images / VM exports were present.
+    quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/adx.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/adx.yml
@@ -20,7 +20,7 @@
 - name: "plaso-adx | assert a timeline was produced for the sources present"
   ansible.builtin.assert:
     that:
-      - dfir_plaso_adx_verify.matched | int > 0 or ((dfir_plaso_adx_run.stdout | from_json).images | int + (dfir_plaso_adx_run.stdout | from_json).vms | int) == 0
+      - dfir_plaso_adx_verify.matched | int > 0 or ((dfir_plaso_adx_run.stdout | from_json).processed | int + (dfir_plaso_adx_run.stdout | from_json).skipped | int) == 0
     fail_msg: >-
       plaso produced no JSONL at all though disk images / VM exports were present.
     quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# dfir_plaso: disk images / VM exports -> enriched Plaso JSONL. The role GROUPS; the
+# playbook DECIDES. Idempotence (skip images with a .plaso db + recorded output)
+# lives in the Python processor, not in a task's `when:`.
+
+- name: "plaso | assert inputs"
+  ansible.builtin.assert:
+    that:
+      - dfir_plaso_pipeline in ['adx', 'sofelk']
+      - dfir_plaso_input_dir | length > 0
+    fail_msg: >-
+      dfir_plaso needs dfir_plaso_pipeline (adx|sofelk) and a non-empty
+      dfir_plaso_input_dir.
+    quiet: true
+  tags: [always]
+
+# Fact-find + preconditions BEFORE any container runs or files are written.
+- name: "plaso | preflight"
+  ansible.builtin.include_tasks:
+    file: preflight.yml
+    apply:
+      tags: [always]
+  tags: [always]
+
+# Pipeline selection is a decision — it sits on the include, never on an action.
+- name: "plaso | ADX pipeline"
+  ansible.builtin.include_tasks: adx.yml
+  when: dfir_plaso_pipeline == 'adx'
+
+- name: "plaso | SOF-ELK pipeline"
+  ansible.builtin.include_tasks: sofelk.yml
+  when: dfir_plaso_pipeline == 'sofelk'

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/preflight.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/preflight.yml
@@ -1,0 +1,44 @@
+---
+# FIND FACTS -> check existence AND location -> (then adx/sofelk MODIFY + VERIFY).
+# dfir_plaso_vm_dir is optional (the processor tolerates its absence), so it is not
+# asserted here.
+
+- name: "plaso-preflight | docker daemon reachable"
+  ansible.builtin.command: docker version
+  register: dfir_plaso_docker
+  changed_when: false
+
+- name: "plaso-preflight | stat the disk-image input dir"
+  ansible.builtin.stat:
+    path: "{{ dfir_plaso_input_dir }}"
+  register: dfir_plaso_input_stat
+
+- name: "plaso-preflight | input dir exists and is a directory"
+  ansible.builtin.assert:
+    that:
+      - dfir_plaso_input_stat.stat.exists
+      - dfir_plaso_input_stat.stat.isdir is defined and dfir_plaso_input_stat.stat.isdir
+    fail_msg: >-
+      dfir_plaso_input_dir ({{ dfir_plaso_input_dir }}) is missing or is not a directory.
+    quiet: true
+
+- name: "plaso-preflight | stat the l2t_json_dfir output module"
+  ansible.builtin.stat:
+    path: "{{ dfir_plaso_module }}"
+  register: dfir_plaso_module_stat
+
+- name: "plaso-preflight | the output module file is present"
+  ansible.builtin.assert:
+    that:
+      - dfir_plaso_module_stat.stat.exists
+      - dfir_plaso_module_stat.stat.isreg is defined and dfir_plaso_module_stat.stat.isreg
+    fail_msg: >-
+      l2t_json_dfir output module not found at {{ dfir_plaso_module }}.
+    quiet: true
+
+- name: "plaso-preflight | the get_sybers_dfir.plaso module imports"
+  ansible.builtin.command: python3 -c "import get_sybers_dfir.plaso"
+  environment:
+    PYTHONPATH: "{{ dfir_plaso_python_path }}"
+  register: dfir_plaso_import
+  changed_when: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/sofelk.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/sofelk.yml
@@ -1,0 +1,25 @@
+---
+# SOF-ELK ingests Plaso json_line natively; the processing is identical, only the
+# destination differs. Delivery INTO SOF-ELK's watch dir is tracked in #45.
+- name: "plaso-sofelk | process disk images / VM exports into Plaso JSONL"
+  ansible.builtin.command:
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.plaso', '--input-dir', dfir_plaso_input_dir, '--vm-dir', dfir_plaso_vm_dir, '--out-dir', dfir_plaso_sofelk_out_dir, '--module', dfir_plaso_module, '--image', dfir_plaso_image] + (['--force'] if dfir_plaso_force | bool else []) }}"
+  environment:
+    PYTHONPATH: "{{ dfir_plaso_python_path }}"
+  register: dfir_plaso_sofelk_run
+  changed_when: (dfir_plaso_sofelk_run.stdout | from_json).processed | int > 0
+
+- name: "plaso-sofelk | verify enriched JSONL on disk"
+  ansible.builtin.find:
+    paths: "{{ dfir_plaso_sofelk_out_dir }}/jsonl"
+    patterns: "*.jsonl"
+    recurse: false
+  register: dfir_plaso_sofelk_verify
+
+- name: "plaso-sofelk | assert a timeline was produced for the sources present"
+  ansible.builtin.assert:
+    that:
+      - dfir_plaso_sofelk_verify.matched | int > 0 or ((dfir_plaso_sofelk_run.stdout | from_json).images | int + (dfir_plaso_sofelk_run.stdout | from_json).vms | int) == 0
+    fail_msg: >-
+      plaso produced no JSONL at all though disk images / VM exports were present.
+    quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/sofelk.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/tasks/sofelk.yml
@@ -19,7 +19,7 @@
 - name: "plaso-sofelk | assert a timeline was produced for the sources present"
   ansible.builtin.assert:
     that:
-      - dfir_plaso_sofelk_verify.matched | int > 0 or ((dfir_plaso_sofelk_run.stdout | from_json).images | int + (dfir_plaso_sofelk_run.stdout | from_json).vms | int) == 0
+      - dfir_plaso_sofelk_verify.matched | int > 0 or ((dfir_plaso_sofelk_run.stdout | from_json).processed | int + (dfir_plaso_sofelk_run.stdout | from_json).skipped | int) == 0
     fail_msg: >-
       plaso produced no JSONL at all though disk images / VM exports were present.
     quiet: true

--- a/python/get_sybers_dfir/plaso.py
+++ b/python/get_sybers_dfir/plaso.py
@@ -192,7 +192,7 @@ def get_vm_descriptor(vm_dir: str) -> tuple[str | None, str]:
             continue
         if not is_vmdk_descriptor(f):
             continue
-        if re.search(r"-[0-9]{6}\.vmdk$", name):
+        if re.search(r"-[0-9]{6}\.vmdk$", low):
             snapshot.append(f)
         else:
             base.append(f)

--- a/python/get_sybers_dfir/plaso.py
+++ b/python/get_sybers_dfir/plaso.py
@@ -1,0 +1,426 @@
+"""Plaso processor — disk images / VM exports -> enriched Plaso JSON Lines.
+
+Faithful port of the retired ``process-log2timeline-Dynamic.sh``. For each forensic
+image (and each VMware VM export) it runs the Plaso two-step in the
+``log2timeline/plaso`` container:
+
+  1. ``log2timeline.py`` parses the image into a durable ``.plaso`` storage db (kept
+     so an analyst can re-run psort later without re-parsing the image).
+  2. ``psort.py -o l2t_json_dfir`` renders the db to json_line with the repo's
+     custom output module (dev-scripts/plaso/l2t_json_dfir.py), which adds
+     image_hostname / username / disk_id / volume_id to EVERY event.
+  3. the output is named by the resolved image_hostname (the box's own name), not
+     the image filename.
+
+Discovery is content-first: each file is identified by MAGIC BYTES (EWF/EWF2, VMDK,
+VHD/VHDX, QCOW2), with the extension used only as a fallback (raw/dd/img/aff carry
+no signature). Raw VMDK extents and EWF continuation segments are never processed on
+their own. VM exports pick the right ``.vmdk`` descriptor (latest snapshot, else the
+single base).
+
+Idempotent: an image whose ``.plaso`` db AND recorded json_line output both exist is
+skipped (a ``.host`` marker records the resolved output name, so a prior failed
+psort is NOT mistaken for done). Emits a machine-readable summary as JSON on stdout
+for an honest ``changed_when`` (``processed > 0``).
+
+    python -m get_sybers_dfir.plaso --input-dir RAW/disk_images --vm-dir RAW/VM_files \
+        --out-dir PROCESSED/log2timeline --module dev-scripts/plaso/l2t_json_dfir.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+_IMAGE = "log2timeline/plaso"
+
+# psort wrapper: import the custom output module (so psort discovers it), then run
+# psort with our argv. The two paths are passed as argv — never spliced into source.
+_PSORT_WRAPPER = (
+    "import importlib.util, sys\n"
+    "spec = importlib.util.spec_from_file_location('l2t_json_dfir', '/opt/l2t_json_dfir.py')\n"
+    "mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)\n"
+    "from plaso.scripts.psort import Main\n"
+    "sys.argv = ['psort.py', '--status_view', 'none', '-o', 'l2t_json_dfir',\n"
+    "            '--output_fallback_hostname', '-w', sys.argv[1], sys.argv[2]]\n"
+    "sys.exit(Main())\n"
+)
+
+_DESCRIPTOR_HEADER = b"# Disk DescriptorFile"
+
+
+def _ensure_writable(path: str) -> None:
+    """Create a dir and make it container-writable. The plaso container runs as a
+    non-root UID and writes the .plaso db and json_line INTO the mounted output, so
+    the dir must be world-writable (the retired shell did `chmod -R 777` for the same
+    Docker UID-mismatch reason — see docs/scripts/Scripts-Overview.md)."""
+    os.makedirs(path, exist_ok=True)
+    try:
+        os.chmod(path, 0o777)
+    except OSError:
+        pass
+
+
+# ---- content-first format detection ----------------------------------------
+def _first8_hex(path: str) -> str:
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(8).hex()
+    except OSError:
+        return ""
+
+
+def detect_format(path: str) -> str:
+    """Identify a file by content -> ewf1|ewf-cont|ewf2|vmdk|vhd|vhdx|qcow2|"".
+
+    Reads only a few header bytes (and a VHD's 512-byte footer) — cheap on multi-GB
+    images. RAW/dd/img and AFF carry no reliable signature (handled by ext_format).
+    """
+    if not os.path.isfile(path):
+        return ""
+    h = _first8_hex(path)
+    if h == "455646090d0aff00":            # "EVF\x09\x0d\x0a\xff\x00" — EWF
+        # segment number: uint16 LE at offset 9; only segment 1 heads the set.
+        try:
+            with open(path, "rb") as fh:
+                fh.seek(9)
+                seg = fh.read(2)
+            segno = seg[0] + (seg[1] << 8) if len(seg) == 2 else 0
+        except OSError:
+            segno = 0
+        return "ewf1" if segno == 1 else "ewf-cont"
+    if h == "455646320d0a8100":            # "EVF2\x0d\x0a\x81\x00"
+        return "ewf2"
+    if h.startswith("4b444d56"):           # "KDMV" monolithic sparse VMDK
+        return "vmdk"
+    if h.startswith("514649fb"):           # "QFI\xfb"
+        return "qcow2"
+    if h == "7668647866696c65":            # "vhdxfile"
+        return "vhdx"
+    if h == "636f6e6563746978":            # "conectix" (dynamic VHD header)
+        return "vhd"
+    # VMDK text descriptor (points at -flat/-sNNN extents in the same dir).
+    try:
+        with open(path, "rb") as fh:
+            if fh.read(64).startswith(b"# Disk DescriptorFile"):
+                return "vmdk"
+    except OSError:
+        pass
+    # A fixed-format VHD carries "conectix" only in its 512-byte footer.
+    try:
+        size = os.path.getsize(path)
+        if size >= 512:
+            with open(path, "rb") as fh:
+                fh.seek(size - 512)
+                if fh.read(8).hex() == "636f6e6563746978":
+                    return "vhd"
+    except OSError:
+        pass
+    return ""
+
+
+def ext_format(name: str) -> str:
+    """Format implied by the extension (fallback path).
+
+    -> ewf1|ewf-cont|vmdk|vmdk-extent|vhd|vhdx|aff|raw|"". 'vmdk-extent' flags a raw
+    VMDK extent and 'ewf-cont' an EWF continuation — neither processed on its own.
+    """
+    n = os.path.basename(name).lower()
+    if re.search(r"-flat\.vmdk$|-delta\.vmdk$|-s[0-9]+\.vmdk$", n):
+        return "vmdk-extent"
+    if n.endswith(".e01"):
+        return "ewf1"
+    if re.search(r"\.e[0-9][0-9]$", n):
+        return "ewf-cont"
+    if n.endswith(".vmdk"):
+        return "vmdk"
+    if n.endswith(".vhd"):
+        return "vhd"
+    if n.endswith(".vhdx"):
+        return "vhdx"
+    if n.endswith(".aff"):
+        return "aff"
+    if n.endswith((".raw", ".img", ".dd")):
+        return "raw"
+    return ""
+
+
+def get_clean_filename(rel: str) -> str:
+    """Collision-free output base name from a path RELATIVE to the input dir:
+    fold subdir separators + spaces, and keep the format in the name
+    ("name.ext" -> "name_ext") so same-stem images in different formats don't collide."""
+    rel = rel.replace("/", "_").replace(" ", "_")
+    if "." in rel:
+        stem, ext = rel.rsplit(".", 1)
+        rel = f"{stem}_{ext}"
+    return rel
+
+
+def is_vmdk_descriptor(path: str) -> bool:
+    """A real VMDK descriptor is a small text file whose first line is
+    '# Disk DescriptorFile'. The -flat/-delta/-sNNN raw extents are binary."""
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(64).startswith(_DESCRIPTOR_HEADER)
+    except OSError:
+        return False
+
+
+def get_vm_descriptor(vm_dir: str) -> tuple[str | None, str]:
+    """Pick the .vmdk descriptor for a VM folder.
+
+    Returns (path, status): status is 'ok' (path set), 'ambiguous' (multiple base
+    descriptors, no snapshot), or 'none' (no usable descriptor). The latest snapshot
+    descriptor wins (it chains back to the base); else the single base descriptor.
+    """
+    snapshot, base = [], []
+    try:
+        names = sorted(os.listdir(vm_dir))
+    except OSError:
+        return None, "none"
+    for name in names:
+        if not name.lower().endswith(".vmdk"):
+            continue
+        f = os.path.join(vm_dir, name)
+        if not os.path.isfile(f):
+            continue
+        low = name.lower()
+        if low.endswith("-flat.vmdk") or low.endswith("-delta.vmdk") or re.search(r"-s[0-9]+\.vmdk$", low):
+            continue
+        if not is_vmdk_descriptor(f):
+            continue
+        if re.search(r"-[0-9]{6}\.vmdk$", name):
+            snapshot.append(f)
+        else:
+            base.append(f)
+    if snapshot:
+        return sorted(snapshot)[-1], "ok"
+    if len(base) == 1:
+        return base[0], "ok"
+    if len(base) > 1:
+        return None, "ambiguous"
+    return None, "none"
+
+
+# ---- discovery -------------------------------------------------------------
+def discover_images(input_dir: str) -> list[dict]:
+    """Every processable image under input_dir (content-first), each as
+    {path, rel, format, by}. Skips vmdk-extents and ewf-continuation segments."""
+    picks: list[dict] = []
+    for root, _dirs, files in os.walk(input_dir):
+        for name in sorted(files):
+            path = os.path.join(root, name)
+            rel = os.path.relpath(path, input_dir)
+            efmt = ext_format(path)
+            if efmt == "vmdk-extent":
+                continue
+            cfmt = detect_format(path)
+            if cfmt:
+                fmt, by = cfmt, "content"
+            else:
+                fmt, by = efmt, "extension"
+            if fmt in ("", "vmdk-extent", "ewf-cont"):
+                continue
+            picks.append({"path": path, "rel": rel, "format": fmt, "by": by})
+    # stable order, de-dup by path
+    seen, out = set(), []
+    for p in sorted(picks, key=lambda d: d["rel"]):
+        if p["path"] in seen:
+            continue
+        seen.add(p["path"])
+        out.append(p)
+    return out
+
+
+def discover_vms(vm_dir: str) -> list[str]:
+    """Immediate sub-folders of vm_dir (one VM export each), sorted."""
+    if not os.path.isdir(vm_dir):
+        return []
+    return sorted(
+        os.path.join(vm_dir, d) for d in os.listdir(vm_dir)
+        if os.path.isdir(os.path.join(vm_dir, d))
+    )
+
+
+# ---- the Plaso two-step ----------------------------------------------------
+def _sanitize_host(value: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9._-]", "_", value or "")
+    return value.strip("_")
+
+
+def _resolved_host(raw_path: str) -> str:
+    """image_hostname the module put on the events (constant across the file)."""
+    try:
+        with open(raw_path, encoding="utf-8", errors="replace") as fh:
+            first = fh.readline()
+        return _sanitize_host((json.loads(first).get("image_hostname") or "").strip())
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return ""
+
+
+def _marker(out_dir: str, name: str) -> str:
+    return os.path.join(out_dir, "plaso", f"{name}.host")
+
+
+def _already_done(out_dir: str, name: str) -> bool:
+    """Done iff the .plaso db, the .host marker, and the recorded json_line all exist
+    (so a prior FAILED psort — db present, no marker — is not mistaken for done)."""
+    plaso_db = os.path.join(out_dir, "plaso", f"{name}.plaso")
+    marker = _marker(out_dir, name)
+    if not (os.path.isfile(plaso_db) and os.path.getsize(plaso_db) > 0 and os.path.isfile(marker)):
+        return False
+    try:
+        with open(marker, encoding="utf-8") as fh:
+            jsonl = fh.read().strip()
+    except OSError:
+        return False
+    return bool(jsonl) and os.path.isfile(os.path.join(out_dir, "jsonl", jsonl))
+
+
+def run_plaso(mount_dir, src_rel, name, out_dir, module_path, image=_IMAGE) -> dict:
+    """Parse one source into a .plaso db, render it to <host>.jsonl. Returns a result
+    dict {source, output, host, ok, error?}."""
+    plaso_dir = os.path.join(out_dir, "plaso")
+    jsonl_dir = os.path.join(out_dir, "jsonl")
+    logs_dir = os.path.join(out_dir, "logs")
+    _ensure_writable(out_dir)
+    for d in (plaso_dir, jsonl_dir, logs_dir):
+        _ensure_writable(d)
+    plaso_db = os.path.join(plaso_dir, f"{name}.plaso")
+    raw = os.path.join(jsonl_dir, f".{name}.raw")
+    log = os.path.join(logs_dir, f"{name}.log")
+
+    with open(log, "w") as logfh:
+        # 1) parse image -> .plaso
+        subprocess.run(
+            [
+                "docker", "run", "--rm",
+                "-v", f"{os.path.realpath(mount_dir)}:/data:ro",
+                "-v", f"{os.path.realpath(out_dir)}:/output",
+                image,
+                "log2timeline.py", "--status_view", "none", "--partitions", "all",
+                "--vss-stores", "all",
+                "--storage-file", f"/output/plaso/{name}.plaso", f"/data/{src_rel}",
+            ],
+            stdout=logfh, stderr=subprocess.STDOUT, check=False,
+        )
+    if not (os.path.isfile(plaso_db) and os.path.getsize(plaso_db) > 0):
+        return {"source": src_rel, "ok": False, "error": "log2timeline produced no .plaso"}
+
+    with open(log, "a") as logfh:
+        # 2) render .plaso -> json_line via the custom output module
+        subprocess.run(
+            [
+                "docker", "run", "--rm",
+                "-v", f"{os.path.realpath(out_dir)}:/output",
+                "-v", f"{os.path.realpath(module_path)}:/opt/l2t_json_dfir.py:ro",
+                "--entrypoint", "python3", image,
+                "-c", _PSORT_WRAPPER,
+                f"/output/jsonl/.{name}.raw", f"/output/plaso/{name}.plaso",
+            ],
+            stdout=logfh, stderr=subprocess.STDOUT, check=False,
+        )
+    if not (os.path.isfile(raw) and os.path.getsize(raw) > 0):
+        if os.path.exists(raw):
+            os.remove(raw)
+        return {"source": src_rel, "ok": False, "error": "psort produced no json_line (0 events?)"}
+
+    # name by the resolved image_hostname; keep distinct output on collision.
+    host = _resolved_host(raw) or name
+    final = os.path.join(jsonl_dir, f"{host}.jsonl")
+    if os.path.exists(final):
+        final = os.path.join(jsonl_dir, f"{host}_{name}.jsonl")
+    os.replace(raw, final)
+    with open(_marker(out_dir, name), "w") as fh:
+        fh.write(os.path.basename(final))
+    return {"source": src_rel, "ok": True, "host": host, "output": os.path.basename(final)}
+
+
+def process(input_dir, vm_dir, out_dir, module_path, image=_IMAGE, force=False) -> dict:
+    """Process every image under input_dir and every VM export under vm_dir."""
+    input_dir = os.path.realpath(input_dir)
+    vm_dir = os.path.realpath(vm_dir) if vm_dir else ""
+    out_dir = os.path.realpath(out_dir)
+    _ensure_writable(out_dir)
+    for sub in ("plaso", "jsonl", "logs"):
+        _ensure_writable(os.path.join(out_dir, sub))
+
+    images = discover_images(input_dir) if os.path.isdir(input_dir) else []
+    vms = discover_vms(vm_dir) if vm_dir else []
+
+    processed = skipped = failed = warnings = 0
+    results = []
+
+    for img in images:
+        name = get_clean_filename(img["rel"])
+        if not force and _already_done(out_dir, name):
+            skipped += 1
+            continue
+        res = run_plaso(input_dir, img["rel"], name, out_dir, module_path, image)
+        if res["ok"]:
+            processed += 1
+        else:
+            failed += 1
+        results.append(res)
+
+    for vm in vms:
+        vm_name = os.path.basename(vm)
+        descriptor, status = get_vm_descriptor(vm)
+        if status != "ok":
+            # A missing/ambiguous descriptor is a config warning (the shell skips
+            # with a message), NOT a processing failure — don't fail the run on it.
+            warnings += 1
+            results.append({"source": vm_name, "ok": False, "warning": f"vmdk descriptor {status}"})
+            continue
+        if not force and _already_done(out_dir, vm_name):
+            skipped += 1
+            continue
+        res = run_plaso(vm, os.path.basename(descriptor), vm_name, out_dir, module_path, image)
+        if res["ok"]:
+            processed += 1
+        else:
+            failed += 1
+        results.append(res)
+
+    return {
+        "tool": "plaso",
+        "input_dir": input_dir,
+        "vm_dir": vm_dir,
+        "out_dir": out_dir,
+        "images": len(images),
+        "vms": len(vms),
+        "processed": processed,
+        "skipped": skipped,
+        "failed": failed,
+        "warnings": warnings,
+        "results": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="get_sybers_dfir.plaso",
+        description="disk images / VM exports -> enriched Plaso JSON Lines",
+    )
+    ap.add_argument("--input-dir", required=True, help="disk-image tree (E01/raw/vmdk/vhd/...)")
+    ap.add_argument("--vm-dir", default="", help="VMware VM exports (one folder per VM)")
+    ap.add_argument("--out-dir", required=True, help="output dir (jsonl/, plaso/, logs/ created within)")
+    ap.add_argument("--module", required=True, help="path to the l2t_json_dfir.py output module")
+    ap.add_argument("--image", default=_IMAGE, help="log2timeline/plaso container image")
+    ap.add_argument("--force", action="store_true", help="reprocess images that already have output")
+    args = ap.parse_args(argv)
+
+    summary = process(
+        args.input_dir, args.vm_dir, args.out_dir, args.module,
+        image=args.image, force=args.force,
+    )
+    json.dump(summary, sys.stdout)
+    sys.stdout.write("\n")
+    return 1 if summary["failed"] and not summary["processed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tests/test_plaso.py
+++ b/python/tests/test_plaso.py
@@ -1,0 +1,146 @@
+"""Unit tests for the pure logic of the plaso processor (no docker needed)."""
+import os
+
+from get_sybers_dfir import plaso
+
+
+# ---- content-first format detection ----------------------------------------
+def _w(p, b):
+    p.write_bytes(b)
+    return str(p)
+
+
+def test_detect_ewf_segment1_vs_continuation(tmp_path):
+    head = b"\x45\x56\x46\x09\x0d\x0a\xff\x00"  # "EVF\x09\x0d\x0a\xff\x00"
+    seg1 = _w(tmp_path / "a.E01", head + b"\x00" + b"\x01\x00")
+    segN = _w(tmp_path / "a.E02", head + b"\x00" + b"\x02\x00")
+    assert plaso.detect_format(seg1) == "ewf1"
+    assert plaso.detect_format(segN) == "ewf-cont"
+
+
+def test_detect_ewf2_vmdk_qcow_vhdx_vhd(tmp_path):
+    assert plaso.detect_format(_w(tmp_path / "x", b"\x45\x56\x46\x32\x0d\x0a\x81\x00")) == "ewf2"
+    assert plaso.detect_format(_w(tmp_path / "k", b"KDMV____")) == "vmdk"
+    assert plaso.detect_format(_w(tmp_path / "q", b"QFI\xfb___")) == "qcow2"
+    assert plaso.detect_format(_w(tmp_path / "h", b"vhdxfile")) == "vhdx"
+    assert plaso.detect_format(_w(tmp_path / "v", b"conectix")) == "vhd"
+
+
+def test_detect_vmdk_text_descriptor(tmp_path):
+    assert plaso.detect_format(_w(tmp_path / "d.vmdk", b"# Disk DescriptorFile\nversion=1\n")) == "vmdk"
+
+
+def test_detect_vhd_footer_only(tmp_path):
+    # header is NOT conectix; last 512 bytes START with conectix (fixed-format VHD).
+    body = b"\x00" * 88 + b"conectix" + b"\x00" * (512 - 8)
+    assert plaso.detect_format(_w(tmp_path / "fixed.vhd", body)) == "vhd"
+
+
+def test_detect_raw_has_no_signature(tmp_path):
+    assert plaso.detect_format(_w(tmp_path / "r.dd", b"\x00" * 32)) == ""
+
+
+# ---- extension fallback ----------------------------------------------------
+def test_ext_format():
+    assert plaso.ext_format("base-flat.vmdk") == "vmdk-extent"
+    assert plaso.ext_format("d-s001.vmdk") == "vmdk-extent"
+    assert plaso.ext_format("img.E01") == "ewf1"
+    assert plaso.ext_format("img.E02") == "ewf-cont"
+    assert plaso.ext_format("d.vmdk") == "vmdk"
+    assert plaso.ext_format("d.VHD") == "vhd"
+    assert plaso.ext_format("d.vhdx") == "vhdx"
+    assert plaso.ext_format("d.aff") == "aff"
+    assert plaso.ext_format("d.dd") == "raw"
+    assert plaso.ext_format("readme.txt") == ""
+
+
+def test_get_clean_filename():
+    assert plaso.get_clean_filename("src/img.E01") == "src_img_E01"
+    assert plaso.get_clean_filename("a b.raw") == "a_b_raw"
+
+
+# ---- VM descriptor selection ----------------------------------------------
+def test_is_vmdk_descriptor(tmp_path):
+    good = _w(tmp_path / "b.vmdk", b"# Disk DescriptorFile\nCID=1\n")
+    bad = _w(tmp_path / "b-flat.vmdk", b"\x00" * 64)
+    assert plaso.is_vmdk_descriptor(good) is True
+    assert plaso.is_vmdk_descriptor(bad) is False
+
+
+def test_get_vm_descriptor_base_only(tmp_path):
+    _w(tmp_path / "vm.vmdk", b"# Disk DescriptorFile\n")
+    _w(tmp_path / "vm-flat.vmdk", b"\x00" * 32)   # raw extent, ignored
+    path, status = plaso.get_vm_descriptor(str(tmp_path))
+    assert status == "ok" and os.path.basename(path) == "vm.vmdk"
+
+
+def test_get_vm_descriptor_latest_snapshot_wins(tmp_path):
+    _w(tmp_path / "vm.vmdk", b"# Disk DescriptorFile\n")
+    _w(tmp_path / "vm-000001.vmdk", b"# Disk DescriptorFile\n")
+    _w(tmp_path / "vm-000002.vmdk", b"# Disk DescriptorFile\n")
+    path, status = plaso.get_vm_descriptor(str(tmp_path))
+    assert status == "ok" and os.path.basename(path) == "vm-000002.vmdk"
+
+
+def test_get_vm_descriptor_ambiguous(tmp_path):
+    _w(tmp_path / "one.vmdk", b"# Disk DescriptorFile\n")
+    _w(tmp_path / "two.vmdk", b"# Disk DescriptorFile\n")
+    path, status = plaso.get_vm_descriptor(str(tmp_path))
+    assert path is None and status == "ambiguous"
+
+
+def test_get_vm_descriptor_none(tmp_path):
+    _w(tmp_path / "vm-flat.vmdk", b"\x00" * 32)
+    path, status = plaso.get_vm_descriptor(str(tmp_path))
+    assert path is None and status == "none"
+
+
+# ---- discovery -------------------------------------------------------------
+def test_discover_images_skips_extents_and_segments(tmp_path):
+    head = b"\x45\x56\x46\x09\x0d\x0a\xff\x00"
+    _w(tmp_path / "case1.E01", head + b"\x00\x01\x00")       # ewf1 (content) -> keep
+    _w(tmp_path / "case1.E02", head + b"\x00\x02\x00")       # ewf-cont -> skip
+    _w(tmp_path / "raw.dd", b"\x00" * 16)                    # raw (ext) -> keep
+    _w(tmp_path / "vm-flat.vmdk", b"\x00" * 16)              # vmdk-extent -> skip
+    _w(tmp_path / "notes.txt", b"hello")                     # junk -> skip
+    got = {(d["rel"], d["format"]) for d in plaso.discover_images(str(tmp_path))}
+    assert ("case1.E01", "ewf1") in got
+    assert ("raw.dd", "raw") in got
+    assert all(rel != "case1.E02" for rel, _ in got)
+    assert all(rel != "vm-flat.vmdk" for rel, _ in got)
+    assert len(got) == 2
+
+
+def test_discover_vms(tmp_path):
+    (tmp_path / "VM-A").mkdir()
+    (tmp_path / "VM-B").mkdir()
+    (tmp_path / "loose.txt").write_bytes(b"x")
+    got = [os.path.basename(p) for p in plaso.discover_vms(str(tmp_path))]
+    assert got == ["VM-A", "VM-B"]
+
+
+# ---- idempotence marker ----------------------------------------------------
+def test_already_done_requires_db_marker_and_jsonl(tmp_path):
+    out = tmp_path
+    (out / "plaso").mkdir()
+    (out / "jsonl").mkdir()
+    (out / "plaso" / "case_E01.plaso").write_bytes(b"PLASO")
+    # db present but no marker -> a prior failed psort, NOT done
+    assert plaso._already_done(str(out), "case_E01") is False
+    # marker + jsonl present -> done
+    (out / "jsonl" / "HOST.jsonl").write_text('{"a":1}\n')
+    (out / "plaso" / "case_E01.host").write_text("HOST.jsonl")
+    assert plaso._already_done(str(out), "case_E01") is True
+    # marker points at a missing jsonl -> not done
+    (out / "plaso" / "case_E01.host").write_text("GONE.jsonl")
+    assert plaso._already_done(str(out), "case_E01") is False
+
+
+def test_sanitize_host():
+    assert plaso._sanitize_host("DESKTOP-ABC 1!") == "DESKTOP-ABC_1"
+    assert plaso._sanitize_host("__weird__") == "weird"
+
+
+def test_process_no_inputs_is_clean(tmp_path):
+    s = plaso.process(str(tmp_path / "in"), "", str(tmp_path / "out"), "module.py")
+    assert s["images"] == 0 and s["vms"] == 0 and s["processed"] == 0 and s["failed"] == 0


### PR DESCRIPTION
Slice of epic #46 — the Plaso lane as **Python** + an **Ansible role**, same shape as the `dfir_zeek` exemplar, conforming to the Get-Sybers standards. The most involved port (content-first image detection, VM descriptor selection, the Plaso two-step).

- `python/get_sybers_dfir/plaso.py` — magic-byte format detection (EWF/EWF2/VMDK/VHD/VHDX/QCOW2 incl. the VHD-footer path; extension fallback for raw/dd/img/aff), skips VMDK extents + EWF continuations, VM descriptor selection (latest snapshot / single base / ambiguous→warning). `log2timeline.py` → `.plaso`, then `psort -o l2t_json_dfir` with the custom output module; output named by resolved `image_hostname`. **Robust idempotence**: `.plaso` db + `.host` marker + recorded json_line must all exist (a prior *failed* psort isn't mistaken for done). Unit-tested (17 tests).
- `dfir_plaso` role: one action per task, `--pipeline adx|sofelk` on the include; preflight (docker; stat input dir + output module → assert; python import); **tolerant** verify gate (some timeline, or no sources) since per-image 0-event failures are non-fatal, and ambiguous VM descriptors are warnings.
- **Fix caught by the live run:** make the mounted output dirs container-writable (`chmod 777`) — the plaso container runs as a non-root UID and writes into the mount, exactly as the retired shell did.

**Validated:** rule-8 gate PASSES; unit tests pass (17); **end-to-end against a real ext2 fixture image** (built with mke2fs/debugfs, no mount) — processor `processed=1` then `skipped=1` (idempotent); role converge `changed=1` → converge-again `changed=0` → verify asserts the `<host>.jsonl` (8 enriched events) and the `.plaso` db.

Branched off `dev` (has zeek/velociraptor/volatility/evtx). Targets `dev`. Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)