### PR TITLE
collection: cross-role consistency sweep (argument_specs required flags; volatility sofelk assert)

### DIFF
--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
@@ -17,7 +17,7 @@ argument_specs:
         description: "Which backend to target; selects the output destination."
       dfir_evtx_evtx_dir:
         type: str
-        required: true
+        required: false
         description: "Directory tree of .evtx logs to parse (recursed)."
       dfir_evtx_adx_out_dir:
         type: str
@@ -29,7 +29,7 @@ argument_specs:
         description: "SOF-ELK-path output dir (its Logstash watch dir)."
       dfir_evtx_evtxecmd_dir:
         type: str
-        required: true
+        required: false
         description: "Operator-supplied EvtxECmd .NET release dir (must hold EvtxECmd.dll)."
       dfir_evtx_dotnet_image:
         type: str

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/argument_specs.yml
@@ -18,7 +18,7 @@ argument_specs:
         description: "Which backend to target; selects the output destination."
       dfir_plaso_input_dir:
         type: str
-        required: true
+        required: false
         description: "Disk-image tree (E01/raw/img/dd/vmdk/vhd/vhdx/aff), recursed."
       dfir_plaso_vm_dir:
         type: str

--- a/ansible/collections/get_sybers.dfir/roles/dfir_velociraptor/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_velociraptor/meta/argument_specs.yml
@@ -17,7 +17,7 @@ argument_specs:
         description: "Which backend to target; selects the output destination."
       dfir_velociraptor_raw_dir:
         type: str
-        required: true
+        required: false
         description: "Directory of Velociraptor offline-collector <collection>.zip files."
       dfir_velociraptor_adx_out_dir:
         type: str

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/argument_specs.yml
@@ -18,7 +18,7 @@ argument_specs:
         description: "Which backend to target; selects the output destination."
       dfir_volatility_memory_dir:
         type: str
-        required: true
+        required: false
         description: "Directory tree of memory images to process (recursed)."
       dfir_volatility_adx_out_dir:
         type: str

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/sofelk.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/tasks/sofelk.yml
@@ -15,3 +15,14 @@
     patterns: "*.jsonl"
     recurse: true
   register: dfir_volatility_sofelk_verify
+
+# Per-plugin failures are NORMAL (Windows plugins error without symbols), so the
+# gate is "some plugin produced output, or there were no images" — not failed==0.
+- name: "volatility-sofelk | assert output was produced for the images present"
+  ansible.builtin.assert:
+    that:
+      - dfir_volatility_sofelk_verify.matched | int > 0 or (dfir_volatility_sofelk_run.stdout | from_json).images | int == 0
+    fail_msg: >-
+      volatility produced no JSONL at all though memory images were present (symbols
+      unavailable for every plugin?).
+    quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_zeek/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_zeek/meta/argument_specs.yml
@@ -16,7 +16,7 @@ argument_specs:
         description: "Which backend to target; selects the output destination."
       dfir_zeek_pcap_dir:
         type: str
-        required: true
+        required: false
         description: "Directory tree of packet captures to process (recursed)."
       dfir_zeek_adx_out_dir:
         type: str


### PR DESCRIPTION
Post-completion **sweep across all six roles** now that zeek/velociraptor/evtx/volatility/plaso/signatures are all merged into `dev`.

## Fixes
- **argument_specs `required` flags** — flipped the input-dir options from `required: true` to `required: false` in every role. Each has a default in `defaults/main.yml` (the roles run zero-config against the repo's `data_store`), so `required: true` was contradictory and a no-op (Ansible applies the default before validation). The spec now matches behaviour; the role's own `assert (… | length > 0)` still guards an explicitly-empty value.
- **`dfir_volatility` sofelk assert** — added the verify assert the ADX path and the other five roles' sofelk paths already have (the registered `find` was otherwise unused), with the same tolerant gate ("some output, or no images") since per-plugin failures are normal without symbols.

## Swept clean (no change needed)
rule-8 gate PASSES on all task files · **55 unit tests pass** · every role structurally complete (same file set) + a playbook each · every default var documented in its README · FQCN throughout · collection builds with `ansible-galaxy collection build` · no conflict markers / stray index files.

Verified the flip is safe with a live velociraptor converge (argument-spec validation auto-runs and passes; converge `changed=1`, verify green).

Targets `dev`.