### PR TITLE
dfir CLI: Typer front-end (process / ingest / deploy / validate)

### DIFF
--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -25,11 +25,11 @@ as a single action. Roles land per source as epic #46 retires the matching
 Ingest and deploy roles (`dfir_ingest_*`, `dfir_deploy_*`) follow as later slices of #46.
 
 ## Usage
-The **`dfir` CLI** (Python package `get_sybers_dfir`) is the front-end — it drives
+The **`dxdfir` CLI** (Python package `get_sybers_dfir`) is the front-end — it drives
 these roles for you:
 ```bash
-dfir process zeek --pipeline adx        # = the dfir_zeek role, preflight → process → verify
-dfir process signatures                 # all lanes
+dxdfir process zeek --pipeline adx      # = the dfir_zeek role, preflight → process → verify
+dxdfir process signatures               # all lanes
 ```
 Or run a playbook directly; each source has one under `playbooks/`, which selects
 the role and passes the pipeline:

--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -25,8 +25,14 @@ as a single action. Roles land per source as epic #46 retires the matching
 Ingest and deploy roles (`dfir_ingest_*`, `dfir_deploy_*`) follow as later slices of #46.
 
 ## Usage
-Each source has a playbook under `playbooks/`; the playbook selects the role and
-passes the pipeline.
+The **`dfir` CLI** (Python package `get_sybers_dfir`) is the front-end — it drives
+these roles for you:
+```bash
+dfir process zeek --pipeline adx        # = the dfir_zeek role, preflight → process → verify
+dfir process signatures                 # all lanes
+```
+Or run a playbook directly; each source has one under `playbooks/`, which selects
+the role and passes the pipeline:
 ```bash
 ansible-playbook playbooks/dfir-process-zeek.yml -e dfir_zeek_pipeline=adx
 ansible-playbook playbooks/dfir-process-velociraptor.yml -e dfir_velociraptor_pipeline=adx

--- a/python/README.md
+++ b/python/README.md
@@ -18,14 +18,15 @@ python -m get_sybers_dfir.signatures  --output-dir PROCESSED/signatures --repo-r
 Every processor prints a machine-readable JSON summary (`processed`/`skipped`/
 `failed`/…) so its role can set an honest `changed_when`.
 
-## The `dfir` CLI
+## The `dxdfir` CLI
 ```bash
-dfir process zeek --pipeline adx        # drive the dfir_zeek role (preflight → process → verify)
-dfir process signatures -e dfir_signatures_lanes='["yara"]'
-dfir ingest --only zeek                 # load processed output into the ADX emulator
-dfir deploy                             # stand up + schema-load the emulator
-dfir validate                           # run the check harness
-dfir list                               # list processable sources
+dxdfir process zeek --pipeline adx      # drive the dfir_zeek role (preflight → process → verify)
+dxdfir process signatures -e dfir_signatures_lanes='["yara"]'
+dxdfir ingest --only zeek               # load processed output into the ADX emulator
+dxdfir deploy                           # stand up + schema-load the emulator
+dxdfir validate                         # run the check harness
+dxdfir list                             # list processable sources
+man dxdfir                              # the manual (man/dxdfir.1)
 ```
 `process` drives the collection with `ansible-playbook` (the role's one action calls
 the matching `python -m get_sybers_dfir.<source>` for the tight loop). `ingest` /
@@ -35,10 +36,12 @@ in later #46 slices. The repo is auto-detected (or pass `--repo-root` /
 
 ## Install
 ```bash
-pip install ./python          # provides the `dfir` entry point + the package
+pip install ./python          # provides the `dxdfir` entry point + the package
+install -Dm644 man/dxdfir.1 ~/.local/share/man/man1/dxdfir.1   # optional: man page
 ```
 In-repo runs need no install — set `PYTHONPATH=python` (the roles do this via
-`dfir_<source>_python_path`).
+`dfir_<source>_python_path`). Without installing the man page, read it directly with
+`man ./python/man/dxdfir.1`.
 
 ## Test
 ```bash

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,46 @@
+# get_sybers_dfir
+
+The processing logic of the DX_DFIR pipeline as an importable, unit-tested Python
+package, plus the **`dfir`** command-line front-end (Typer) — the top layer of epic
+#46. The heavy per-item work (container runs, JSON reshaping) lives here; the
+`get_sybers.dfir` Ansible collection orchestrates it one action per task.
+
+## Processors
+Each source is a module runnable standalone or through its role:
+```bash
+python -m get_sybers_dfir.zeek        --pcap-dir RAW/pcaps --out-dir PROCESSED/zeek
+python -m get_sybers_dfir.velociraptor --raw-dir RAW/velociraptor --out-dir PROCESSED/velociraptor
+python -m get_sybers_dfir.evtx        --evtx-dir RAW/WinEvt --out-dir PROCESSED/windows_logs --evtxecmd-dir DEPS/evtxecmd
+python -m get_sybers_dfir.volatility  --memory-dir RAW/memory --out-dir PROCESSED/volatility --symbols-dir DEPS/symbols --renderer … --plugins-dir …
+python -m get_sybers_dfir.plaso       --input-dir RAW/disk_images --out-dir PROCESSED/log2timeline --module dev-scripts/plaso/l2t_json_dfir.py
+python -m get_sybers_dfir.signatures  --output-dir PROCESSED/signatures --repo-root .
+```
+Every processor prints a machine-readable JSON summary (`processed`/`skipped`/
+`failed`/…) so its role can set an honest `changed_when`.
+
+## The `dfir` CLI
+```bash
+dfir process zeek --pipeline adx        # drive the dfir_zeek role (preflight → process → verify)
+dfir process signatures -e dfir_signatures_lanes='["yara"]'
+dfir ingest --only zeek                 # load processed output into the ADX emulator
+dfir deploy                             # stand up + schema-load the emulator
+dfir validate                           # run the check harness
+dfir list                               # list processable sources
+```
+`process` drives the collection with `ansible-playbook` (the role's one action calls
+the matching `python -m get_sybers_dfir.<source>` for the tight loop). `ingest` /
+`deploy` / `validate` currently front the repo's shell scripts — they become roles
+in later #46 slices. The repo is auto-detected (or pass `--repo-root` /
+`$DFIR_REPO_ROOT`).
+
+## Install
+```bash
+pip install ./python          # provides the `dfir` entry point + the package
+```
+In-repo runs need no install — set `PYTHONPATH=python` (the roles do this via
+`dfir_<source>_python_path`).
+
+## Test
+```bash
+cd python && PYTHONPATH=. python -m pytest        # 64 unit tests (pure logic; no docker)
+```

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -1,0 +1,210 @@
+"""``dfir`` — the DX_DFIR pipeline front-end (Typer).
+
+The three layers of epic #46 meet here: this CLI holds the user-facing verbs, the
+``get_sybers.dfir`` Ansible collection holds the orchestration (one role per source,
+one action per task), and the ``get_sybers_dfir`` package holds the heavy per-item
+processing the roles invoke.
+
+    dfir process zeek --pipeline adx     # drive the dfir_zeek role
+    dfir ingest --only zeek              # load processed output into the ADX emulator
+    dfir deploy                          # stand up + schema-load the emulator
+    dfir validate                        # run the check harness
+
+``process`` drives the collection with ``ansible-playbook`` (preflight → process →
+verify); the role's single action calls ``python -m get_sybers_dfir.<source>`` for
+the tight loop. ``ingest`` / ``deploy`` / ``validate`` currently front the repo's
+shell scripts — they become roles in later #46 slices.
+"""
+from __future__ import annotations
+
+import enum
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import typer
+
+from . import __version__
+
+app = typer.Typer(
+    help="DX_DFIR forensic pipeline front-end (process / ingest / deploy / validate).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+_COLLECTION = "ansible/collections/get_sybers.dfir"
+
+
+class Source(str, enum.Enum):
+    zeek = "zeek"
+    velociraptor = "velociraptor"
+    evtx = "evtx"
+    volatility = "volatility"
+    plaso = "plaso"
+    signatures = "signatures"
+
+
+class Pipeline(str, enum.Enum):
+    adx = "adx"
+    sofelk = "sofelk"
+
+
+# --------------------------------------------------------------------------- helpers
+def _repo_root(explicit: Path | None) -> Path:
+    """Locate the DX_DFIR repo: --repo-root, then $DFIR_REPO_ROOT, then walk up from
+    cwd, then the installed package's in-repo location. Must hold the collection."""
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(explicit)
+    if os.environ.get("DFIR_REPO_ROOT"):
+        candidates.append(Path(os.environ["DFIR_REPO_ROOT"]))
+    cur = Path.cwd()
+    candidates.extend([cur, *cur.parents])
+    # get_sybers_dfir/cli.py -> get_sybers_dfir -> python -> <repo>
+    candidates.append(Path(__file__).resolve().parents[2])
+    for c in candidates:
+        if (c / _COLLECTION).is_dir():
+            return c.resolve()
+    typer.secho(
+        "Could not locate the DX_DFIR repo (no ansible/collections/get_sybers.dfir "
+        "found). Pass --repo-root or set $DFIR_REPO_ROOT.",
+        fg=typer.colors.RED, err=True,
+    )
+    raise typer.Exit(2)
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None, env: dict | None = None) -> None:
+    """Echo and run a command; exit non-zero on failure (fail loud)."""
+    typer.secho("→ " + " ".join(cmd), fg=typer.colors.BRIGHT_BLACK)
+    full_env = {**os.environ, **(env or {})}
+    rc = subprocess.call(cmd, cwd=str(cwd) if cwd else None, env=full_env)
+    if rc != 0:
+        typer.secho(f"command failed (exit {rc}): {cmd[0]}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(rc)
+
+
+def _need(tool: str) -> None:
+    if shutil.which(tool) is None:
+        typer.secho(f"required tool not on PATH: {tool}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(127)
+
+
+def _script(repo: Path, name: str) -> str:
+    p = repo / "scripts" / name
+    if not p.is_file():
+        typer.secho(f"script not found: {p}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    return str(p)
+
+
+# --------------------------------------------------------------------------- commands
+@app.command()
+def process(
+    source: Source = typer.Argument(..., help="Which evidence source to process."),
+    pipeline: Pipeline = typer.Option(Pipeline.adx, "--pipeline", "-p", help="Backend to target."),
+    force: bool = typer.Option(False, "--force", help="Reprocess inputs that already have output."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+    extra_var: list[str] = typer.Option(
+        None, "--extra-var", "-e", help="Extra Ansible var KEY=VALUE (repeatable)."
+    ),
+) -> None:
+    """Process one evidence source by driving its role (preflight → process → verify)."""
+    _need("ansible-playbook")
+    repo = _repo_root(repo_root)
+    name = source.value
+    playbook = repo / _COLLECTION / "playbooks" / f"dfir-process-{name}.yml"
+    if not playbook.is_file():
+        typer.secho(f"no playbook for source '{name}': {playbook}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    cmd = [
+        "ansible-playbook", "-i", "localhost,", "-c", "local", str(playbook),
+        "-e", f"dfir_{name}_pipeline={pipeline.value}",
+        "-e", f"dfir_{name}_force={'true' if force else 'false'}",
+    ]
+    for kv in extra_var or []:
+        cmd += ["-e", kv]
+    # resolve the role without installing the collection
+    env = {"ANSIBLE_ROLES_PATH": str(repo / _COLLECTION / "roles")}
+    typer.secho(f"processing {name} → {pipeline.value}", fg=typer.colors.GREEN)
+    _run(cmd, cwd=repo, env=env)
+
+
+@app.command()
+def ingest(
+    only: str = typer.Option(None, "--only", help="Load one source: l2t|zeek|evtx|volatility|velociraptor."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Load processed output into the ADX (Kusto) emulator (fronts ingest-kusto.sh)."""
+    _need("bash")
+    repo = _repo_root(repo_root)
+    cmd = ["bash", _script(repo, "ingest-kusto.sh")]
+    if only:
+        cmd += ["--only", only]
+    _run(cmd, cwd=repo)
+
+
+@app.command()
+def deploy(
+    persist: bool = typer.Option(False, "--persist", help="Persist emulator data (opt-in)."),
+    port: int = typer.Option(None, "--port", help="Emulator port override."),
+    schema: bool = typer.Option(True, "--schema/--no-schema", help="Apply the schema after deploy."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Deploy the ADX (Kusto) emulator and (by default) apply the schema.
+
+    ⚠️ deploy-kusto.sh accepts Microsoft's EULA on your behalf; the emulator has no
+    auth and is localhost-only by default.
+    """
+    _need("bash")
+    repo = _repo_root(repo_root)
+    deploy_cmd = ["bash", _script(repo, "deploy-kusto.sh")]
+    if persist:
+        deploy_cmd.append("--persist")
+    if port is not None:
+        deploy_cmd += ["--port", str(port)]
+    _run(deploy_cmd, cwd=repo)
+    if schema:
+        _run(["bash", _script(repo, "apply-kusto-schema.sh")], cwd=repo)
+
+
+@app.command()
+def validate(
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Run the repository check harness (fronts tests/run-checks.sh)."""
+    _need("bash")
+    repo = _repo_root(repo_root)
+    checks = repo / "tests" / "run-checks.sh"
+    if not checks.is_file():
+        typer.secho(f"check harness not found: {checks}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    _run(["bash", str(checks)], cwd=repo)
+
+
+@app.command(name="list")
+def list_sources() -> None:
+    """List the evidence sources the CLI can process."""
+    typer.echo("Evidence sources (dfir process <source>):")
+    for s in Source:
+        typer.echo(f"  {s.value}")
+
+
+def _version_cb(value: bool) -> None:
+    if value:
+        typer.echo(f"dfir (get_sybers_dfir) {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False, "--version", callback=_version_cb, is_eager=True, help="Show version and exit."
+    ),
+) -> None:
+    """DX_DFIR forensic processing pipeline — process evidence, then deploy/ingest/validate."""
+
+
+if __name__ == "__main__":
+    app()

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -5,10 +5,10 @@ The three layers of epic #46 meet here: this CLI holds the user-facing verbs, th
 one action per task), and the ``get_sybers_dfir`` package holds the heavy per-item
 processing the roles invoke.
 
-    dfir process zeek --pipeline adx     # drive the dfir_zeek role
-    dfir ingest --only zeek              # load processed output into the ADX emulator
-    dfir deploy                          # stand up + schema-load the emulator
-    dfir validate                        # run the check harness
+    dxdfir process zeek --pipeline adx   # drive the dfir_zeek role
+    dxdfir ingest --only zeek            # load processed output into the ADX emulator
+    dxdfir deploy                        # stand up + schema-load the emulator
+    dxdfir validate                      # run the check harness
 
 ``process`` drives the collection with ``ansible-playbook`` (preflight → process →
 verify); the role's single action calls ``python -m get_sybers_dfir.<source>`` for
@@ -186,14 +186,14 @@ def validate(
 @app.command(name="list")
 def list_sources() -> None:
     """List the evidence sources the CLI can process."""
-    typer.echo("Evidence sources (dfir process <source>):")
+    typer.echo("Evidence sources (dxdfir process <source>):")
     for s in Source:
         typer.echo(f"  {s.value}")
 
 
 def _version_cb(value: bool) -> None:
     if value:
-        typer.echo(f"dfir (get_sybers_dfir) {__version__}")
+        typer.echo(f"dxdfir (get_sybers_dfir) {__version__}")
         raise typer.Exit()
 
 

--- a/python/man/dxdfir.1
+++ b/python/man/dxdfir.1
@@ -1,0 +1,186 @@
+.TH DXDFIR 1 "2026-08-15" "get_sybers_dfir 0.1.0" "DX_DFIR Manual"
+.SH NAME
+dxdfir \- DX_DFIR forensic processing pipeline front-end
+.SH SYNOPSIS
+.B dxdfir
+.RI [ --version ]
+.I COMMAND
+.RI [ ARGS ...]
+.br
+.B dxdfir process
+.I SOURCE
+.RB [ --pipeline
+.IR adx | sofelk ]
+.RB [ --force ]
+.RB [ --repo-root
+.IR PATH ]
+.RB [ --extra-var
+.IR KEY=VALUE ]...
+.br
+.B dxdfir ingest
+.RB [ --only
+.IR SOURCE ]
+.br
+.B dxdfir deploy
+.RB [ --persist ]
+.RB [ --port
+.IR PORT ]
+.RB [ --no-schema ]
+.br
+.B dxdfir validate
+.br
+.B dxdfir list
+.SH DESCRIPTION
+.B dxdfir
+is the user-facing front-end of the DX_DFIR pipeline \(em an offline,
+container-based digital-forensics workflow that turns raw evidence (packet
+captures, disk images, memory, Windows event logs, Velociraptor collections) into
+normalised JSON and detection events for the analysis backend.
+.PP
+It is the top of a three-layer design: this command holds the verbs, the
+.B get_sybers.dfir
+Ansible collection holds the orchestration (one role per source, one action per
+task), and the
+.B get_sybers_dfir
+Python package holds the heavy per-item processing the roles invoke.
+.PP
+.B dxdfir process
+drives a source's role with
+.BR ansible-playbook (1)
+\(em preflight, then process, then verify \(em and the role's single action calls
+.RB \(lq python \-m get_sybers_dfir. SOURCE \(rq
+for the tight loop.
+.B ingest ,
+.B deploy
+and
+.B validate
+currently front the repository's shell scripts; they become roles in later slices
+of epic #46.
+.SH COMMANDS
+.TP
+.BI "process " SOURCE
+Process one evidence source. \fISOURCE\fR is one of
+.BR zeek ", " velociraptor ", " evtx ", " volatility ", " plaso ", " signatures .
+Idempotent: inputs that already have output are skipped (use
+.B --force
+to reprocess).
+.TP
+.B ingest
+Load processed output into the ADX (Kusto) emulator (fronts
+.IR ingest-kusto.sh ).
+.TP
+.B deploy
+Deploy the ADX (Kusto) emulator and, by default, apply the schema (fronts
+.I deploy-kusto.sh
+and
+.IR apply-kusto-schema.sh ).
+.TP
+.B validate
+Run the repository check harness (fronts
+.IR tests/run-checks.sh ).
+.TP
+.B list
+List the evidence sources
+.B process
+accepts.
+.SH OPTIONS
+.SS Global
+.TP
+.B --version
+Print the version and exit.
+.TP
+.B --help
+Show help for the command and exit.
+.SS process
+.TP
+.BR --pipeline ", " -p " " \fIadx\fR|\fIsofelk\fR
+Backend to target; selects the output destination. Default:
+.BR adx .
+.TP
+.B --force
+Reprocess inputs that already have output.
+.TP
+.BI --repo-root " PATH"
+DX_DFIR repository root. Auto-detected otherwise (see
+.BR ENVIRONMENT ).
+.TP
+.BR --extra-var ", " -e " " \fIKEY=VALUE\fR
+Pass an extra Ansible variable through to the role; repeatable. Use it to override
+a role default, e.g.
+.RB \(lq -e\  dfir_zeek_pcap_dir=/evidence/pcaps \(rq
+or
+.RB \(lq -e\  dfir_signatures_lanes=[\(dqyara\(dq] \(rq.
+.SS deploy
+.TP
+.B --persist
+Persist the emulator's data (opt-in; it is ephemeral by default).
+.TP
+.BI --port " PORT"
+Emulator port override.
+.TP
+.BR --schema " / " --no-schema
+Apply (default) or skip the schema after deploying.
+.SS ingest
+.TP
+.BI --only " SOURCE"
+Load one source only:
+.BR l2t ", " zeek ", " evtx ", " volatility ", " velociraptor .
+.SH ENVIRONMENT
+.TP
+.B DFIR_REPO_ROOT
+Repository root, used when
+.B --repo-root
+is not given. If neither is set, the repo is found by walking up from the current
+directory, then from the installed package's location.
+.TP
+.B ANSIBLE_ROLES_PATH
+Set by
+.B process
+to the collection's roles directory so the roles resolve without installing the
+collection.
+.SH EXIT STATUS
+.B dxdfir
+exits
+.B 0
+on success and propagates the exit status of the underlying
+.BR ansible-playbook (1)
+run or script on failure;
+.B 2
+for a usage/lookup error (e.g. the repo or a playbook could not be found) and
+.B 127
+if a required tool is not on
+.BR PATH .
+.SH EXAMPLES
+.TP
+Process packet captures for the ADX backend:
+.B dxdfir process zeek --pipeline adx
+.TP
+Reprocess memory images, overriding the input directory:
+.B dxdfir process volatility --force -e dfir_volatility_memory_dir=/evidence/mem
+.TP
+Run only the YARA signature lane:
+.B dxdfir process signatures -e dfir_signatures_lanes=[\(dqyara\(dq]
+.TP
+Stand up the emulator, then load Zeek output:
+.B dxdfir deploy && dxdfir ingest --only zeek
+.SH FILES
+.TP
+.I ansible/collections/get_sybers.dfir/
+The Ansible collection driven by
+.BR "dxdfir process" .
+.TP
+.I python/get_sybers_dfir/
+The processing package (also runnable as
+.RB \(lq python\ -m\ get_sybers_dfir. SOURCE \(rq).
+.TP
+.I data_store/
+Raw evidence and processed output (gitignored).
+.SH SEE ALSO
+.BR ansible-playbook (1),
+.BR docker (1).
+The processors run standalone as
+.RB \(lq python\ -m\ get_sybers_dfir. SOURCE \ --help\(rq.
+.SH AUTHOR
+Get-Sybers.
+.SH LICENSE
+MIT.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "get-sybers-dfir"
 version = "0.1.0"
-description = "DX_DFIR forensic processing package (zeek, velociraptor, evtx, volatility, plaso, signatures) + dfir CLI"
+description = "DX_DFIR forensic processing package (zeek, velociraptor, evtx, volatility, plaso, signatures) + dxdfir CLI"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
@@ -13,9 +13,9 @@ dependencies = [
 ]
 
 [project.scripts]
-# `dfir` front-end (Typer). The processors also run standalone via
+# `dxdfir` front-end (Typer). The processors also run standalone via
 # `python -m get_sybers_dfir.<source>`.
-dfir = "get_sybers_dfir.cli:app"
+dxdfir = "get_sybers_dfir.cli:app"
 
 [tool.setuptools.packages.find]
 include = ["get_sybers_dfir*"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,12 +5,17 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "get-sybers-dfir"
 version = "0.1.0"
-description = "DX_DFIR forensic processing package (zeek, plaso, volatility, evtx, signatures) + CLI"
+description = "DX_DFIR forensic processing package (zeek, velociraptor, evtx, volatility, plaso, signatures) + dfir CLI"
 requires-python = ">=3.10"
 license = { text = "MIT" }
+dependencies = [
+    "typer>=0.12",
+]
 
 [project.scripts]
-# CLI (Typer) is a later child issue (#46); processors run via `python -m get_sybers_dfir.<source>` today.
+# `dfir` front-end (Typer). The processors also run standalone via
+# `python -m get_sybers_dfir.<source>`.
+dfir = "get_sybers_dfir.cli:app"
 
 [tool.setuptools.packages.find]
 include = ["get_sybers_dfir*"]

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,105 @@
+"""Unit tests for the dfir CLI (Typer CliRunner; subprocess mocked)."""
+import os
+from pathlib import Path
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from get_sybers_dfir import cli
+
+runner = CliRunner()
+_COLLECTION = "ansible/collections/get_sybers.dfir"
+
+
+def _fake_repo(tmp_path: Path) -> Path:
+    """A minimal repo tree the CLI can discover + drive."""
+    (tmp_path / _COLLECTION / "playbooks").mkdir(parents=True)
+    (tmp_path / _COLLECTION / "roles").mkdir(parents=True)
+    for src in ("zeek", "velociraptor"):
+        (tmp_path / _COLLECTION / "playbooks" / f"dfir-process-{src}.yml").write_text("---\n")
+    (tmp_path / "scripts").mkdir()
+    for s in ("ingest-kusto.sh", "deploy-kusto.sh", "apply-kusto-schema.sh"):
+        (tmp_path / "scripts" / s).write_text("#!/bin/bash\n")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "run-checks.sh").write_text("#!/bin/bash\n")
+    return tmp_path
+
+
+def test_version():
+    r = runner.invoke(cli.app, ["--version"])
+    assert r.exit_code == 0
+    assert "0.1.0" in r.stdout
+
+
+def test_list_shows_all_sources():
+    r = runner.invoke(cli.app, ["list"])
+    assert r.exit_code == 0
+    for src in ("zeek", "velociraptor", "evtx", "volatility", "plaso", "signatures"):
+        assert src in r.stdout
+
+
+def test_repo_root_explicit(tmp_path):
+    repo = _fake_repo(tmp_path)
+    assert cli._repo_root(repo) == repo.resolve()
+
+
+def test_process_builds_playbook_command(tmp_path):
+    repo = _fake_repo(tmp_path)
+    with mock.patch.object(cli.subprocess, "call", return_value=0) as m, \
+            mock.patch.object(cli.shutil, "which", return_value="/usr/bin/ansible-playbook"):
+        r = runner.invoke(cli.app, [
+            "process", "zeek", "--pipeline", "adx", "--force",
+            "--repo-root", str(repo), "-e", "dfir_zeek_pcap_dir=/x",
+        ])
+    assert r.exit_code == 0, r.stdout
+    cmd = m.call_args.args[0]
+    assert cmd[0] == "ansible-playbook"
+    assert str(repo / _COLLECTION / "playbooks" / "dfir-process-zeek.yml") in cmd
+    assert "dfir_zeek_pipeline=adx" in cmd
+    assert "dfir_zeek_force=true" in cmd
+    assert "dfir_zeek_pcap_dir=/x" in cmd
+    # role path is exported so the collection resolves without install
+    env = m.call_args.kwargs["env"]
+    assert env["ANSIBLE_ROLES_PATH"] == str(repo / _COLLECTION / "roles")
+
+
+def test_process_unknown_source_rejected(tmp_path):
+    repo = _fake_repo(tmp_path)
+    r = runner.invoke(cli.app, ["process", "bogus", "--repo-root", str(repo)])
+    assert r.exit_code != 0
+
+
+def test_ingest_builds_script_command(tmp_path):
+    repo = _fake_repo(tmp_path)
+    with mock.patch.object(cli.subprocess, "call", return_value=0) as m:
+        r = runner.invoke(cli.app, ["ingest", "--only", "zeek", "--repo-root", str(repo)])
+    assert r.exit_code == 0, r.stdout
+    cmd = m.call_args.args[0]
+    assert cmd[0] == "bash"
+    assert cmd[1].endswith("scripts/ingest-kusto.sh")
+    assert cmd[-2:] == ["--only", "zeek"]
+
+
+def test_deploy_runs_deploy_then_schema(tmp_path):
+    repo = _fake_repo(tmp_path)
+    with mock.patch.object(cli.subprocess, "call", return_value=0) as m:
+        r = runner.invoke(cli.app, ["deploy", "--repo-root", str(repo)])
+    assert r.exit_code == 0, r.stdout
+    ran = [c.args[0][1] for c in m.call_args_list]   # the script path arg
+    assert any(p.endswith("deploy-kusto.sh") for p in ran)
+    assert any(p.endswith("apply-kusto-schema.sh") for p in ran)
+
+
+def test_deploy_no_schema_skips_apply(tmp_path):
+    repo = _fake_repo(tmp_path)
+    with mock.patch.object(cli.subprocess, "call", return_value=0) as m:
+        runner.invoke(cli.app, ["deploy", "--no-schema", "--repo-root", str(repo)])
+    ran = [c.args[0][1] for c in m.call_args_list]
+    assert not any(p.endswith("apply-kusto-schema.sh") for p in ran)
+
+
+def test_failing_command_propagates_exit_code(tmp_path):
+    repo = _fake_repo(tmp_path)
+    with mock.patch.object(cli.subprocess, "call", return_value=3):
+        r = runner.invoke(cli.app, ["ingest", "--repo-root", str(repo)])
+    assert r.exit_code == 3


### PR DESCRIPTION
The top layer of epic #46 — the user-facing **`dfir`** command, completing the three-layer split (CLI verbs → `get_sybers.dfir` collection orchestration → `get_sybers_dfir` package).

## Commands
- **`dfir process <source> [--pipeline adx|sofelk] [--force] [-e KEY=VAL]`** — drives the matching role via `ansible-playbook` (preflight → process → verify); the role's single action calls `python -m get_sybers_dfir.<source>` for the tight loop. Sources: zeek, velociraptor, evtx, volatility, plaso, signatures.
- **`dfir ingest [--only …]` / `dfir deploy [--persist/--port/--no-schema]` / `dfir validate`** — front the existing ingest/deploy/check scripts (they become roles in later #46 slices).
- `dfir list`, `dfir --version`.
- Repo auto-detection (`--repo-root` / `$DFIR_REPO_ROOT` / walk-up / package location); the collection resolves without install via `ANSIBLE_ROLES_PATH`; fails loud on non-zero child exit.
- `pyproject` declares the `dfir` entry point + `typer` dependency; `python/README.md` documents it.

## Validated
9 CLI unit tests (Typer `CliRunner`, subprocess mocked — command building, repo discovery, exit-code propagation, deploy schema toggle); **full suite now 64 tests, 0 failed**. Live: **`dfir process velociraptor` drove the real role end-to-end** (ok=12, changed=1 → artefact JSON on disk; idempotent re-run changed=0); help/version/list render.

Targets `dev`. Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)