### PR TITLE
dfir_ingest_adx: load processed data into the ADX emulator (Python + role)

### DIFF
--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -22,7 +22,9 @@ as a single action. Roles land per source as epic #46 retires the matching
 | `dfir_plaso` | Disk images / VM exports → Plaso JSONL | `get_sybers_dfir.plaso` |
 | `dfir_signatures` | YARA / Suricata / Hayabusa detections | `get_sybers_dfir.signatures` |
 
-Ingest and deploy roles (`dfir_ingest_*`, `dfir_deploy_*`) follow as later slices of #46.
+Loading: **`dfir_ingest_adx`** (processed → ADX emulator, idempotent via an in-DB
+ledger) is in. `dfir_ingest_sofelk` and the `dfir_deploy_*` roles follow as later
+slices of #46.
 
 ## Usage
 The **`dxdfir` CLI** (Python package `get_sybers_dfir`) is the front-end — it drives

--- a/ansible/collections/get_sybers.dfir/playbooks/dfir-ingest-adx.yml
+++ b/ansible/collections/get_sybers.dfir/playbooks/dfir-ingest-adx.yml
@@ -1,0 +1,10 @@
+---
+# The playbook holds the decisions; the role groups, the tasks act.
+- name: "DFIR | load processed data into the ADX emulator"
+  hosts: "{{ dfir_hosts | default('localhost') }}"
+  connection: "{{ dfir_connection | default('local') }}"
+  gather_facts: true
+  tasks:
+    - name: "dfir-ingest-adx | run the ingest role"
+      ansible.builtin.include_role:
+        name: dfir_ingest_adx

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/README.md
@@ -1,0 +1,48 @@
+# dfir_ingest_adx
+
+Load **`data_store/processed`** into the **ADX (Kusto) emulator**. The role is
+structure only — it asserts inputs, runs a preflight (docker, the processed dir, the
+module, **and that the emulator engine is reachable**), then invokes the
+`get_sybers_dfir.ingest` Python loader as a **single action**. This is the ADX
+ingest path; the SOF-ELK ingest is a separate role.
+
+Each source's files are shaped with their constant columns (see the loader), copied
+INTO the emulator container (it reads from its own filesystem), and batch-ingested;
+Plaso l2t fans one json_line file out into per-parser `L2t<Parser>` tables.
+
+## Role variables
+| Variable | Default | Description |
+|---|---|---|
+| `dfir_ingest_adx_processed_dir` | `<repo>/data_store/processed` | Tree to load. |
+| `dfir_ingest_adx_only` | `""` (all) | Load one source: `l2t`, `zeek`, `evtx`, `volatility`, `velociraptor`. |
+| `dfir_ingest_adx_kusto_host` | `127.0.0.1` | Emulator host. |
+| `dfir_ingest_adx_kusto_port` | `8080` | Emulator port. |
+| `dfir_ingest_adx_kusto_container` | `kusto-emulator` | Emulator container (files are docker-cp'd into it). |
+| `dfir_ingest_adx_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
+| `dfir_ingest_adx_force` | `false` | Re-ingest files already in the ledger (additive — duplicates rows). |
+| `dfir_ingest_adx_dry_run` | `false` | List what would be loaded; contact nothing. |
+
+## Idempotence
+The shell ingest was additive (no fishbucket) — re-running duplicated rows. This
+loader keeps an in-DB **ledger** (`host._DfirIngestLedger`) of the sha1 of every file
+loaded, and skips files already recorded unless `dfir_ingest_adx_force` is set. The
+ledger lives in the (ephemeral) database, so a redeploy wipes the ledger and the data
+together — they never drift. A first run loads new files (`changed=true`); an
+immediate re-run loads nothing (`changed=false`).
+
+## Prerequisite
+A deployed, schema-loaded emulator — `dxdfir deploy` (or `deploy-kusto.sh` +
+`apply-kusto-schema.sh`). The preflight fails clearly if the engine is unreachable.
+
+## Example
+```bash
+dxdfir ingest                       # = this role, all sources
+dxdfir ingest --only zeek
+ansible-playbook playbooks/dfir-ingest-adx.yml -e dfir_ingest_adx_only=volatility
+```
+
+## Testing
+Python unit tests cover the pure logic (Kusto failure detection, record shaping,
+staged-name safety, l2t split). The **Molecule** scenario needs a running emulator:
+it stages a probe artefact, converges (loads it), converges again asserting zero
+changes (ledger idempotence), and verifies the probe row is queryable.

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# Repo root is five levels up from this role
+# (roles/dfir_ingest_adx -> get_sybers.dfir -> collections -> ansible -> repo).
+dfir_ingest_adx_repo_root: "{{ role_path }}/../../../../.."
+
+dfir_ingest_adx_processed_dir: "{{ dfir_ingest_adx_repo_root }}/data_store/processed"
+# Which source to load; empty = all (l2t, zeek, evtx, volatility, velociraptor).
+dfir_ingest_adx_only: ""
+# The ADX (Kusto) emulator endpoint + container (files are docker-cp'd into it).
+dfir_ingest_adx_kusto_host: "127.0.0.1"
+dfir_ingest_adx_kusto_port: 8080
+dfir_ingest_adx_kusto_container: "kusto-emulator"
+# In-repo runs use PYTHONPATH; a deployed run installs the package instead.
+dfir_ingest_adx_python_path: "{{ dfir_ingest_adx_repo_root }}/python"
+# Re-ingest files already recorded in the in-DB ledger (additive — duplicates rows).
+dfir_ingest_adx_force: false
+# List what would be loaded; contact nothing.
+dfir_ingest_adx_dry_run: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/meta/argument_specs.yml
@@ -1,0 +1,51 @@
+---
+argument_specs:
+  main:
+    short_description: "Load data_store/processed into the ADX (Kusto) emulator."
+    description:
+      - >-
+        Loads each processed source into its Kusto table (files are shaped with their
+        constant columns and copied into the emulator container, then batch-ingested;
+        Plaso l2t fans one json_line file out into per-parser L2t<Parser> tables).
+        Idempotent: an in-DB ledger records every loaded file, so a re-run loads only
+        new files unless dfir_ingest_adx_force is set. Requires a deployed emulator.
+    options:
+      dfir_ingest_adx_processed_dir:
+        type: str
+        required: false
+        description: "data_store/processed tree to load."
+      dfir_ingest_adx_only:
+        type: str
+        required: false
+        default: ""
+        choices: ["", l2t, zeek, evtx, volatility, velociraptor]
+        description: "Load one source only; empty = all."
+      dfir_ingest_adx_kusto_host:
+        type: str
+        required: false
+        default: "127.0.0.1"
+        description: "Emulator host."
+      dfir_ingest_adx_kusto_port:
+        type: int
+        required: false
+        default: 8080
+        description: "Emulator port."
+      dfir_ingest_adx_kusto_container:
+        type: str
+        required: false
+        default: "kusto-emulator"
+        description: "Emulator container name (files are docker-cp'd into it)."
+      dfir_ingest_adx_python_path:
+        type: str
+        required: false
+        description: "PYTHONPATH to the get_sybers_dfir package (in-repo/dev runs)."
+      dfir_ingest_adx_force:
+        type: bool
+        required: false
+        default: false
+        description: "Re-ingest files already in the ledger (additive; duplicates rows)."
+      dfir_ingest_adx_dry_run:
+        type: bool
+        required: false
+        default: false
+        description: "List what would be loaded; contact nothing."

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/meta/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: dfir_ingest_adx
+  namespace: get_sybers
+  author: Get-Sybers
+  description: >-
+    Load data_store/processed into the ADX (Kusto) emulator. Invokes the
+    get_sybers_dfir.ingest Python loader; idempotent via an in-DB ledger of loaded
+    files. The ADX ingest path; SOF-ELK ingest is a separate role.
+  company: Get-Sybers
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions: [bookworm, trixie]
+  galaxy_tags: [dfir, ingest, kusto, adx]
+
+dependencies: []

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/converge.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/converge.yml
@@ -1,0 +1,12 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: true
+  vars:
+    dfir_ingest_adx_processed_dir: /tmp/dfir_ingest_adx_molecule/processed
+    dfir_ingest_adx_only: velociraptor
+    dfir_ingest_adx_python_path: "{{ (playbook_dir + '/../../../../../../../python') | realpath }}"
+  tasks:
+    - name: "converge | run dfir_ingest_adx"
+      ansible.builtin.include_role:
+        name: dfir_ingest_adx

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/molecule.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: default            # delegated — the role talks to the running emulator
+platforms:
+  - name: localhost
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      localhost:
+        ansible_connection: local
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+verifier:
+  name: ansible

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/prepare.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Needs a deployed emulator (`dxdfir deploy`) with the schema applied. Stages a tiny
+# processed/velociraptor fixture so the converge has something to load.
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_processed: /tmp/dfir_ingest_adx_molecule/processed
+  tasks:
+    - name: "molecule-prepare | require a reachable emulator"
+      ansible.builtin.command:
+        argv: [python3, -m, get_sybers_dfir.ingest, --ping]
+      environment:
+        PYTHONPATH: "{{ (playbook_dir + '/../../../../../../../python') | realpath }}"
+      register: ping
+      changed_when: false
+      failed_when: ping.rc != 0
+
+    - name: "molecule-prepare | processed/velociraptor fixture dir"
+      ansible.builtin.file:
+        path: "{{ molecule_processed }}/velociraptor/HOSTMOL"
+        state: directory
+        mode: "0755"
+
+    - name: "molecule-prepare | a distinctive artefact record"
+      ansible.builtin.copy:
+        dest: "{{ molecule_processed }}/velociraptor/HOSTMOL/Molecule.Probe.json"
+        content: |
+          {"Marker":"DFIR_INGEST_MOLECULE","Key":"HKLM\\probe","Val":7}
+        mode: "0644"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/verify.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/molecule/default/verify.yml
@@ -1,0 +1,25 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  vars:
+    dfir_ingest_adx_python_path: "{{ (playbook_dir + '/../../../../../../../python') | realpath }}"
+  tasks:
+    - name: "molecule-verify | query the emulator for the loaded probe record"
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:8080/v1/rest/query"
+        method: POST
+        body_format: json
+        body:
+          db: host
+          csl: >-
+            VelociraptorJson | where Record.Marker == "DFIR_INGEST_MOLECULE" | count
+        return_content: true
+      register: probe
+
+    - name: "molecule-verify | assert the probe record landed"
+      ansible.builtin.assert:
+        that:
+          - (probe.json.Tables[0].Rows[0][0] | int) >= 1
+        fail_msg: "the molecule probe record was not found in host.VelociraptorJson"
+        quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/tasks/ingest.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/tasks/ingest.yml
@@ -1,0 +1,17 @@
+---
+- name: "ingest-adx | load data_store/processed into the emulator"
+  ansible.builtin.command:
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.ingest', '--processed-dir', dfir_ingest_adx_processed_dir, '--host', dfir_ingest_adx_kusto_host, '--port', dfir_ingest_adx_kusto_port | string, '--container', dfir_ingest_adx_kusto_container] + (['--only', dfir_ingest_adx_only] if dfir_ingest_adx_only | length > 0 else []) + (['--force'] if dfir_ingest_adx_force | bool else []) + (['--dry-run'] if dfir_ingest_adx_dry_run | bool else []) }}"
+  environment:
+    PYTHONPATH: "{{ dfir_ingest_adx_python_path }}"
+  register: dfir_ingest_adx_run
+  changed_when: (dfir_ingest_adx_run.stdout | from_json).submitted | int > 0
+
+- name: "ingest-adx | assert no source failed to load"
+  ansible.builtin.assert:
+    that:
+      - (dfir_ingest_adx_run.stdout | from_json).failed | int == 0
+    fail_msg: >-
+      ingest reported {{ (dfir_ingest_adx_run.stdout | from_json).failed }} failed
+      file(s): {{ (dfir_ingest_adx_run.stdout | from_json).errors }}
+    quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/tasks/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# dfir_ingest_adx: load data_store/processed into the ADX emulator. Idempotence
+# (skip files already in the in-DB ledger) lives in the Python loader, not in a
+# task's `when:`.
+
+- name: "ingest-adx | assert inputs"
+  ansible.builtin.assert:
+    that:
+      - dfir_ingest_adx_processed_dir | length > 0
+      - dfir_ingest_adx_only in ['', 'l2t', 'zeek', 'evtx', 'volatility', 'velociraptor']
+    fail_msg: >-
+      dfir_ingest_adx needs a non-empty dfir_ingest_adx_processed_dir; dfir_ingest_adx_only
+      may only be one of l2t/zeek/evtx/volatility/velociraptor (or empty for all).
+    quiet: true
+  tags: [always]
+
+# Fact-find + preconditions BEFORE any ingest.
+- name: "ingest-adx | preflight"
+  ansible.builtin.include_tasks:
+    file: preflight.yml
+    apply:
+      tags: [always]
+  tags: [always]
+
+- name: "ingest-adx | load processed data into the emulator"
+  ansible.builtin.include_tasks: ingest.yml

--- a/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/tasks/preflight.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_ingest_adx/tasks/preflight.yml
@@ -1,0 +1,46 @@
+---
+# FIND FACTS -> check existence AND location + engine reachability -> (then INGEST).
+
+- name: "ingest-adx-preflight | docker daemon reachable"
+  ansible.builtin.command: docker version
+  register: dfir_ingest_adx_docker
+  changed_when: false
+
+- name: "ingest-adx-preflight | stat the processed dir"
+  ansible.builtin.stat:
+    path: "{{ dfir_ingest_adx_processed_dir }}"
+  register: dfir_ingest_adx_proc_stat
+
+- name: "ingest-adx-preflight | processed dir exists and is a directory"
+  ansible.builtin.assert:
+    that:
+      - dfir_ingest_adx_proc_stat.stat.exists
+      - dfir_ingest_adx_proc_stat.stat.isdir is defined and dfir_ingest_adx_proc_stat.stat.isdir
+    fail_msg: >-
+      dfir_ingest_adx_processed_dir ({{ dfir_ingest_adx_processed_dir }}) is missing or
+      is not a directory.
+    quiet: true
+
+- name: "ingest-adx-preflight | the get_sybers_dfir.ingest module imports"
+  ansible.builtin.command: python3 -c "import get_sybers_dfir.ingest"
+  environment:
+    PYTHONPATH: "{{ dfir_ingest_adx_python_path }}"
+  register: dfir_ingest_adx_import
+  changed_when: false
+
+- name: "ingest-adx-preflight | the ADX emulator engine is reachable"
+  ansible.builtin.command:
+    argv:
+      - python3
+      - -m
+      - get_sybers_dfir.ingest
+      - --ping
+      - --host
+      - "{{ dfir_ingest_adx_kusto_host }}"
+      - --port
+      - "{{ dfir_ingest_adx_kusto_port }}"
+  environment:
+    PYTHONPATH: "{{ dfir_ingest_adx_python_path }}"
+  register: dfir_ingest_adx_reachable
+  changed_when: false
+  failed_when: dfir_ingest_adx_reachable.rc != 0 and not dfir_ingest_adx_dry_run | bool

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -134,15 +134,30 @@ def process(
 @app.command()
 def ingest(
     only: str = typer.Option(None, "--only", help="Load one source: l2t|zeek|evtx|volatility|velociraptor."),
+    force: bool = typer.Option(False, "--force", help="Re-ingest files already in the ledger."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="List what would be loaded; contact nothing."),
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+    extra_var: list[str] = typer.Option(None, "--extra-var", "-e", help="Extra Ansible var KEY=VALUE (repeatable)."),
 ) -> None:
-    """Load processed output into the ADX (Kusto) emulator (fronts ingest-kusto.sh)."""
-    _need("bash")
+    """Load processed output into the ADX (Kusto) emulator by driving dfir_ingest_adx."""
+    _need("ansible-playbook")
     repo = _repo_root(repo_root)
-    cmd = ["bash", _script(repo, "ingest-kusto.sh")]
+    playbook = repo / _COLLECTION / "playbooks" / "dfir-ingest-adx.yml"
+    if not playbook.is_file():
+        typer.secho(f"ingest playbook not found: {playbook}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    cmd = ["ansible-playbook", "-i", "localhost,", "-c", "local", str(playbook)]
     if only:
-        cmd += ["--only", only]
-    _run(cmd, cwd=repo)
+        cmd += ["-e", f"dfir_ingest_adx_only={only}"]
+    if force:
+        cmd += ["-e", "dfir_ingest_adx_force=true"]
+    if dry_run:
+        cmd += ["-e", "dfir_ingest_adx_dry_run=true"]
+    for kv in extra_var or []:
+        cmd += ["-e", kv]
+    env = {"ANSIBLE_ROLES_PATH": str(repo / _COLLECTION / "roles")}
+    typer.secho("ingesting processed → ADX emulator", fg=typer.colors.GREEN)
+    _run(cmd, cwd=repo, env=env)
 
 
 @app.command()

--- a/python/get_sybers_dfir/ingest/__init__.py
+++ b/python/get_sybers_dfir/ingest/__init__.py
@@ -1,0 +1,277 @@
+"""Load ``data_store/processed`` into the ADX (Kusto) emulator.
+
+Port of ``scripts/ingest-kusto.sh``. Each source's files are shaped (constant-column
+wrapping — see :mod:`.prepare`), copied INTO the emulator container (it reads from
+its own filesystem, not the host's), and loaded with a batched ``.ingest into``.
+Plaso l2t has its own driver: one json_line file fans out into several
+``L2t<Parser>`` tables.
+
+The shell ingest is additive (no fishbucket) — re-running duplicates rows. To make
+the role idempotent, a tiny in-DB **ledger** (``host._DfirIngestLedger``) records
+the sha1 of every source file loaded; a file already in the ledger is skipped unless
+``force`` is set. The ledger lives in the (ephemeral) database, so a redeploy wipes
+the ledger and the data together — they never drift.
+"""
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+
+from .kusto import KustoClient, error_message, failed
+from . import prepare
+
+CONTAINER_STAGE = "/tmp/dfir-ingest"
+_LEDGER_DB = "host"
+_LEDGER_TABLE = "_DfirIngestLedger"
+_BATCH = 50
+
+L2T_MAPPING = (
+    '[{"Column":"SourceImage","Properties":{"Path":"$.SourceImage"}},'
+    '{"Column":"Timestamp","Properties":{"Path":"$.Timestamp"}},'
+    '{"Column":"Parser","Properties":{"Path":"$.Parser"}},'
+    '{"Column":"Record","Properties":{"Path":"$.Record"}}]'
+)
+
+# key | label | subdir | glob | db | table | mapping | fmt | hdr | wrap-hook
+SOURCES = [
+    {"key": "evtx", "label": "EvtxECmd -> host.EvtxEcmdJson", "subdir": "windows_logs",
+     "glob": "*_EvtxECmd_Output.json", "db": "host", "table": "EvtxEcmdJson",
+     "mapping": "EvtxEcmdJsonMapping", "fmt": "multijson", "hdr": False, "wrap": None},
+    {"key": "zeek", "label": "Zeek conn -> network.ZeekConn", "subdir": "zeek",
+     "glob": "conn.json", "db": "network", "table": "ZeekConn",
+     "mapping": "ZeekConnMapping", "fmt": "multijson", "hdr": False, "wrap": None},
+    {"key": "zeek", "label": "Zeek other logs -> network.Zeek", "subdir": "zeek",
+     "glob": "*.json", "db": "network", "table": "Zeek",
+     "mapping": "ZeekJsonMapping", "fmt": "multijson", "hdr": False, "wrap": "zeek"},
+    {"key": "volatility", "label": "Volatility 3 -> memory.VolatilityJson", "subdir": "volatility",
+     "glob": "*.jsonl", "db": "memory", "table": "VolatilityJson",
+     "mapping": "VolatilityJsonMapping", "fmt": "multijson", "hdr": False, "wrap": "volatility"},
+    {"key": "velociraptor", "label": "Velociraptor -> host.VelociraptorJson", "subdir": "velociraptor",
+     "glob": "*.json", "db": "host", "table": "VelociraptorJson",
+     "mapping": "VelociraptorJsonMapping", "fmt": "multijson", "hdr": False, "wrap": "velociraptor"},
+]
+
+_WRAP_FUNCS = {
+    "zeek": prepare.zeek_wrap,
+    "volatility": prepare.volatility_wrap,
+    "velociraptor": prepare.velociraptor_wrap,
+}
+
+VALID_SOURCES = ("l2t", "zeek", "evtx", "volatility", "velociraptor")
+
+
+# ---- helpers ---------------------------------------------------------------
+def _find(root: str, glob: str) -> list[str]:
+    import fnmatch
+    out = []
+    for cur, _dirs, files in os.walk(root):
+        for name in files:
+            if fnmatch.fnmatch(name, glob):
+                out.append(os.path.join(cur, name))
+    return sorted(out)
+
+
+def _file_hash(rel: str) -> str:
+    return hashlib.sha1(rel.encode("utf-8")).hexdigest()
+
+
+def _docker_exec(container: str, *args: str) -> bool:
+    return subprocess.run(["docker", "exec", container, *args],
+                          capture_output=True).returncode == 0
+
+
+def _docker_cp(src: str, container: str, dest: str) -> bool:
+    return subprocess.run(["docker", "cp", src, f"{container}:{dest}"],
+                          capture_output=True).returncode == 0
+
+
+# ---- ledger ----------------------------------------------------------------
+def ensure_ledger(client: KustoClient) -> None:
+    client.mgmt(_LEDGER_DB, f".create-merge table {_LEDGER_TABLE} (Hash:string, IngestedAt:datetime)")
+
+
+def ledger_hashes(client: KustoClient) -> set[str]:
+    resp = client.query(_LEDGER_DB, f"{_LEDGER_TABLE} | distinct Hash")
+    if failed(resp):
+        return set()
+    try:
+        d = json.loads(resp)
+        rows = (d.get("Tables") or [{}])[0].get("Rows") or []
+        return {r[0] for r in rows if r and r[0]}
+    except (json.JSONDecodeError, ValueError, IndexError):
+        return set()
+
+
+def record_hashes(client: KustoClient, hashes: list[str]) -> None:
+    if not hashes:
+        return
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    csv = "\n".join(f"{h},{now}" for h in hashes)
+    client.mgmt(_LEDGER_DB, f".ingest inline into table {_LEDGER_TABLE} <|\n{csv}")
+
+
+# ---- ingest ----------------------------------------------------------------
+def _ingest_cmd(table: str, locators: list[str], mapping: str, fmt: str, hdr: bool) -> str:
+    locs = ", ".join(f'@"{p}"' for p in locators)
+    cmd = f'.ingest into table {table} ({locs}) with (format="{fmt}"'
+    if mapping and mapping != "-":
+        cmd += f', ingestionMappingReference="{mapping}"'
+    if hdr:
+        cmd += ", ignoreFirstRecord=true"
+    return cmd + ")"
+
+
+def _ingest_batched(client, db, table, mapping, fmt, hdr, locators, dry_run, summary) -> bool:
+    """Ingest locators in batches of 50. Returns True if all batches succeeded."""
+    ok = True
+    for i in range(0, len(locators), _BATCH):
+        batch = locators[i:i + _BATCH]
+        summary["submitted"] += len(batch)
+        if dry_run:
+            continue
+        resp = client.mgmt(db, _ingest_cmd(table, batch, mapping, fmt, hdr))
+        if failed(resp):
+            ok = False
+            summary["failed"] += len(batch)
+            summary["errors"].append({"table": f"{db}.{table}", "error": error_message(resp)})
+    return ok
+
+
+def _stage(files, processed_dir, wrap_key, container, staging_dir, dry_run, summary):
+    """Return [(container_path, file_hash), ...] for files to ingest, staging each
+    (docker cp the original, or a wrapped rewrite) into the container."""
+    staged = []
+    wrap_fn = _WRAP_FUNCS.get(wrap_key)
+    for f in files:
+        rel = os.path.relpath(f, processed_dir)
+        name = prepare.staged_name(rel)
+        dest = f"{CONTAINER_STAGE}/{name}"
+        fh = _file_hash(rel)
+        if dry_run:
+            staged.append((dest, fh))
+            continue
+        if wrap_fn is None:                       # stage the original as-is
+            if _docker_cp(f, container, dest):
+                staged.append((dest, fh))
+            else:
+                summary["failed"] += 1
+        else:
+            lines = wrap_fn(f, rel)
+            if not lines:                          # skipped (e.g. conn.json) or empty
+                continue
+            host_tmp = os.path.join(staging_dir, name)
+            with open(host_tmp, "w") as w:
+                w.write("\n".join(lines) + "\n")
+            if _docker_cp(host_tmp, container, dest):
+                staged.append((dest, fh))
+            else:
+                summary["failed"] += 1
+    return staged
+
+
+def run_source(client, row, processed_dir, container, staging_dir, seen, dry_run, summary):
+    subdir = os.path.join(processed_dir, row["subdir"])
+    if not os.path.isdir(subdir):
+        return
+    files = _find(subdir, row["glob"])
+    # idempotence: skip files already in the ledger (unless forced -> seen is empty)
+    todo = [f for f in files if _file_hash(os.path.relpath(f, processed_dir)) not in seen]
+    if not todo:
+        summary["sources"][row["label"]] = {"found": len(files), "ingested": 0, "skipped": len(files)}
+        return
+    staged = _stage(todo, processed_dir, row["wrap"], container, staging_dir, dry_run, summary)
+    if not staged:
+        summary["sources"][row["label"]] = {"found": len(files), "ingested": 0, "skipped": len(files) - len(todo)}
+        return
+    ok = _ingest_batched(client, row["db"], row["table"], row["mapping"],
+                         row["fmt"], row["hdr"], [p for p, _ in staged], dry_run, summary)
+    if ok and not dry_run:
+        record_hashes(client, [h for _, h in staged])
+    summary["sources"][row["label"]] = {
+        "found": len(files), "ingested": len(staged), "skipped": len(files) - len(todo)}
+
+
+def run_l2t(client, processed_dir, container, staging_dir, seen, dry_run, summary):
+    jsonl_dir = os.path.join(processed_dir, "log2timeline", "jsonl")
+    if not os.path.isdir(jsonl_dir):
+        return
+    files = _find(jsonl_dir, "*.jsonl")
+    todo = [f for f in files if _file_hash(os.path.relpath(f, processed_dir)) not in seen]
+    ingested = 0
+    ensured = set()
+    for f in todo:
+        rel = os.path.relpath(f, processed_dir)
+        fh = _file_hash(rel)
+        prefix = prepare.staged_name(rel)
+        tables = prepare.split_l2t(f, rel)
+        if not tables:
+            continue
+        file_ok = True
+        for table, lines in tables.items():
+            if not dry_run and table not in ensured:
+                client.mgmt("host", f".create-merge table {table} "
+                            "(SourceImage:string, Timestamp:datetime, Parser:string, Record:dynamic)")
+                client.mgmt("host", f'.create-or-alter table {table} ingestion json mapping '
+                            f'"L2tMapping" ```{L2T_MAPPING}```')
+                ensured.add(table)
+            name = f"{prefix}.{table}"
+            dest = f"{CONTAINER_STAGE}/{name}"
+            if dry_run:
+                summary["submitted"] += 1
+                continue
+            host_tmp = os.path.join(staging_dir, name)
+            with open(host_tmp, "w") as w:
+                w.write("\n".join(lines) + "\n")
+            if not _docker_cp(host_tmp, container, dest):
+                summary["failed"] += 1
+                file_ok = False
+                continue
+            if not _ingest_batched(client, "host", table, "L2tMapping", "multijson", False,
+                                   [dest], dry_run, summary):
+                file_ok = False
+        if file_ok and not dry_run:
+            record_hashes(client, [fh])
+            ingested += 1
+    summary["sources"]["Plaso l2t -> host.L2t<Parser>"] = {
+        "found": len(files), "ingested": ingested, "skipped": len(files) - len(todo)}
+
+
+def process(processed_dir, only=None, dry_run=False, force=False,
+            host="127.0.0.1", port=8080, container="kusto-emulator") -> dict:
+    processed_dir = os.path.realpath(processed_dir)
+    client = KustoClient(host=host, port=port, container=container)
+    summary = {
+        "tool": "ingest", "endpoint": client.base, "processed_dir": processed_dir,
+        "dry_run": dry_run, "submitted": 0, "failed": 0, "sources": {}, "errors": [],
+    }
+    if not os.path.isdir(processed_dir):
+        summary["error"] = f"no processed dir at {processed_dir}"
+        return summary
+    if not dry_run and not client.reachable():
+        summary["error"] = f"nothing answering at {client.base} (deploy first)"
+        return summary
+
+    seen: set[str] = set()
+    if not dry_run:
+        ensure_ledger(client)
+        if not force:
+            seen = ledger_hashes(client)
+        if not _docker_exec(container, "mkdir", "-p", CONTAINER_STAGE):
+            summary["error"] = f"could not reach container '{container}'"
+            return summary
+
+    with tempfile.TemporaryDirectory(prefix="dfir-ingest-") as staging_dir:
+        for row in SOURCES:
+            if only and only != row["key"]:
+                continue
+            run_source(client, row, processed_dir, container, staging_dir, seen, dry_run, summary)
+        if not only or only == "l2t":
+            run_l2t(client, processed_dir, container, staging_dir, seen, dry_run, summary)
+
+    if not dry_run:
+        _docker_exec(container, "rm", "-rf", CONTAINER_STAGE)
+    return summary

--- a/python/get_sybers_dfir/ingest/__main__.py
+++ b/python/get_sybers_dfir/ingest/__main__.py
@@ -1,0 +1,48 @@
+"""CLI for the ingest loader: python -m get_sybers_dfir.ingest ..."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from . import VALID_SOURCES, process
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="get_sybers_dfir.ingest",
+        description="Load data_store/processed into the ADX (Kusto) emulator",
+    )
+    ap.add_argument("--processed-dir", help="data_store/processed tree to load")
+    ap.add_argument("--ping", action="store_true", help="check the emulator is reachable; exit 0/1")
+    ap.add_argument("--only", choices=list(VALID_SOURCES), help="load one source only")
+    ap.add_argument("--dry-run", action="store_true", help="list what would be loaded; contact nothing")
+    ap.add_argument("--force", action="store_true", help="re-ingest files already in the ledger")
+    ap.add_argument("--host", default="127.0.0.1", help="emulator host (default 127.0.0.1)")
+    ap.add_argument("--port", type=int, default=8080, help="emulator port (default 8080)")
+    ap.add_argument("--container", default="kusto-emulator", help="emulator container name")
+    args = ap.parse_args(argv)
+
+    if args.ping:
+        from .kusto import KustoClient
+        up = KustoClient(host=args.host, port=args.port, container=args.container).reachable()
+        sys.stdout.write(("reachable" if up else "unreachable") + f" {args.host}:{args.port}\n")
+        return 0 if up else 1
+
+    if not args.processed_dir:
+        ap.error("--processed-dir is required unless --ping is given")
+
+    summary = process(
+        args.processed_dir, only=args.only, dry_run=args.dry_run, force=args.force,
+        host=args.host, port=args.port, container=args.container,
+    )
+    json.dump(summary, sys.stdout)
+    sys.stdout.write("\n")
+    if summary.get("error"):
+        sys.stderr.write(summary["error"] + "\n")
+        return 2
+    return 1 if summary["failed"] and not summary["submitted"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/get_sybers_dfir/ingest/kusto.py
+++ b/python/get_sybers_dfir/ingest/kusto.py
@@ -1,0 +1,124 @@
+"""Minimal client for the Kusto emulator's REST endpoints.
+
+Port of ``scripts/lib/kusto-api.sh``. The emulator has no auth (it binds to
+localhost), so there is no token handling. Kusto routes by request type:
+``/v1/rest/mgmt`` for control commands (leading ``.``) and ``/v1/rest/query`` for
+KQL. The engine returns HTTP 200 with an error *document* on failure, so the status
+code proves nothing — :func:`failed` inspects the body (error envelope, a per-row
+``Result="Failed"``, a non-JSON body, or no body at all).
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+_TIMEOUT = 600
+
+
+def failed(resp: str) -> bool:
+    """True if a Kusto response is a failure (envelope, per-row Failed, non-JSON,
+    or empty). Mirrors kusto-api.sh's kusto_failed."""
+    if not resp or not resp.strip():
+        return True                         # no response = failure
+    try:
+        d = json.loads(resp)
+    except (json.JSONDecodeError, ValueError):
+        return True                         # not JSON at all = failure
+
+    def walk(o) -> bool:
+        if isinstance(o, dict):
+            for k, v in o.items():
+                if k in ("error", "OneApiErrors", "Errors"):
+                    return True
+                if k == "@type" and isinstance(v, str) and v.startswith("Kusto"):
+                    return True
+                if k in ("Result", "Status") and isinstance(v, str) and v.lower() in ("failed", "error"):
+                    return True
+                if k == "HasErrors" and v in (True, "true", "True"):
+                    return True
+                if walk(v):
+                    return True
+        elif isinstance(o, list):
+            for v in o:
+                if walk(v):
+                    return True
+        return False
+
+    def tables(doc) -> bool:
+        for t in (doc.get("Tables", []) if isinstance(doc, dict) else []):
+            cols = [c.get("ColumnName") for c in t.get("Columns", [])]
+            for row in t.get("Rows", []) or []:
+                for name, val in zip(cols, row):
+                    if name in ("Result", "Status") and isinstance(val, str) and val.lower() in ("failed", "error"):
+                        return True
+                    if name == "HasErrors" and val in (True, "true", "True"):
+                        return True
+        return False
+
+    return walk(d) or tables(d)
+
+
+def error_message(resp: str) -> str:
+    """A human-readable message pulled from a failure response."""
+    try:
+        d = json.loads(resp)
+    except (json.JSONDecodeError, ValueError):
+        return (resp.strip() or "(empty response — engine unreachable?)")[:400]
+
+    def find(o):
+        if isinstance(o, dict):
+            for k in ("message", "@message", "Reason", "description"):
+                v = o.get(k)
+                if isinstance(v, str) and v:
+                    return v
+            for v in o.values():
+                r = find(v)
+                if r:
+                    return r
+        elif isinstance(o, list):
+            for v in o:
+                r = find(v)
+                if r:
+                    return r
+        return None
+
+    return find(d) or json.dumps(d)[:400]
+
+
+class KustoClient:
+    """POST control/query commands to the emulator."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 8080, container: str = "kusto-emulator"):
+        self.base = f"http://{host}:{port}"
+        self.container = container
+
+    def _post(self, path: str, db: str, csl: str) -> str:
+        body = json.dumps({"db": db, "csl": csl}).encode("utf-8")
+        req = urllib.request.Request(
+            self.base + path, data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_TIMEOUT) as r:
+                return r.read().decode("utf-8", "replace")
+        except urllib.error.HTTPError as e:                # engine 4xx/5xx: body still useful
+            try:
+                return e.read().decode("utf-8", "replace")
+            except OSError:
+                return ""
+        except (urllib.error.URLError, OSError):           # unreachable / timeout = no response
+            return ""
+
+    def mgmt(self, db: str, csl: str) -> str:
+        return self._post("/v1/rest/mgmt", db, csl)
+
+    def query(self, db: str, csl: str) -> str:
+        return self._post("/v1/rest/query", db, csl)
+
+    def reachable(self) -> bool:
+        """Is the ENGINE up (not just something on the port)?"""
+        resp = self.mgmt("NetDefaultDB", ".show version")
+        if failed(resp):
+            return False
+        return '"Tables"' in resp or '"Rows"' in resp

--- a/python/get_sybers_dfir/ingest/prepare.py
+++ b/python/get_sybers_dfir/ingest/prepare.py
@@ -1,0 +1,133 @@
+"""Record-shaping for ingest — the constant-column wrapping ``.ingest`` cannot do.
+
+``.ingest into`` cannot inject a per-file constant (which log type / plugin /
+artefact / image a row came from), and it cannot convert Plaso's microsecond epoch
+to a datetime. So each source's files are rewritten to JSON Lines with the constant
+columns alongside the original record before staging:
+
+  zeek (non-conn) -> {"LogType", "SourceFile", "Record"}   (conn is the typed table's job)
+  volatility      -> {"Plugin",  "SourceFile", "Record"}
+  velociraptor    -> {"Artefact","SourceFile", "Record"}
+  plaso l2t       -> {"SourceImage","Timestamp","Parser","Record"}, one table per top parser
+
+These functions are pure (path in, list-of-JSONL-strings out) so they unit-test
+without a Kusto engine.
+"""
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import re
+
+_SAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def staged_name(rel: str) -> str:
+    """A collision-free, KQL-safe stage name for a file, from its path relative to
+    the processed dir: an 8-char sha1 of the path (uniqueness) + the sanitised path
+    (safety — staged names are spliced into KQL as @"..." verbatim strings)."""
+    safe = _SAFE.sub("_", rel)
+    digest = hashlib.sha1(rel.encode("utf-8")).hexdigest()[:8]
+    return f"{digest}_{safe}"
+
+
+def _records(path: str):
+    """Yield the records in a processed file — a JSON array/object, or JSON Lines."""
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        raw = fh.read()
+    stripped = raw.lstrip()
+    if stripped[:1] == "[":
+        try:
+            data = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            return
+        yield from (data if isinstance(data, list) else [data])
+        return
+    if stripped[:1] == "{" and "\n" not in stripped.strip():
+        try:
+            yield json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            return
+        return
+    for line in raw.splitlines():                 # JSON Lines
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+
+def wrap(path: str, key: str, value: str, source_rel: str) -> list[str]:
+    """Wrap each record as {key: value, "SourceFile": source_rel, "Record": rec}."""
+    return [
+        json.dumps({key: value, "SourceFile": source_rel, "Record": rec})
+        for rec in _records(path)
+    ]
+
+
+def zeek_logtype(path: str) -> str:
+    return os.path.basename(path)[: -len(".json")] if path.lower().endswith(".json") else os.path.basename(path)
+
+
+def zeek_wrap(path: str, source_rel: str) -> list[str] | None:
+    """None for conn.json (skipped — the typed ZeekConn table loads it); else the
+    generic {LogType, SourceFile, Record} lines."""
+    logtype = zeek_logtype(path)
+    if logtype == "conn":
+        return None
+    return wrap(path, "LogType", logtype, source_rel)
+
+
+def volatility_plugin(path: str) -> str:
+    base = os.path.basename(path)
+    for ext in (".jsonl", ".json"):
+        if base.lower().endswith(ext):
+            base = base[: -len(ext)]
+            break
+    return base
+
+
+def volatility_wrap(path: str, source_rel: str) -> list[str]:
+    return wrap(path, "Plugin", volatility_plugin(path), source_rel)
+
+
+def velociraptor_artefact(path: str) -> str:
+    return os.path.basename(path)[: -len(".json")] if path.lower().endswith(".json") else os.path.basename(path)
+
+
+def velociraptor_wrap(path: str, source_rel: str) -> list[str]:
+    return wrap(path, "Artefact", velociraptor_artefact(path), source_rel)
+
+
+# ---- plaso l2t: fan one json_line file out into per-parser tables ----------
+def table_name(parser: str) -> str:
+    """Top-level parser -> table name: filestat -> L2tFilestat,
+    winreg/appcompatcache -> L2tWinreg, firefox_cache -> L2tFirefoxCache."""
+    top = re.split(r"/", parser or "unknown")[0] or "unknown"
+    parts = [p for p in re.split(r"[^A-Za-z0-9]+", top) if p]
+    return "L2t" + "".join(p[:1].upper() + p[1:] for p in parts) if parts else "L2tUnknown"
+
+
+def split_l2t(path: str, source_rel: str) -> dict[str, list[str]]:
+    """Group a Plaso json_line file by top-level parser; return
+    {table -> [wrapped JSONL strings]} with {SourceImage, Timestamp, Parser, Record}.
+    A zero/absent/out-of-range timestamp is left unset (not 1970)."""
+    out: dict[str, list[str]] = {}
+    for rec in _records(path):
+        parser = str(rec.get("parser") or "unknown")
+        table = table_name(parser)
+        row = {"SourceImage": source_rel, "Parser": parser, "Record": rec}
+        ts = rec.get("timestamp")
+        if isinstance(ts, (int, float)) and ts > 0:
+            try:
+                row["Timestamp"] = datetime.datetime.fromtimestamp(
+                    ts / 1_000_000, datetime.timezone.utc
+                ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            except (OverflowError, OSError, ValueError):
+                pass
+        out.setdefault(table, []).append(json.dumps(row))
+    return out

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -17,6 +17,7 @@ def _fake_repo(tmp_path: Path) -> Path:
     (tmp_path / _COLLECTION / "roles").mkdir(parents=True)
     for src in ("zeek", "velociraptor"):
         (tmp_path / _COLLECTION / "playbooks" / f"dfir-process-{src}.yml").write_text("---\n")
+    (tmp_path / _COLLECTION / "playbooks" / "dfir-ingest-adx.yml").write_text("---\n")
     (tmp_path / "scripts").mkdir()
     for s in ("ingest-kusto.sh", "deploy-kusto.sh", "apply-kusto-schema.sh"):
         (tmp_path / "scripts" / s).write_text("#!/bin/bash\n")
@@ -69,15 +70,18 @@ def test_process_unknown_source_rejected(tmp_path):
     assert r.exit_code != 0
 
 
-def test_ingest_builds_script_command(tmp_path):
+def test_ingest_drives_the_role(tmp_path):
     repo = _fake_repo(tmp_path)
-    with mock.patch.object(cli.subprocess, "call", return_value=0) as m:
-        r = runner.invoke(cli.app, ["ingest", "--only", "zeek", "--repo-root", str(repo)])
+    with mock.patch.object(cli.subprocess, "call", return_value=0) as m, \
+            mock.patch.object(cli.shutil, "which", return_value="/usr/bin/ansible-playbook"):
+        r = runner.invoke(cli.app, ["ingest", "--only", "zeek", "--force", "--repo-root", str(repo)])
     assert r.exit_code == 0, r.stdout
     cmd = m.call_args.args[0]
-    assert cmd[0] == "bash"
-    assert cmd[1].endswith("scripts/ingest-kusto.sh")
-    assert cmd[-2:] == ["--only", "zeek"]
+    assert cmd[0] == "ansible-playbook"
+    assert str(repo / _COLLECTION / "playbooks" / "dfir-ingest-adx.yml") in cmd
+    assert "dfir_ingest_adx_only=zeek" in cmd
+    assert "dfir_ingest_adx_force=true" in cmd
+    assert m.call_args.kwargs["env"]["ANSIBLE_ROLES_PATH"] == str(repo / _COLLECTION / "roles")
 
 
 def test_deploy_runs_deploy_then_schema(tmp_path):
@@ -100,6 +104,7 @@ def test_deploy_no_schema_skips_apply(tmp_path):
 
 def test_failing_command_propagates_exit_code(tmp_path):
     repo = _fake_repo(tmp_path)
-    with mock.patch.object(cli.subprocess, "call", return_value=3):
+    with mock.patch.object(cli.subprocess, "call", return_value=3), \
+            mock.patch.object(cli.shutil, "which", return_value="/usr/bin/ansible-playbook"):
         r = runner.invoke(cli.app, ["ingest", "--repo-root", str(repo)])
     assert r.exit_code == 3

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -1,0 +1,99 @@
+"""Unit tests for ingest pure logic (Kusto failure detection + record shaping)."""
+import json
+
+from get_sybers_dfir.ingest import kusto, prepare
+
+
+# ---- kusto.failed / error_message -----------------------------------------
+def test_failed_empty_and_nonjson():
+    assert kusto.failed("") is True
+    assert kusto.failed("   ") is True
+    assert kusto.failed("<html>not kusto</html>") is True
+
+
+def test_failed_error_envelope():
+    assert kusto.failed('{"error": {"message": "boom"}}') is True
+    assert kusto.failed('{"OneApiErrors": [1]}') is True
+
+
+def test_failed_per_row_status():
+    resp = json.dumps({"Tables": [{
+        "Columns": [{"ColumnName": "Result"}], "Rows": [["Failed"]]}]})
+    assert kusto.failed(resp) is True
+
+
+def test_failed_ok_response():
+    resp = json.dumps({"Tables": [{
+        "Columns": [{"ColumnName": "BuildVersion"}], "Rows": [["1.0.0"]]}]})
+    assert kusto.failed(resp) is False
+
+
+def test_error_message_extracts():
+    assert kusto.error_message('{"error": {"message": "table not found"}}') == "table not found"
+    assert "unreachable" in kusto.error_message("")
+
+
+# ---- staged_name -----------------------------------------------------------
+def test_staged_name_hash_and_sanitised():
+    n = prepare.staged_name('WinEvt/WKS"1/Security.json')
+    assert '"' not in n and "/" not in n
+    assert n.split("_", 1)[0].isalnum() and len(n.split("_", 1)[0]) == 8
+    # different paths that sanitise the same still differ (hash prefix)
+    assert prepare.staged_name("a b") != prepare.staged_name("a_b")
+
+
+# ---- record shaping --------------------------------------------------------
+def test_records_array_and_jsonl(tmp_path):
+    arr = tmp_path / "a.json"
+    arr.write_text('[{"x":1},{"x":2}]')
+    assert list(prepare._records(str(arr))) == [{"x": 1}, {"x": 2}]
+    jl = tmp_path / "b.jsonl"
+    jl.write_text('{"x":1}\n\n{"x":2}\n')
+    assert list(prepare._records(str(jl))) == [{"x": 1}, {"x": 2}]
+
+
+def test_zeek_wrap_skips_conn(tmp_path):
+    conn = tmp_path / "conn.json"
+    conn.write_text('{"id":1}\n')
+    assert prepare.zeek_wrap(str(conn), "zeek/cap/conn.json") is None
+    dns = tmp_path / "dns.json"
+    dns.write_text('{"q":"x"}\n')
+    got = prepare.zeek_wrap(str(dns), "zeek/cap/dns.json")
+    obj = json.loads(got[0])
+    assert obj == {"LogType": "dns", "SourceFile": "zeek/cap/dns.json", "Record": {"q": "x"}}
+
+
+def test_volatility_and_velociraptor_wrap(tmp_path):
+    v = tmp_path / "windows.pslist.jsonl"
+    v.write_text('{"PID":4}\n')
+    obj = json.loads(prepare.volatility_wrap(str(v), "volatility/img/windows.pslist.jsonl")[0])
+    assert obj["Plugin"] == "windows.pslist" and obj["Record"] == {"PID": 4}
+
+    r = tmp_path / "Windows.Registry.RecentApps.json"
+    r.write_text('[{"k":"v"}]')
+    obj = json.loads(prepare.velociraptor_wrap(str(r), "velociraptor/H/Windows.Registry.RecentApps.json")[0])
+    assert obj["Artefact"] == "Windows.Registry.RecentApps"
+
+
+# ---- l2t split -------------------------------------------------------------
+def test_table_name():
+    assert prepare.table_name("filestat") == "L2tFilestat"
+    assert prepare.table_name("winreg/appcompatcache") == "L2tWinreg"
+    assert prepare.table_name("firefox_cache") == "L2tFirefoxCache"
+    assert prepare.table_name("") == "L2tUnknown"
+
+
+def test_split_l2t_groups_and_converts_timestamp(tmp_path):
+    f = tmp_path / "host.jsonl"
+    f.write_text(
+        '{"parser":"filestat","timestamp":1609459200000000,"image_hostname":"H"}\n'
+        '{"parser":"winreg/appcompatcache","timestamp":0}\n'
+    )
+    out = prepare.split_l2t(str(f), "log2timeline/jsonl/host.jsonl")
+    assert set(out) == {"L2tFilestat", "L2tWinreg"}
+    fs = json.loads(out["L2tFilestat"][0])
+    assert fs["Parser"] == "filestat" and fs["SourceImage"].endswith("host.jsonl")
+    assert fs["Timestamp"] == "2021-01-01T00:00:00.000000Z"
+    # zero timestamp -> left unset (not 1970)
+    wr = json.loads(out["L2tWinreg"][0])
+    assert "Timestamp" not in wr


### PR DESCRIPTION
First ingest slice of epic #46 — ports `ingest-kusto.sh` (+ `kusto-api.sh` + `l2t-split.py`) to the `get_sybers_dfir.ingest` Python subpackage and the `dfir_ingest_adx` role, and wires `dxdfir ingest` to drive the role.

- **`ingest/kusto.py`** — urllib client for `/v1/rest/{mgmt,query}`; failure detection (error envelope / per-row `Result=Failed` / non-JSON / no response).
- **`ingest/prepare.py`** — pure record shaping: collision-free KQL-safe `staged_name`; the constant-column wrapping `.ingest` can't do (zeek/volatility/velociraptor); the l2t per-parser split with µs→ISO timestamp conversion.
- **`ingest/__init__.py`** — sources table, docker-cp staging into the emulator, batched `.ingest`, the l2t driver. **Idempotence via an in-DB ledger** (`host._DfirIngestLedger`): each loaded file's sha1 is recorded and skipped on re-run unless `--force`; the ledger lives in the ephemeral DB so a redeploy wipes ledger+data together — a real improvement over the additive shell.
- **`dfir_ingest_adx` role** — one action per task; preflight (docker; processed dir; module import; **engine reachable via `--ping`**); assert no source failed.
- **`dxdfir ingest`** now drives `dfir-ingest-adx.yml`.

**Validated:** rule-8 gate PASSES; unit tests (11 ingest; package suite **75/0**); **end-to-end against the running emulator** — loaded a fixture (row queryable), re-run skipped via the ledger (no duplicate), `--force` re-ingested; **role converge `changed=1` → converge-again `changed=0` → verify** queries the probe row. Live test data cleaned up.

Targets `dev`. Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)