### PR TITLE
ingest: tolerate a processed file vanishing mid-read (concurrent processing)

### DIFF
--- a/python/get_sybers_dfir/ingest/prepare.py
+++ b/python/get_sybers_dfir/ingest/prepare.py
@@ -34,9 +34,18 @@ def staged_name(rel: str) -> str:
 
 
 def _records(path: str):
-    """Yield the records in a processed file — a JSON array/object, or JSON Lines."""
-    with open(path, encoding="utf-8", errors="replace") as fh:
-        raw = fh.read()
+    """Yield the records in a processed file — a JSON array/object, or JSON Lines.
+
+    Resilient to the file vanishing mid-read: a processor still running may remove
+    an empty/failed output between the loader discovering it and opening it (e.g.
+    Volatility prunes empty per-plugin files), so a missing/unreadable file yields
+    nothing rather than raising.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            raw = fh.read()
+    except OSError:
+        return
     stripped = raw.lstrip()
     if stripped[:1] == "[":
         try:

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -52,6 +52,12 @@ def test_records_array_and_jsonl(tmp_path):
     assert list(prepare._records(str(jl))) == [{"x": 1}, {"x": 2}]
 
 
+def test_records_missing_file_yields_nothing(tmp_path):
+    # a processor still running may prune an empty output between the loader
+    # discovering it and reading it — a vanished file must yield nothing, not raise.
+    assert list(prepare._records(str(tmp_path / "gone.jsonl"))) == []
+
+
 def test_zeek_wrap_skips_conn(tmp_path):
     conn = tmp_path / "conn.json"
     conn.write_text('{"id":1}\n')


### PR DESCRIPTION
Found during the validation round. Ingesting **while a processor is still running** races with the processor pruning its own empty outputs — Volatility removes an empty per-plugin `.jsonl` between the loader discovering it (`os.walk`) and opening it, raising `FileNotFoundError` and aborting the whole ingest.

`prepare._records()` now returns nothing on `OSError` instead of raising, so a file removed under concurrent processing is skipped (the in-DB ledger picks it up on a later run). Regression test added; ingest suite 12/0.

Verified live: with the fix, `--only volatility` ingested 756/757 files (the one vanished file gracefully skipped, 0 failed) mid-Volatility-run.