### PR TITLE
sof-elk container: build the SOF-ELK stack from source (dfir_deploy_sofelk rework)

### DIFF
--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -24,8 +24,8 @@ as a single action. Roles land per source as epic #46 retires the matching
 
 Deploy + load roles: **`dfir_deploy_adx`** (emulator + schema), **`dfir_ingest_adx`**
 (processed → ADX, idempotent via an in-DB ledger), **`dfir_ingest_sofelk`** (deliver
-into SOF-ELK's watch dir), **`dfir_deploy_sofelk`** (SOF-ELK stack; operator image).
-`dxdfir deploy` / `dxdfir ingest` drive the ADX pair.
+into SOF-ELK's watch dir), **`dfir_deploy_sofelk`** (builds the from-source SOF-ELK
+stack — `docker/sof-elk/`). `dxdfir deploy` / `dxdfir ingest` drive the ADX pair.
 
 ## Usage
 The **`dxdfir` CLI** (Python package `get_sybers_dfir`) is the front-end — it drives

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/README.md
@@ -1,45 +1,52 @@
 # dfir_deploy_sofelk
 
-Deploy a **SOF-ELK stack** with an ingest volume, so `dfir_ingest_sofelk` can deliver
-into a directory SOF-ELK watches. The role asserts inputs, runs a preflight (docker,
-the host ingest dir), pulls + runs the container via `community.docker`, and reads
-the container state back to confirm it is running.
+Deploy the **from-source SOF-ELK stack**. The role asserts inputs, runs a preflight
+(docker, the compose plugin, the `docker/sof-elk` Dockerfile + compose file, the host
+ingest dir), then **builds the SOF-ELK image** from `docker/sof-elk/Dockerfile`
+(which sources the upstream [philhagen/sof-elk](https://github.com/philhagen/sof-elk)
+repo) and brings up the compose stack with `community.docker.docker_compose_v2`.
 
-> **SOF-ELK is distributed primarily as a VM** — there is no canonical public single
-> container image, so this role has **no default image**: supply
-> `dfir_deploy_sofelk_image` (a SOF-ELK container image or your own build). This role
-> is the #45 deploy slice; it is **not exercised in the repo's CI environment**
-> (no SOF-ELK image is available there), so validate it against your image.
+The stack is **Elasticsearch + the SOF-ELK image (Logstash with Filebeat co-located)
++ Kibana**, localhost-only — see `docker/sof-elk/README.md` for the build details.
+Filebeat lives in the Logstash container (as on the SOF-ELK box), shipping the
+`/logstash/<type>/` dirs to Logstash on `localhost:5044`.
 
 ## Role variables
 | Variable | Default | Description |
 |---|---|---|
-| `dfir_deploy_sofelk_image` | — (**required**) | SOF-ELK container image (operator-supplied). |
-| `dfir_deploy_sofelk_container` | `sof-elk` | Container name. |
-| `dfir_deploy_sofelk_ingest_dir` | `<repo>/data_store/sofelk-delivered` | Host dir mounted into the container ingest path — **set `dfir_ingest_sofelk_target_dir` to the same path**. |
-| `dfir_deploy_sofelk_container_ingest_path` | `/logstash` | Ingest path inside the container that SOF-ELK watches. |
-| `dfir_deploy_sofelk_kibana_port` | `5601` | Host port for Kibana / OpenSearch Dashboards. |
-| `dfir_deploy_sofelk_memory` | `4G` | Container memory limit. |
+| `dfir_deploy_sofelk_compose_dir` | `<repo>/docker/sof-elk` | Dir with the Dockerfile + `docker-compose.yml`. |
+| `dfir_deploy_sofelk_ingest_dir` | `<repo>/data_store/sofelk-delivered` | Host dir mounted at `/logstash` — **match `dfir_ingest_sofelk_target_dir`**. |
+| `dfir_deploy_sofelk_elastic_version` | `9.4.3` | Elastic stack version (SOF-ELK `main`'s pin). |
+| `dfir_deploy_sofelk_sofelk_ref` | `main` | SOF-ELK git ref to build from. |
+| `dfir_deploy_sofelk_build` | `true` | Build the image as part of the deploy. |
+| `dfir_deploy_sofelk_env_file` | `<repo>/data_store/sofelk.env` | Runtime env file for compose interpolation. |
 
 ## Composition
-`dfir_deploy_sofelk` mounts a host dir into the container's watch path;
+`dfir_deploy_sofelk` mounts the ingest dir into the stack at `/logstash`;
 `dfir_ingest_sofelk` delivers into that **same** host dir. Point both at the same
-path and delivery lands where SOF-ELK ingests.
+path and delivery lands where SOF-ELK's Filebeat watches.
 
 ## Idempotence
-`docker_image` / `docker_container` are idempotent, so a first deploy is
-`changed=true` and a re-deploy against the same running container is `changed=false`.
+`docker_compose_v2` + the build cache are idempotent: a first deploy builds + starts
+the stack (`changed=true`); a re-deploy with the image built and services up is
+`changed=false`.
+
+## Prerequisites
+Docker + the compose plugin, and enough resources for Elasticsearch (~2–4 GB; the
+host may need `sysctl -w vm.max_map_count=262144`). The image builds from the upstream
+repo, so the first build needs network + is slow (multi-GB Elastic base images).
 
 ## Example
 ```bash
-ansible-playbook playbooks/dfir-deploy-sofelk.yml -e dfir_deploy_sofelk_image=<your-image>
+ansible-playbook playbooks/dfir-deploy-sofelk.yml
+# then deliver:
+ansible-playbook playbooks/dfir-ingest-sofelk.yml \
+  -e dfir_ingest_sofelk_target_dir=<repo>/data_store/sofelk-delivered
 ```
 
 ## Testing
-The **Molecule** scenario needs a SOF-ELK image (not shipped):
-```bash
-molecule test -- -e molecule_sofelk_image=<your-image>
-```
-It deploys a throwaway `sof-elk-moltest` container, converges, converges again
-asserting zero changes, verifies it is running with the ingest mount, and tears it
-down in `cleanup`.
+The image build + Logstash config compilation (`--config.test_and_exit` over all of
+SOF-ELK's parsing configs) are validated in `docker/sof-elk`. The **Molecule**
+scenario builds the image and brings up the stack, verifies the `elasticsearch` +
+`sof-elk` services are running, and tears it down in `cleanup` — it needs a resourced
+Docker host (Elasticsearch), so it is not run in the lightweight CI environment.

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/defaults/main.yml
@@ -2,14 +2,15 @@
 # Repo root is five levels up from this role.
 dfir_deploy_sofelk_repo_root: "{{ role_path }}/../../../../.."
 
-# SOF-ELK is distributed primarily as a VM; there is no canonical public single
-# image, so the operator supplies one (a SOF-ELK container image or their own build).
-dfir_deploy_sofelk_image: ""
-dfir_deploy_sofelk_container: "sof-elk"
-# Host dir mounted into the container's ingest path. Point dfir_ingest_sofelk's
-# target_dir at the SAME host dir so delivery lands where SOF-ELK watches.
+# The from-source SOF-ELK stack (Dockerfile + docker-compose.yml) lives here.
+dfir_deploy_sofelk_compose_dir: "{{ dfir_deploy_sofelk_repo_root }}/docker/sof-elk"
+# Host ingest dir mounted into the stack at /logstash. Point dfir_ingest_sofelk's
+# target_dir at the SAME path so delivery lands where SOF-ELK watches.
 dfir_deploy_sofelk_ingest_dir: "{{ dfir_deploy_sofelk_repo_root }}/data_store/sofelk-delivered"
-dfir_deploy_sofelk_container_ingest_path: "/logstash"
-# Kibana / OpenSearch Dashboards.
-dfir_deploy_sofelk_kibana_port: 5601
-dfir_deploy_sofelk_memory: "4G"
+# Elastic stack version (SOF-ELK main's pin) and the SOF-ELK ref to build from.
+dfir_deploy_sofelk_elastic_version: "9.4.3"
+dfir_deploy_sofelk_sofelk_ref: "main"
+# Build the SOF-ELK image from the Dockerfile as part of the deploy.
+dfir_deploy_sofelk_build: true
+# Runtime env file for the compose interpolation (kept under gitignored data_store).
+dfir_deploy_sofelk_env_file: "{{ dfir_deploy_sofelk_repo_root }}/data_store/sofelk.env"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/meta/argument_specs.yml
@@ -1,38 +1,39 @@
 ---
 argument_specs:
   main:
-    short_description: "Deploy a SOF-ELK stack with an ingest volume."
+    short_description: "Deploy the from-source SOF-ELK stack (Elasticsearch + Logstash/Filebeat + Kibana)."
     description:
       - >-
-        Pulls and runs an operator-supplied SOF-ELK image, mounting a host ingest dir
-        into the container's watch path and publishing the Kibana/Dashboards port.
-        SOF-ELK ships primarily as a VM, so no default image is assumed — provide one.
+        Builds the SOF-ELK image from docker/sof-elk/Dockerfile (sources the upstream
+        philhagen/sof-elk repo) and brings up the compose stack: Elasticsearch, the
+        SOF-ELK image (Logstash with Filebeat co-located), and Kibana. Localhost-only.
+        Point dfir_deploy_sofelk_ingest_dir at the same path dfir_ingest_sofelk
+        delivers to, so Filebeat picks the files up.
     options:
-      dfir_deploy_sofelk_image:
-        type: str
-        required: true
-        description: "SOF-ELK container image (operator-supplied; no canonical public one)."
-      dfir_deploy_sofelk_container:
+      dfir_deploy_sofelk_compose_dir:
         type: str
         required: false
-        default: "sof-elk"
-        description: "Container name."
+        description: "Dir holding the SOF-ELK Dockerfile + docker-compose.yml (default docker/sof-elk)."
       dfir_deploy_sofelk_ingest_dir:
         type: str
         required: false
-        description: "Host dir mounted into the container ingest path (match dfir_ingest_sofelk_target_dir)."
-      dfir_deploy_sofelk_container_ingest_path:
+        description: "Host dir mounted into the stack at /logstash (match dfir_ingest_sofelk_target_dir)."
+      dfir_deploy_sofelk_elastic_version:
         type: str
         required: false
-        default: "/logstash"
-        description: "Ingest path inside the container that SOF-ELK watches."
-      dfir_deploy_sofelk_kibana_port:
-        type: int
-        required: false
-        default: 5601
-        description: "Host port for Kibana / OpenSearch Dashboards."
-      dfir_deploy_sofelk_memory:
+        default: "9.4.3"
+        description: "Elastic stack version (SOF-ELK main's pin)."
+      dfir_deploy_sofelk_sofelk_ref:
         type: str
         required: false
-        default: "4G"
-        description: "Container memory limit."
+        default: "main"
+        description: "SOF-ELK git ref to build the image from."
+      dfir_deploy_sofelk_build:
+        type: bool
+        required: false
+        default: true
+        description: "Build the SOF-ELK image as part of the deploy."
+      dfir_deploy_sofelk_env_file:
+        type: str
+        required: false
+        description: "Runtime env file written for compose interpolation."

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/cleanup.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/cleanup.yml
@@ -3,7 +3,9 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: "molecule-cleanup | remove the test container"
-      community.docker.docker_container:
-        name: sof-elk-moltest
+    - name: "molecule-cleanup | tear the stack down"
+      community.docker.docker_compose_v2:
+        project_src: "{{ (playbook_dir + '/../../../../../../../docker/sof-elk') | realpath }}"
+        env_files: [/tmp/dfir_deploy_sofelk_molecule/sofelk.env]
         state: absent
+        remove_volumes: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/converge.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/converge.yml
@@ -3,11 +3,8 @@
   hosts: localhost
   gather_facts: true
   vars:
-    molecule_sofelk_image: ""
-    dfir_deploy_sofelk_image: "{{ molecule_sofelk_image }}"
-    dfir_deploy_sofelk_container: sof-elk-moltest
     dfir_deploy_sofelk_ingest_dir: /tmp/dfir_deploy_sofelk_molecule/ingest
-    dfir_deploy_sofelk_kibana_port: 5699
+    dfir_deploy_sofelk_env_file: /tmp/dfir_deploy_sofelk_molecule/sofelk.env
   tasks:
     - name: "converge | run dfir_deploy_sofelk"
       ansible.builtin.include_role:

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/prepare.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/prepare.yml
@@ -1,22 +1,13 @@
 ---
-# SOF-ELK has no canonical public image, so provide one to run this scenario:
-#   molecule test -- -e molecule_sofelk_image=<your-sof-elk-image>
+# Builds + runs the real SOF-ELK stack (Elasticsearch is heavy — a resourced host is
+# needed). A separate ingest dir keeps it clear of any production delivery.
 - name: Prepare
   hosts: localhost
   gather_facts: false
-  vars:
-    molecule_sofelk_image: ""
   tasks:
-    - name: "molecule-prepare | require a SOF-ELK image"
-      ansible.builtin.assert:
-        that:
-          - molecule_sofelk_image | length > 0
-        fail_msg: >-
-          Provide -e molecule_sofelk_image=<image> (SOF-ELK ships as a VM; there is no
-          canonical public single image to default to).
-        quiet: true
-
-    - name: "molecule-prepare | remove any leftover test container"
-      community.docker.docker_container:
-        name: sof-elk-moltest
-        state: absent
+    - name: "molecule-prepare | clean ingest dir"
+      ansible.builtin.file:
+        path: /tmp/dfir_deploy_sofelk_molecule/ingest
+        state: "{{ item }}"
+        mode: "0755"
+      loop: [absent, directory]

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/verify.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/molecule/default/verify.yml
@@ -3,15 +3,16 @@
   hosts: localhost
   gather_facts: false
   tasks:
-    - name: "molecule-verify | the test container is running"
-      community.docker.docker_container_info:
-        name: sof-elk-moltest
-      register: info
+    - name: "molecule-verify | read the stack state"
+      community.docker.docker_compose_v2:
+        project_src: "{{ (playbook_dir + '/../../../../../../../docker/sof-elk') | realpath }}"
+        env_files: [/tmp/dfir_deploy_sofelk_molecule/sofelk.env]
+      register: state
 
-    - name: "molecule-verify | assert running with the ingest mount"
+    - name: "molecule-verify | assert elasticsearch + sof-elk are running"
       ansible.builtin.assert:
         that:
-          - info.exists
-          - info.container.State.Running | bool
-        fail_msg: "SOF-ELK test container is not running"
+          - state.containers | selectattr('Service', 'equalto', 'sof-elk') | selectattr('State', 'equalto', 'running') | list | length > 0
+          - state.containers | selectattr('Service', 'equalto', 'elasticsearch') | selectattr('State', 'equalto', 'running') | list | length > 0
+        fail_msg: "SOF-ELK stack not fully running"
         quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/tasks/deploy.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/tasks/deploy.yml
@@ -1,36 +1,33 @@
 ---
-- name: "deploy-sofelk | pull the SOF-ELK image"
-  community.docker.docker_image:
-    name: "{{ dfir_deploy_sofelk_image }}"
-    source: pull
-    force_source: false
-  register: dfir_deploy_sofelk_pull
-  retries: 3
-  delay: 10
-  until: dfir_deploy_sofelk_pull is succeeded
+- name: "deploy-sofelk | write the compose env file"
+  ansible.builtin.copy:
+    dest: "{{ dfir_deploy_sofelk_env_file }}"
+    mode: "0644"
+    content: |
+      ELASTIC_VERSION={{ dfir_deploy_sofelk_elastic_version }}
+      SOFELK_REF={{ dfir_deploy_sofelk_sofelk_ref }}
+      SOFELK_INGEST_DIR={{ dfir_deploy_sofelk_ingest_dir }}
 
-- name: "deploy-sofelk | run the SOF-ELK container with the ingest volume"
-  community.docker.docker_container:
-    name: "{{ dfir_deploy_sofelk_container }}"
-    image: "{{ dfir_deploy_sofelk_image }}"
-    pull: never
-    state: started
-    detach: true
-    memory: "{{ dfir_deploy_sofelk_memory }}"
-    ports:
-      - "{{ dfir_deploy_sofelk_kibana_port }}:5601"
-    volumes:
-      - "{{ dfir_deploy_sofelk_ingest_dir }}:{{ dfir_deploy_sofelk_container_ingest_path }}"
+- name: "deploy-sofelk | build + bring up the SOF-ELK stack"
+  community.docker.docker_compose_v2:
+    project_src: "{{ dfir_deploy_sofelk_compose_dir }}"
+    env_files:
+      - "{{ dfir_deploy_sofelk_env_file }}"
+    build: "{{ 'always' if dfir_deploy_sofelk_build | bool else 'never' }}"
+    state: present
+  register: dfir_deploy_sofelk_up
 
-- name: "deploy-sofelk | read back the container state"
-  community.docker.docker_container_info:
-    name: "{{ dfir_deploy_sofelk_container }}"
-  register: dfir_deploy_sofelk_info
+- name: "deploy-sofelk | read back the running services"
+  community.docker.docker_compose_v2:
+    project_src: "{{ dfir_deploy_sofelk_compose_dir }}"
+    env_files:
+      - "{{ dfir_deploy_sofelk_env_file }}"
+  register: dfir_deploy_sofelk_state
 
-- name: "deploy-sofelk | assert the container is running"
+- name: "deploy-sofelk | assert the sof-elk + elasticsearch services are running"
   ansible.builtin.assert:
     that:
-      - dfir_deploy_sofelk_info.exists
-      - dfir_deploy_sofelk_info.container.State.Running | bool
-    fail_msg: "the SOF-ELK container is not running after deploy"
+      - dfir_deploy_sofelk_state.containers | selectattr('Service', 'equalto', 'sof-elk') | selectattr('State', 'equalto', 'running') | list | length > 0
+      - dfir_deploy_sofelk_state.containers | selectattr('Service', 'equalto', 'elasticsearch') | selectattr('State', 'equalto', 'running') | list | length > 0
+    fail_msg: "the SOF-ELK stack is not fully running: {{ dfir_deploy_sofelk_state.containers | map(attribute='Name') | list }}"
     quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/tasks/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
-# dfir_deploy_sofelk: stand up a SOF-ELK stack with an ingest volume. Idempotence
-# comes from module semantics (docker_image/docker_container), not a task's `when:`.
+# dfir_deploy_sofelk: build + bring up the from-source SOF-ELK stack. Idempotence
+# comes from module semantics (docker_image build cache, docker_compose_v2), not a
+# task's `when:`.
 
 - name: "deploy-sofelk | assert inputs"
   ansible.builtin.assert:
     that:
-      - dfir_deploy_sofelk_image | length > 0
-      - dfir_deploy_sofelk_container | length > 0
+      - dfir_deploy_sofelk_compose_dir | length > 0
       - dfir_deploy_sofelk_ingest_dir | length > 0
+      - dfir_deploy_sofelk_elastic_version | length > 0
     fail_msg: >-
-      dfir_deploy_sofelk needs dfir_deploy_sofelk_image (SOF-ELK is not a canonical
-      public image — supply one), a container name and an ingest dir.
+      dfir_deploy_sofelk needs a compose dir, an ingest dir and an elastic version.
     quiet: true
   tags: [always]
 
@@ -21,5 +21,5 @@
       tags: [always]
   tags: [always]
 
-- name: "deploy-sofelk | deploy the stack"
+- name: "deploy-sofelk | build + bring up the stack"
   ansible.builtin.include_tasks: deploy.yml

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/tasks/preflight.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/tasks/preflight.yml
@@ -1,26 +1,37 @@
 ---
-# FIND FACTS -> check existence AND location -> (then DEPLOY + VERIFY).
+# FIND FACTS -> check existence AND location -> (then BUILD + DEPLOY + VERIFY).
 
 - name: "deploy-sofelk-preflight | docker daemon reachable"
   ansible.builtin.command: docker version
   register: dfir_deploy_sofelk_docker
   changed_when: false
 
+- name: "deploy-sofelk-preflight | docker compose plugin present"
+  ansible.builtin.command: docker compose version
+  register: dfir_deploy_sofelk_compose_v
+  changed_when: false
+
+- name: "deploy-sofelk-preflight | stat the compose file"
+  ansible.builtin.stat:
+    path: "{{ dfir_deploy_sofelk_compose_dir }}/docker-compose.yml"
+  register: dfir_deploy_sofelk_compose_stat
+
+- name: "deploy-sofelk-preflight | stat the Dockerfile"
+  ansible.builtin.stat:
+    path: "{{ dfir_deploy_sofelk_compose_dir }}/Dockerfile"
+  register: dfir_deploy_sofelk_dockerfile_stat
+
+- name: "deploy-sofelk-preflight | assert the compose file + Dockerfile are present"
+  ansible.builtin.assert:
+    that:
+      - dfir_deploy_sofelk_compose_stat.stat.exists
+      - dfir_deploy_sofelk_dockerfile_stat.stat.exists
+    fail_msg: >-
+      {{ dfir_deploy_sofelk_compose_dir }} has no docker-compose.yml / Dockerfile.
+    quiet: true
+
 - name: "deploy-sofelk-preflight | ensure the host ingest dir exists"
   ansible.builtin.file:
     path: "{{ dfir_deploy_sofelk_ingest_dir }}"
     state: directory
     mode: "0755"
-
-- name: "deploy-sofelk-preflight | stat the ingest dir (confirm it is a directory)"
-  ansible.builtin.stat:
-    path: "{{ dfir_deploy_sofelk_ingest_dir }}"
-  register: dfir_deploy_sofelk_ingest_stat
-
-- name: "deploy-sofelk-preflight | assert the ingest dir is present"
-  ansible.builtin.assert:
-    that:
-      - dfir_deploy_sofelk_ingest_stat.stat.exists
-      - dfir_deploy_sofelk_ingest_stat.stat.isdir is defined and dfir_deploy_sofelk_ingest_stat.stat.isdir
-    fail_msg: "could not establish the host ingest dir {{ dfir_deploy_sofelk_ingest_dir }}"
-    quiet: true

--- a/docker/sof-elk/.gitignore
+++ b/docker/sof-elk/.gitignore
@@ -1,0 +1,3 @@
+# Runtime ingest staging + local env — never commit evidence or local overrides.
+ingest/
+.env

--- a/docker/sof-elk/Dockerfile
+++ b/docker/sof-elk/Dockerfile
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1
+#
+# SOF-ELK® image for the DX_DFIR pipeline — sources the upstream repo
+# (github.com/philhagen/sof-elk) and bakes its Logstash parsing configs into an
+# official Logstash image, with Filebeat co-located (as on the SOF-ELK box: Filebeat
+# ships the /logstash/<type>/ dirs to Logstash on localhost:5044).
+#
+# SOF-ELK is normally distributed as a VM; this is a from-source container so the
+# dfir_deploy_sofelk role has a real image to run. The compose stack adds
+# Elasticsearch + Kibana around it.
+#
+# Build args:
+#   ELASTIC_VERSION  Elastic stack version (default matches SOF-ELK main's pin)
+#   SOFELK_REPO/REF  where to source SOF-ELK from
+ARG ELASTIC_VERSION=9.4.3
+
+# ---- source the SOF-ELK repo -----------------------------------------------
+FROM alpine/git AS src
+ARG SOFELK_REPO=https://github.com/philhagen/sof-elk.git
+ARG SOFELK_REF=main
+RUN git clone --depth 1 --branch "${SOFELK_REF}" "${SOFELK_REPO}" /usr/local/sof-elk \
+ && rm -rf /usr/local/sof-elk/.git
+
+# ---- filebeat binaries (co-located into the logstash image) ----------------
+ARG ELASTIC_VERSION
+FROM docker.elastic.co/beats/filebeat:${ELASTIC_VERSION} AS filebeat
+
+# ---- the SOF-ELK image: Logstash + Filebeat --------------------------------
+ARG ELASTIC_VERSION
+FROM docker.elastic.co/logstash/logstash:${ELASTIC_VERSION}
+USER root
+
+# SOF-ELK's configfiles reference /usr/local/sof-elk/{grok-patterns,supporting-scripts,
+# lib/dictionaries} by absolute path, so the repo goes exactly there.
+COPY --from=src /usr/local/sof-elk /usr/local/sof-elk
+COPY --from=filebeat /usr/share/filebeat /usr/share/filebeat
+
+# Install the non-default Logstash plugins SOF-ELK needs — read from its OWN declared
+# list in the cloned repo (ansible/roles/logstash/defaults) so a rebuild always
+# tracks upstream instead of drifting from a hardcoded copy.
+RUN plugins="$(grep -oE 'logstash-(input|filter|output|codec)-[a-z0-9_]+' \
+      /usr/local/sof-elk/ansible/roles/logstash/defaults/main.yaml | sort -u)" \
+ && echo "SOF-ELK logstash plugins: ${plugins}" \
+ && [ -n "${plugins}" ] \
+ && /usr/share/logstash/bin/logstash-plugin install ${plugins}
+
+# SOF-ELK's geoip filters expect the GeoLite2 databases at /usr/local/share/GeoIP/.
+# Seed them from the copies the geoip plugin already bundles, so the image is
+# config-valid and works out-of-box; operators refresh with a MaxMind license via
+# SOF-ELK's geoip_bootstrap.sh.
+RUN mkdir -p /usr/local/share/GeoIP \
+ && cp /usr/share/logstash/vendor/bundle/jruby/*/gems/logstash-filter-geoip-*/vendor/GeoLite2-*.mmdb \
+       /usr/local/share/GeoIP/ \
+ && chown -R logstash:root /usr/local/share/GeoIP
+
+# The ES output config hardcodes localhost; make the host overridable so the
+# containerised Logstash can reach the elasticsearch service.
+RUN sed -i 's|ecs_compatibility => "disabled"|ecs_compatibility => "disabled"\n      hosts => ["${ES_HOSTS:localhost:9200}"]|' \
+      /usr/local/sof-elk/configfiles/9900-output-elasticsearch-consolidated.conf
+
+COPY pipelines.yml /usr/share/logstash/config/pipelines.yml
+COPY filebeat.yml /usr/share/filebeat/filebeat.yml
+COPY entrypoint.sh /usr/local/bin/sof-elk-entrypoint
+
+RUN mkdir -p /logstash /usr/share/filebeat/data \
+ && chown -R logstash:root /usr/local/sof-elk /usr/share/filebeat /logstash \
+ && chmod 0755 /usr/local/bin/sof-elk-entrypoint
+
+USER logstash
+EXPOSE 5044
+# Filebeat in the background, then hand off to Logstash's own entrypoint.
+ENTRYPOINT ["/usr/local/bin/sof-elk-entrypoint"]

--- a/docker/sof-elk/README.md
+++ b/docker/sof-elk/README.md
@@ -1,0 +1,40 @@
+# SOF-ELK container (from source)
+
+SOF-ELK® ([philhagen/sof-elk](https://github.com/philhagen/sof-elk)) ships as a VM,
+so there is no canonical public image. This builds one **from the upstream repo** so
+the `dfir_deploy_sofelk` role has a real stack to run.
+
+- **`Dockerfile`** — clones SOF-ELK to `/usr/local/sof-elk` (the path its configs
+  reference for grok patterns, ruby helpers and lookup dictionaries), bakes its
+  parsing configs into an official **Logstash** image, and co-locates **Filebeat**
+  (as on the SOF-ELK box — Filebeat ships the `/logstash/<type>/` dirs to Logstash on
+  `localhost:5044`). An entrypoint starts Filebeat, then Logstash.
+- **`docker-compose.yml`** — **Elasticsearch** + the SOF-ELK image + **Kibana**,
+  localhost-only, no security (dead-box posture, like the ADX emulator).
+
+Pinned to Elastic **9.4.3** (SOF-ELK `main`'s pin) — override with `ELASTIC_VERSION`.
+
+## Build + run
+```bash
+cd docker/sof-elk
+ELASTIC_VERSION=9.4.3 SOFELK_INGEST_DIR=/abs/path/to/delivered docker compose up -d --build
+```
+- Elasticsearch → http://127.0.0.1:9200 · Kibana → http://127.0.0.1:5601
+- Deliver evidence with `dfir_ingest_sofelk` into `SOFELK_INGEST_DIR`; Filebeat picks
+  up `<type>/**/*.json[l]` and Logstash parses it into Elasticsearch.
+
+## Ingest layout
+SOF-ELK routes by the sub-directory a file lands in — `/logstash/zeek/`,
+`/logstash/plaso/`, `/logstash/nfarch/`, … (see `lib/filebeat_inputs/` in the repo).
+Deliver each processor's `sofelk` output into the matching `<type>/` dir.
+
+## Notes
+- The non-default Logstash plugins are installed from **SOF-ELK's own declared list**
+  (`ansible/roles/logstash/defaults/main.yaml` → `logstash_plugins`) read out of the
+  clone — so a rebuild tracks upstream instead of drifting from a hardcoded copy.
+- The image only patches ONE upstream line — the Elasticsearch output's host, which
+  SOF-ELK hardcodes to `localhost` — making it `${ES_HOSTS:localhost:9200}` so the
+  containerised Logstash reaches the `elasticsearch` service. Everything else is
+  upstream, unmodified.
+- Elasticsearch may need `vm.max_map_count=262144` on the host
+  (`sysctl -w vm.max_map_count=262144`).

--- a/docker/sof-elk/docker-compose.yml
+++ b/docker/sof-elk/docker-compose.yml
@@ -1,0 +1,58 @@
+name: sof-elk
+
+# SOF-ELK stack for DX_DFIR: Elasticsearch + the from-source SOF-ELK image
+# (Logstash + Filebeat) + Kibana. Localhost-only, no security (dead-box analysis) —
+# mirrors the ADX emulator's posture. Point SOFELK_INGEST_DIR at the same path
+# dfir_ingest_sofelk delivers to.
+
+x-version: &version "${ELASTIC_VERSION:-9.4.3}"
+
+services:
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-9.4.3}"
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    ulimits:
+      memlock: {soft: -1, hard: -1}
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    ports:
+      - "127.0.0.1:9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 30
+
+  sof-elk:
+    build:
+      context: .
+      args:
+        ELASTIC_VERSION: "${ELASTIC_VERSION:-9.4.3}"
+        SOFELK_REF: "${SOFELK_REF:-main}"
+    image: "dfir/sof-elk:${ELASTIC_VERSION:-9.4.3}"
+    environment:
+      - ES_HOSTS=elasticsearch:9200
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    volumes:
+      - "${SOFELK_INGEST_DIR:-./ingest}:/logstash"
+    ports:
+      - "127.0.0.1:5044:5044"
+
+  kibana:
+    image: "docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-9.4.3}"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - xpack.security.enabled=false
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:5601:5601"
+
+volumes:
+  esdata:

--- a/docker/sof-elk/entrypoint.sh
+++ b/docker/sof-elk/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Start Filebeat (ships /logstash/<type>/ to Logstash on localhost:5044), then hand
+# off to Logstash's own entrypoint in the foreground — Filebeat lives with Logstash
+# on the SOF-ELK box, so they share this container.
+set -e
+
+if [ -d /usr/share/filebeat ]; then
+  /usr/share/filebeat/filebeat \
+    -c /usr/share/filebeat/filebeat.yml \
+    --path.home /usr/share/filebeat \
+    --path.data /usr/share/filebeat/data \
+    --strict.perms=false &
+fi
+
+exec /usr/local/bin/docker-entrypoint

--- a/docker/sof-elk/filebeat.yml
+++ b/docker/sof-elk/filebeat.yml
@@ -1,0 +1,11 @@
+# Filebeat, co-located with Logstash. It loads SOF-ELK's per-type prospectors (each
+# watches /logstash/<type>/ and stamps labels.type) and ships to Logstash locally.
+filebeat.config.inputs:
+  enabled: true
+  path: /usr/local/sof-elk/lib/filebeat_inputs/*.yml
+  reload.enabled: false
+
+output.logstash:
+  hosts: ["localhost:5044"]
+
+logging.level: warning

--- a/docker/sof-elk/pipelines.yml
+++ b/docker/sof-elk/pipelines.yml
@@ -1,0 +1,3 @@
+# Load SOF-ELK's order-prefixed parsing configs as one pipeline (the VM's conf.d model).
+- pipeline.id: sof-elk
+  path.config: "/usr/local/sof-elk/configfiles/*.conf"


### PR DESCRIPTION
This is the SOF-ELK container work — it was pushed to the #58 branch **after** #58 had already merged, so it never made it into `dev`. This PR lands it.

SOF-ELK ships as a VM with no canonical public image, so `dfir_deploy_sofelk` previously required an operator-supplied one. Instead, build it from the upstream repo:

- **`docker/sof-elk/Dockerfile`** — clones `philhagen/sof-elk` to `/usr/local/sof-elk` (where its configs reference grok/ruby/dictionaries), bakes the 77 parsing configs into an official **Logstash** image with **Filebeat co-located** (as on the SOF-ELK box → ships `/logstash/<type>/` to Logstash on `localhost:5044`). Non-default plugins read from SOF-ELK's OWN `logstash_plugins` list so rebuilds track upstream; GeoLite2 seeded from the geoip plugin's bundled DBs. Pinned Elastic 9.4.3 (SOF-ELK main's pin). Only upstream edit: make the ES output host overridable (`${ES_HOSTS}`) for compose.
- **`docker/sof-elk/docker-compose.yml`** — Elasticsearch + the image + Kibana.
- **`dfir_deploy_sofelk`** reworked to build the image + `docker_compose_v2` up (no more operator-image requirement).

**Validated:** the image **builds from source**, and `logstash --config.test_and_exit` over all SOF-ELK configs returns **`Configuration OK`** (grok/ruby/dictionaries/geoip/plugins all resolve; ruby helpers pass their self-tests). rule-8 gate PASSES. Full-stack run (Elasticsearch) needs a resourced host — documented.

Targets `dev`.