### PR TITLE
docs: align documentation with the dxdfir/collection rewrite (epics #45/#46)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,6 +9,11 @@ lookups), are in THIRD_PARTY_NOTICES.md. Formerly vendored components remain
 in this repository's git history, and their attributions continue to apply to
 anyone working from an older commit.
 
+The get_sybers_dfir Python package (python/) and the get_sybers.dfir Ansible
+collection (ansible/collections/) are licensed MIT, as declared in their
+pyproject.toml, galaxy.yml and role meta/main.yml files. The repository root is
+otherwise Apache-2.0 (see LICENSE).
+
 --------------------------------------------------------------------------------
 MITRE Cyber Analytics Repository (CAR)
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ functions.
 ### 📚 This Page
 
 - [Overview](#overview)
+- [How It Runs](#how-it-runs)
 - [What Actually Works](#what-actually-works)
 - [Before You Run Anything](#before-you-run-anything)
 - [Why This Exists](#why-this-exists)
@@ -78,6 +79,31 @@ instead of a pile of CSVs.
 
 That's the idea. Here's where it honestly stands.
 
+## 🧱 How It Runs
+<a name="how-it-runs"></a>
+
+The pipeline is a three-layer design (epic #46):
+
+- **`dxdfir` CLI** — the front-end (`python/`, Typer): `dxdfir process <source>`,
+  `dxdfir deploy`, `dxdfir ingest`, `dxdfir validate`, `dxdfir list` (`man dxdfir`
+  for the manual).
+- **`get_sybers.dfir` Ansible collection** — orchestration, one role per source,
+  one action per task; the CLI drives it with `ansible-playbook`.
+- **`get_sybers_dfir` Python package** — the per-item processing the roles invoke
+  (also runnable as `python -m get_sybers_dfir.<source>`).
+
+Each processor targets a backend with `--pipeline adx|sofelk`: **ADX** (the Kusto
+emulator, default) or **SOF-ELK** (`docker/sof-elk/`). `dxdfir deploy`/`ingest`
+cover the ADX pair; SOF-ELK deploy and delivery run from the collection's
+`dfir-deploy-sofelk.yml` / `dfir-ingest-sofelk.yml` playbooks.
+
+The original `process-*.sh` scripts still ship under `scripts/` — they are the
+layer the capabilities below were actually exercised with, and are retired per
+source as each role's full path is proven. The CLI additionally needs
+`ansible-playbook` on `PATH` and the package installed (`pip install ./python`, or
+`PYTHONPATH=python` for in-repo runs); `setup-environment.sh` does not install
+these yet.
+
 ## 🧪 What Actually Works
 <a name="what-actually-works"></a>
 
@@ -87,6 +113,11 @@ and interfaces may still change. What the current line buys you over the
 [pre-release line](https://github.com/Get-Sybers/DX_DFIR/tree/deprecated) is
 that the defects below are known and written down rather than waiting to be
 discovered.
+
+The **Notes** name the `process-*.sh` script that does the work; each source is
+also runnable as `dxdfir process <source>` (which drives the matching
+`dfir_<source>` role — same container, same output). The ✅/⚠️ states reflect
+hand-runs of the scripts, not the role path or any automated test.
 
 | Capability | State | Notes |
 |:---|:---|:---|

--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ lookups, splunk-ansible playbooks — since retired with the Splunk stack, but
 still in git history). Matching that licence keeps the project compatible with
 everything it has ever redistributed.
 
+**Mixed licensing.** The repository root is Apache-2.0 (above). The pipeline code
+added in the #46 rewrite is offered under the more permissive **MIT** licence as
+self-contained, reusable components: the `get_sybers_dfir` Python package
+(`python/`, per its `pyproject.toml`) and the `get_sybers.dfir` Ansible collection
+(`ansible/collections/`, per `galaxy.yml` and each role's `meta/main.yml`). MIT and
+Apache-2.0 are compatible; each subtree carries its own declared licence.
+
 Third-party components, the tools this pipeline drives, and the licensing
 obligations that fall on *you* rather than on this code are documented in
 [THIRD_PARTY_NOTICES.md](/THIRD_PARTY_NOTICES.md). Attribution required by

--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -10,8 +10,9 @@ Conforms to the Get-Sybers Ansible standards (naming/structuring + one-action-pe
 
 ## Roles
 One role per evidence source; each invokes its `get_sybers_dfir.<source>` processor
-as a single action. Roles land per source as epic #46 retires the matching
-`process-*.sh` script (`dfir_zeek` is the exemplar).
+as a single action. All six process roles exist (`dfir_zeek` was the exemplar the
+pattern was proven on); the matching `process-*.sh` script is retired per source as
+each role's full path is proven (epic #46).
 
 | Role | Source | Processor |
 |---|---|---|

--- a/docs/Containers.md
+++ b/docs/Containers.md
@@ -15,7 +15,11 @@ jasonish/suricata:latest                                     # signatures — Su
 mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest   # analysis backend (Kusto emulator)
 ```
 
-`save-docker-images.sh` pulls/saves/loads these for offline hosts.
+`save-docker-images.sh` seeds only the three long-lived images for offline hosts —
+`log2timeline/plaso`, `zeek/zeek` and the Kusto emulator. The `sk4la/volatility3`,
+`blacktop/yara` and `jasonish/suricata` images are pulled on first use by the
+memory/signature scripts (save/load them manually with `docker save`/`docker load`
+if you need them offline too).
 
 **Not containers:** **Hayabusa** ships as a self-contained Rust binary (no official
 image) — `process-signatures.sh --fetch` downloads the pinned release into

--- a/docs/Dir-Structure.md
+++ b/docs/Dir-Structure.md
@@ -1,14 +1,30 @@
 ## 🗺️ Find Your Way Around
+
+The pipeline is a three-layer design (epic #46): the **`dxdfir` CLI** (the verbs)
+drives the **`get_sybers.dfir` Ansible collection** (orchestration), which invokes
+the **`get_sybers_dfir` Python package** (the per-item processing). The original
+`process-*.sh` scripts still ship under `scripts/` and are retired per source as
+each role is proven.
+
 ```
   $DX_DFIR
-    └── scripts/                                      # Processing + emulator deploy/apply/ingest scripts
-    │   │
+    └── python/                                       # get_sybers_dfir package + the dxdfir CLI — the front-end
+    │   └── get_sybers_dfir/                          # processors (zeek/plaso/volatility/evtx/velociraptor/signatures), ingest/, cli.py
+    │   └── man/                                      # dxdfir.1 man page
+    │   └── tests/                                    # pytest unit tests (pure logic, no Docker)
+    │
+    └── ansible/collections/get_sybers.dfir/         # the Ansible collection — orchestration
+    │   └── roles/                                    # one role per source + ingest/deploy roles (adx, sofelk)
+    │   └── playbooks/                                # dfir-process-* / dfir-ingest-* / dfir-deploy-*
+    │
+    └── scripts/                                      # Legacy bash pipeline (process/deploy/apply/ingest) — being retired per #46
     │   └── lib/                                      # Shared bash libraries: docker lifecycle, Kusto REST API
     │
-    └── dev-scripts/                                  # Experimental/one-off helpers, unsupported
+    └── docker/                                       # Container builds — the from-source SOF-ELK stack (sof-elk/)
+    │
+    └── dev-scripts/                                  # Experimental/one-off helpers, unsupported (e.g. the Plaso output module)
     │
     └── kusto/                                        # The analysis backend — offline Azure Data Explorer
-    │   │
     │   └── schema/                                   # Databases, tables, ingestion mappings, MITRE CAR functions
     │
     └── tests/                                        # run-checks.sh — the check harness that gates CI
@@ -65,9 +81,11 @@
             └── velociraptor/                         # Velociraptor collector output (EZ Tools) -> host.VelociraptorJson
 ```
 
-The Splunk-era tree (`splunk/` with its eight apps, `ansible/` with the
-in-container provisioning playbooks) was retired when the SIEM moved to the
-Kusto emulator, and the KAPE automation (`processed/kape/`, the two PowerShell
-scripts) was removed in favour of the planned Velociraptor offline collectors
-running the EZ Tools. All of it survives in git history and on the frozen
+The Splunk-era tree (`splunk/` with its eight apps, and a since-removed
+in-container provisioning `ansible/` — **unrelated to today's
+`get_sybers.dfir` collection** under `ansible/collections/`) was retired when
+the SIEM moved to the Kusto emulator, and the KAPE automation
+(`processed/kape/`, the two PowerShell scripts) was removed in favour of the
+planned Velociraptor offline collectors running the EZ Tools. All of it
+survives in git history and on the frozen
 [`deprecated`](https://github.com/Get-Sybers/DX_DFIR/tree/deprecated) branch.

--- a/docs/Get-Started.md
+++ b/docs/Get-Started.md
@@ -5,6 +5,26 @@
 > note that the Kusto emulator carries licensing terms you are accepting
 > — [THIRD_PARTY_NOTICES.md](/THIRD_PARTY_NOTICES.md).
 
+### 🧭 Two ways to drive this
+
+The **`dxdfir` CLI** is the pipeline's front-end (three-layer design — see
+[How It Runs](/README.md#how-it-runs)). The numbered steps below use the underlying
+`process-*.sh` scripts directly — the layer the
+[capability states](/README.md#what-actually-works) were validated with. The CLI
+runs the same flow:
+
+```bash
+pip install ./python     # provides dxdfir (also needs ansible-playbook on PATH)
+dxdfir process plaso     # sources: plaso | zeek | evtx | volatility | velociraptor | signatures
+dxdfir deploy            # stand up the ADX (Kusto) emulator + apply schema
+dxdfir ingest            # load data_store/processed into it
+dxdfir validate          # run the repo check harness
+```
+
+`dxdfir deploy`/`ingest` target the ADX emulator; the SOF-ELK path
+(`dxdfir process <source> --pipeline sofelk`, then the `dfir-*-sofelk.yml`
+playbooks) is delivered separately. `man dxdfir` for the manual.
+
 ### ⚙️ **Step 1: Setup Environment**
 - **Run setup-environment.sh:**
   ```bash
@@ -40,7 +60,9 @@ _Refer to [📁 Dir-Structure](/docs/Dir-Structure.md) for detailed directory st
 DX_DFIR/scripts/process-log2timeline-Dynamic.sh
 ```
 - Automates forensic analysis of all `.E01` disk images and VMware VM exports using Plaso.
-- Output lands in `data_store/processed/log2timeline/csv/`, with job logs in `logs/`.
+- Output lands in `data_store/processed/log2timeline/jsonl/` (Plaso `json_line`,
+  fanned out into one `host.L2t<Parser>` table per top-level parser on ingest),
+  the `.plaso` databases in `plaso/`, and job logs in `logs/`.
 
 ### 🛜 **Step 4: Process PCAPs with Zeek**
 ```bash
@@ -116,16 +138,18 @@ DX_DFIR/scripts/apply-kusto-schema.sh
 ```bash
 DX_DFIR/scripts/ingest-kusto.sh
 ```
-- Loads `data_store/processed/` into the emulator: Plaso CSV → `host.L2tCsv`,
-  EvtxECmd JSON → `host.EvtxEcmdJson`, Zeek `conn.log` → `network.ZeekConn`.
+- Loads `data_store/processed/` into the emulator: Plaso `json_line` fanned out
+  into per-parser `host.L2t<Parser>` tables, EvtxECmd JSON → `host.EvtxEcmdJson`,
+  Zeek `conn` → `network.ZeekConn` (every other Zeek log → the generic
+  `network.Zeek`), and Volatility JSONL → `memory.VolatilityJson`.
 - The Velociraptor loader is **not implemented yet** — the table
   exists, the loader does not. The script says so rather than pretending.
   (Artefact collection is planned via Velociraptor offline collectors running
   the EZ Tools; the KAPE path was removed.)
 - Ingestion is additive with no fishbucket: re-running duplicates rows. To
   start clean, redeploy (ephemeral default) and re-ingest.
-- `--only l2t|zeek|evtx` limits to one source; `--dry-run` lists without
-  contacting anything.
+- `--only l2t|zeek|evtx|volatility|velociraptor` limits to one source;
+  `--dry-run` lists without contacting anything.
 
 ### 🔎 **Step 9: Query**
 

--- a/docs/Kusto-Port.md
+++ b/docs/Kusto-Port.md
@@ -105,7 +105,7 @@ schema, kept for the reasoning even though the Splunk side is retired.
 | Splunk | Kusto | Notes |
 |:---|:---|:---|
 | Index | **Database** | `host`, `network`, `memory`, `misc`, `mitre` → 5 databases |
-| Sourcetype | **Table** | Kusto entity names cannot contain `:`, so `l2t:csv` → `L2tCsv` |
+| Sourcetype | **Table** | Kusto entity names cannot contain `:`, so a colon-bearing sourcetype like `zeek:conn` → `ZeekConn` |
 | `props.conf INDEXED_EXTRACTIONS` | **Ingestion mapping** | CSV and JSON mappings, precreated and referenced |
 | `props.conf` FIELDALIAS / EVAL | **Function**, or update policy | See below |
 | `transforms.conf` | **Update policy** | Only where a materialised second table is wanted |
@@ -150,8 +150,8 @@ than failing halfway and leaving a partial state.
 > necessary, the data is 'coerced' into this schema during ingestion."
 
 No schema inference. Every table needs explicit DDL, which means the port has
-to decide column types for each source up front — Plaso CSV, Zeek TSV,
-EvtxECmd JSON, Velociraptor JSON. That is the bulk of Stage 2's work.
+to decide column types for each source up front — Plaso json_line, Zeek JSON,
+EvtxECmd JSON, Velociraptor and Volatility JSON. That is the bulk of Stage 2's work.
 
 One `.ingest into` locator is one file; multiple files go in one command as
 multiple locators, or via an external table over the directory.

--- a/docs/scripts/Scripts-Overview.md
+++ b/docs/scripts/Scripts-Overview.md
@@ -5,6 +5,15 @@ for **deploying, schema-loading and ingesting into the Kusto emulator** — the
 DX_DFIR pipeline. Host artefacts are collected with **Velociraptor offline
 collectors running the EZ Tools** (replacing the removed KAPE automation).
 
+> **These scripts are the legacy layer.** The pipeline's front-end is now the
+> **`dxdfir` CLI** driving the **`get_sybers.dfir` Ansible collection** (one role
+> per source) — see [How It Runs](/README.md#how-it-runs). Each `process-*.sh`
+> below has a matching `dfir_<source>` role (`dxdfir process <source>`); the
+> deploy/apply/ingest scripts map to the `dfir_deploy_adx` / `dfir_ingest_adx`
+> roles (`dxdfir deploy` / `dxdfir ingest`). Scripts are retired per source as each
+> role's full path is proven (epic #46); until then both work, and this page
+> documents the scripts.
+
 ---
 
 ## 📂 Processing scripts

--- a/docs/scripts/Setup_Environment.md
+++ b/docs/scripts/Setup_Environment.md
@@ -11,6 +11,12 @@ concern and lives in its own script, [`save-docker-images.sh`](#pre-seeding-imag
 On a host with registry access nothing further is needed — the individual
 processing scripts pull their images on first use.
 
+> **For the `dxdfir` CLI path** (the pipeline front-end): this script installs the
+> *scripts'* dependencies, not the CLI's. `dxdfir` additionally needs
+> `ansible-playbook` on `PATH` and the Python package installed
+> (`pip install ./python`, or `PYTHONPATH=python` for in-repo runs) — see
+> [How It Runs](/README.md#how-it-runs).
+
 ## Prerequisites
 - A Debian- or Ubuntu-based Linux distribution (the Docker apt repository is
   derived from `/etc/os-release`, so derivatives that declare `ID_LIKE` work too)

--- a/docs/scripts/processing_data/process-zeek-ALL.md
+++ b/docs/scripts/processing_data/process-zeek-ALL.md
@@ -23,15 +23,17 @@ The `process-zeek-ALL.sh` script automates the processing of network packet capt
 2. For each packet capture file:
    - Creates a temporary directory for initial processing
    - Runs Zeek analysis inside a Docker container
-   - Converts timestamps to ISO8601 format using zeek-cut
+   - Zeek writes JSON directly (`LogAscii::use_json=T`) with ISO-8601 timestamps
    - Saves the processed logs to a dedicated output directory
 3. Cleans up temporary files and Docker containers after processing
 
 ## Output Format
-- Each PCAP file gets its own directory of Zeek log files
-- Log files follow Zeek's standard naming conventions (conn.log, dns.log, http.log, etc.)
-- All timestamps are converted to ISO8601 format for consistency
-- Tab-separated values in each log file with field headers
+- Each PCAP file gets its own directory of Zeek logs
+- Zeek writes JSON natively (`LogAscii::use_json=T`); each log is renamed from
+  Zeek's `.log` extension to `.json` on the way out (`conn.json`, `dns.json`,
+  `http.json`, …)
+- Content is JSON, one object per line, with ISO-8601 timestamps
+  (`LogAscii::json_timestamps=JSON::TS_ISO8601`) — not TSV
 
 ## Troubleshooting
 - Check Docker is running

--- a/project-progress.md
+++ b/project-progress.md
@@ -10,6 +10,17 @@ pre-release code is frozen on the
 [`deprecated`](https://github.com/Get-Sybers/DX_DFIR/tree/deprecated)
 branch.
 
+## 🧱 Architecture (epics #45 / #46)
+
+The pipeline has been rebuilt as a three-layer stack: the **`dxdfir` CLI** →
+the **`get_sybers.dfir` Ansible collection** (one role per source) → the
+**`get_sybers_dfir` Python package**, driving two backends via
+`--pipeline adx|sofelk` (ADX / Kusto emulator + SOF-ELK). All ten roles, the CLI
+and the from-source SOF-ELK stack exist on `dev`; the one open box is **per-source
+retirement of the `process-*.sh` scripts**. The tables below track the
+processing / ingest layer (still named by the `process-*.sh` scripts the roles
+wrap) — see [How It Runs](/README.md#how-it-runs) and #46.
+
 A note on what the ticks mean, because the previous version of this board was
 generous with them:
 
@@ -31,7 +42,7 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 
 | Processing Tool / Artefact                                    | Automate Data | File Type      | Kusto Ingest | CAR Functions |
 |:--------------------------------------------------------------|:-------------:|:---------------|:------------:|:-------------:|
-| [Log2timeline](https://github.com/log2timeline/plaso)         | ✅            | csv             | ✅           |     ✅ (`file`) |
+| [Log2timeline](https://github.com/log2timeline/plaso)         | ✅            | json_line       | ✅           |     ✅ (`file`) |
 | [Zeek](https://zeek.org/)                                     | ✅            | json            | ✅ (`conn` typed + all other logs generic) | ✅ (`flow`) |
 | [WinEvent Logs](https://www.sans.org/white-papers/32949/) (EvtxECmd) | ⚠️     | evtx → json     | ✅           |     ✅ (`process`/`user_session`/`service`) |
 | Velociraptor offline collectors ([EZ Tools](https://ericzimmerman.github.io/)) | ✅ `process-velociraptor.sh` (unpack collection) | json | ✅ `host.VelociraptorJson` | ✅ (`registry`) |
@@ -144,7 +155,9 @@ Things that are broken or unsafe right now.
 ## 🔄 In Progress
 
 ### 🔹 **Documentation**
-- Update **READMEs** based on testing outcomes and any new features.
+- Align the docs with the #45/#46 rewrite — present the `dxdfir` CLI + collection
+  as the front-end and frame the `process-*.sh` scripts as the legacy layer being
+  retired (in progress).
 
 ---
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 # get_sybers_dfir
 
 The processing logic of the DX_DFIR pipeline as an importable, unit-tested Python
-package, plus the **`dfir`** command-line front-end (Typer) — the top layer of epic
+package, plus the **`dxdfir`** command-line front-end (Typer) — the top layer of epic
 #46. The heavy per-item work (container runs, JSON reshaping) lives here; the
 `get_sybers.dfir` Ansible collection orchestrates it one action per task.
 
@@ -29,10 +29,10 @@ dxdfir list                             # list processable sources
 man dxdfir                              # the manual (man/dxdfir.1)
 ```
 `process` drives the collection with `ansible-playbook` (the role's one action calls
-the matching `python -m get_sybers_dfir.<source>` for the tight loop). `ingest` /
-`deploy` / `validate` currently front the repo's shell scripts — they become roles
-in later #46 slices. The repo is auto-detected (or pass `--repo-root` /
-`$DFIR_REPO_ROOT`).
+the matching `python -m get_sybers_dfir.<source>` for the tight loop). `ingest` and
+`deploy` drive the `dfir_ingest_adx` / `dfir_deploy_adx` roles the same way;
+`validate` runs the repo's check harness (`tests/run-checks.sh`). The repo is
+auto-detected (or pass `--repo-root` / `$DFIR_REPO_ROOT`).
 
 ## Install
 ```bash

--- a/python/README.md
+++ b/python/README.md
@@ -45,5 +45,5 @@ In-repo runs need no install — set `PYTHONPATH=python` (the roles do this via
 
 ## Test
 ```bash
-cd python && PYTHONPATH=. python -m pytest        # 64 unit tests (pure logic; no docker)
+cd python && PYTHONPATH=. python -m pytest        # 81 unit tests (pure logic; no docker)
 ```

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -1,4 +1,4 @@
-"""``dfir`` — the DX_DFIR pipeline front-end (Typer).
+"""``dxdfir`` — the DX_DFIR pipeline front-end (Typer).
 
 The three layers of epic #46 meet here: this CLI holds the user-facing verbs, the
 ``get_sybers.dfir`` Ansible collection holds the orchestration (one role per source,
@@ -12,8 +12,9 @@ processing the roles invoke.
 
 ``process`` drives the collection with ``ansible-playbook`` (preflight → process →
 verify); the role's single action calls ``python -m get_sybers_dfir.<source>`` for
-the tight loop. ``ingest`` / ``deploy`` / ``validate`` currently front the repo's
-shell scripts — they become roles in later #46 slices.
+the tight loop. ``ingest`` and ``deploy`` drive the ``dfir_ingest_adx`` /
+``dfir_deploy_adx`` roles the same way; ``validate`` runs the repo's check harness
+(``tests/run-checks.sh``).
 """
 from __future__ import annotations
 

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -92,14 +92,6 @@ def _need(tool: str) -> None:
         raise typer.Exit(127)
 
 
-def _script(repo: Path, name: str) -> str:
-    p = repo / "scripts" / name
-    if not p.is_file():
-        typer.secho(f"script not found: {p}", fg=typer.colors.RED, err=True)
-        raise typer.Exit(2)
-    return str(p)
-
-
 # --------------------------------------------------------------------------- commands
 @app.command()
 def process(

--- a/python/man/dxdfir.1
+++ b/python/man/dxdfir.1
@@ -20,12 +20,13 @@ dxdfir \- DX_DFIR forensic processing pipeline front-end
 .B dxdfir ingest
 .RB [ --only
 .IR SOURCE ]
+.RB [ --force ]
+.RB [ --dry-run ]
 .br
 .B dxdfir deploy
 .RB [ --persist ]
 .RB [ --port
 .IR PORT ]
-.RB [ --no-schema ]
 .br
 .B dxdfir validate
 .br
@@ -50,12 +51,17 @@ drives a source's role with
 \(em preflight, then process, then verify \(em and the role's single action calls
 .RB \(lq python \-m get_sybers_dfir. SOURCE \(rq
 for the tight loop.
-.B ingest ,
-.B deploy
+.B ingest
 and
+.B deploy
+likewise drive roles \(em
+.B dfir_ingest_adx
+and
+.B dfir_deploy_adx
+\(em while
 .B validate
-currently front the repository's shell scripts; they become roles in later slices
-of epic #46.
+fronts the repository's check harness
+.RB ( tests/run-checks.sh ).
 .SH COMMANDS
 .TP
 .BI "process " SOURCE
@@ -66,14 +72,17 @@ Idempotent: inputs that already have output are skipped (use
 to reprocess).
 .TP
 .B ingest
-Load processed output into the ADX (Kusto) emulator (fronts
-.IR ingest-kusto.sh ).
+Load processed output into the ADX (Kusto) emulator by driving the
+.B dfir_ingest_adx
+role. Idempotent: an in-DB ledger records every loaded file, so a re-run loads
+only new files (use
+.B --force
+to re-ingest).
 .TP
 .B deploy
-Deploy the ADX (Kusto) emulator and, by default, apply the schema (fronts
-.I deploy-kusto.sh
-and
-.IR apply-kusto-schema.sh ).
+Deploy the ADX (Kusto) emulator and apply the schema by driving the
+.B dfir_deploy_adx
+role.
 .TP
 .B validate
 Run the repository check harness (fronts
@@ -117,14 +126,17 @@ Persist the emulator's data (opt-in; it is ephemeral by default).
 .TP
 .BI --port " PORT"
 Emulator port override.
-.TP
-.BR --schema " / " --no-schema
-Apply (default) or skip the schema after deploying.
 .SS ingest
 .TP
 .BI --only " SOURCE"
 Load one source only:
 .BR l2t ", " zeek ", " evtx ", " volatility ", " velociraptor .
+.TP
+.B --force
+Re-ingest files already recorded in the ledger (additive; duplicates rows).
+.TP
+.B --dry-run
+List what would be loaded; contact nothing.
 .SH ENVIRONMENT
 .TP
 .B DFIR_REPO_ROOT


### PR DESCRIPTION
## What & why

`dev` carries the completed epic **#46** rewrite (the `dxdfir` CLI, the `get_sybers.dfir` Ansible collection, the `get_sybers_dfir` Python package) and the **#45** SOF-ELK dual-output — but the docs still described only the legacy bash pipeline, and the new code's own docs had drifted from `cli.py`. This aligns the documentation with what's actually implemented on `dev`, **fixing** existing docs rather than adding parallel ones, so the tree is accurate when it reaches `main`.

## Code↔doc corrections (the new CLI/package)
- `python/man/dxdfir.1`, `cli.py` docstring, `python/README.md`: `ingest`/`deploy` **drive the `dfir_ingest_adx`/`dfir_deploy_adx` roles**, not shell scripts; removed the non-existent `--no-schema`; documented `ingest --force/--dry-run`; `dfir` → `dxdfir`; test count 64 → 81.
- `cli.py`: removed the dead `_script()` helper, orphaned when ingest/deploy moved from fronting scripts to driving roles.

## Entry / board docs reoriented (measured, not wholesale CLI-first)
- **README** — new "How It Runs" section (three-layer design, `--pipeline adx|sofelk`). Each capability's `dxdfir`/role equivalent is noted, but the ✅/⚠️ states stay on the **script** path where they were validated — the role path has not been run against a live emulator.
- **Get-Started** — a `dxdfir` quickstart (with the honest `ansible` + `pip install` caveat); fixed Plaso `csv`→`jsonl`, `L2tCsv`→per-parser `L2t<Parser>` + generic `network.Zeek`, and ingest `--only` now lists all five sources.
- **Dir-Structure** — added `python/`/`ansible/`/`docker/`; disambiguated the "`ansible/` was retired" line (it's now the collection).
- **Scripts-Overview / Setup_Environment / project-progress** — scripts framed as the legacy layer retired per source under #46; architecture summary added; `csv`→`json_line`; CLI prerequisites noted.

## Factual fixes
- `process-zeek-ALL` (JSON via `use_json=T`, not TSV/`zeek-cut`), `Containers` (3 seeded images, not 6), `Kusto-Port` (stale `L2tCsv`/formats), collection README (all six process roles exist).

## Licensing
- Documented the **MIT** licensing of the `python/` package and `get_sybers.dfir` collection (declared in `pyproject.toml`/`galaxy.yml`/role `meta/main.yml`) alongside the Apache-2.0 repo root, in the README Licence section + `NOTICE`. No code-license values changed.

## Validation
`./tests/run-checks.sh` → **103 passed / 0 failed** (includes the documentation-links check).

Docs-only; no pipeline behaviour changes (the one non-doc edit removes dead code in `cli.py`).



---
