### PR TITLE
docs: collection audit + alignment follow-ups (continues #61)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,5 +117,7 @@ GitHub and on any case-sensitive filesystem.
 
 ## Licensing of contributions
 
-By contributing you agree your work is licensed under
-[Apache-2.0](/LICENSE), the project's licence.
+By contributing you agree your work is licensed under the licence of the subtree
+you touch: **MIT** for the `python/` package and the `get_sybers.dfir` collection
+(`ansible/collections/`), and **Apache-2.0** — the repository default — everywhere
+else. See the [Licence](/README.md#licence) section.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ cover the ADX pair; SOF-ELK deploy and delivery run from the collection's
 The original `process-*.sh` scripts still ship under `scripts/` — they are the
 layer the capabilities below were actually exercised with, and are retired per
 source as each role's full path is proven. The CLI additionally needs
-`ansible-playbook` on `PATH` and the package installed (`pip install ./python`, or
-`PYTHONPATH=python` for in-repo runs); `setup-environment.sh` does not install
-these yet.
+`ansible-playbook` on `PATH` and the package installed with `pip install ./python`
+(which provides the `dxdfir` entry point and its one dependency, Typer);
+`setup-environment.sh` does not install these yet.
 
 ## 🧪 What Actually Works
 <a name="what-actually-works"></a>

--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -11,8 +11,9 @@ Conforms to the Get-Sybers Ansible standards (naming/structuring + one-action-pe
 ## Roles
 One role per evidence source; each invokes its `get_sybers_dfir.<source>` processor
 as a single action. All six process roles exist (`dfir_zeek` was the exemplar the
-pattern was proven on); the matching `process-*.sh` script is retired per source as
-each role's full path is proven (epic #46).
+pattern was proven on); the matching `process-*.sh` scripts all remain and are
+retired per source only as each role's full path is proven — none retired yet
+(epic #46).
 
 | Role | Source | Processor |
 |---|---|---|

--- a/ansible/collections/get_sybers.dfir/galaxy.yml
+++ b/ansible/collections/get_sybers.dfir/galaxy.yml
@@ -18,5 +18,5 @@ tags:
 dependencies:
   community.docker: ">=3.10.3"
 build_ignore:
-  - molecule
+  - "roles/*/molecule"
   - "*.pyc"

--- a/ansible/collections/get_sybers.dfir/galaxy.yml
+++ b/ansible/collections/get_sybers.dfir/galaxy.yml
@@ -15,6 +15,8 @@ tags:
   - dfir
   - forensics
   - security
+dependencies:
+  community.docker: ">=3.10.3"
 build_ignore:
   - molecule
   - "*.pyc"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_adx/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_adx/README.md
@@ -36,7 +36,7 @@ re-deploy against the same running cluster is `changed=false`.
 
 ## Example
 ```bash
-dxdfir deploy                       # (once the CLI's deploy is wired to this role)
+dxdfir deploy                       # drives this role
 ansible-playbook playbooks/dfir-deploy-adx.yml
 ```
 

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/README.md
@@ -45,8 +45,8 @@ ansible-playbook playbooks/dfir-ingest-sofelk.yml \
 ```
 
 ## Testing
-The image build + Logstash config compilation (`--config.test_and_exit` over all of
-SOF-ELK's parsing configs) are validated in `docker/sof-elk`. The **Molecule**
-scenario builds the image and brings up the stack, verifies the `elasticsearch` +
-`sof-elk` services are running, and tears it down in `cleanup` — it needs a resourced
-Docker host (Elasticsearch), so it is not run in the lightweight CI environment.
+The **Molecule** scenario builds the image and brings up the stack, verifies the
+`elasticsearch` + `sof-elk` services are running, and tears it down in `cleanup` — it
+needs a resourced Docker host (Elasticsearch), so it is not run in the lightweight CI
+environment. There is no automated Logstash config-compilation check; `docker/sof-elk`
+bakes SOF-ELK's own parsing configs unmodified.

--- a/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/meta/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_deploy_sofelk/meta/main.yml
@@ -4,9 +4,10 @@ galaxy_info:
   namespace: get_sybers
   author: Get-Sybers
   description: >-
-    Deploy a SOF-ELK stack (operator-supplied image) with an ingest volume, so
-    dfir_ingest_sofelk can deliver into a directory SOF-ELK watches. Runs the
-    container via community.docker.
+    Deploy the from-source SOF-ELK stack (Elasticsearch + Logstash/Filebeat +
+    Kibana) built from docker/sof-elk, with an ingest volume SOF-ELK watches, so
+    dfir_ingest_sofelk can deliver into it. Brings the stack up via
+    community.docker.docker_compose_v2.
   company: Get-Sybers
   license: MIT
   min_ansible_version: "2.15"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
@@ -26,7 +26,7 @@ argument_specs:
       dfir_evtx_sofelk_out_dir:
         type: str
         required: false
-        description: "SOF-ELK-path output dir (its Logstash watch dir)."
+        description: "SOF-ELK-path output dir (delivered into SOF-ELK by dfir_ingest_sofelk)."
       dfir_evtx_evtxecmd_dir:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_plaso/meta/argument_specs.yml
@@ -31,7 +31,7 @@ argument_specs:
       dfir_plaso_sofelk_out_dir:
         type: str
         required: false
-        description: "SOF-ELK-path output dir (its Logstash watch dir)."
+        description: "SOF-ELK-path output dir (delivered into SOF-ELK by dfir_ingest_sofelk)."
       dfir_plaso_module:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_signatures/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_signatures/README.md
@@ -9,13 +9,17 @@ as a **single action**. One `<lane>/` folder of detections under the output base
 ## Lanes
 | Lane | Input | Output |
 |---|---|---|
-| `yara` | files, mounted disk images (FUSE), process memory (Volatility `vadyarascan`) | `yara/{matches,disk,memory}.jsonl` |
+| `yara` | loose files under `raw/other_raw_data/` | `yara/matches.jsonl` |
 | `suricata` | PCAPs | `suricata/<name>.eve.jsonl` (alert + context event types) |
-| `hayabusa` | Windows Event Logs (`.evtx`), loose or from disk images | `hayabusa/timeline.jsonl` |
+| `hayabusa` | loose Windows Event Logs (`.evtx`) under `raw/` | `hayabusa/timeline.jsonl` |
 
-Disk-image mounting needs `/dev/fuse` (an LXC device-cgroup restriction blocks it by
-default); a lane that can't mount notes it and moves on — the YARA lane never
-extracts files out of images.
+> **Ported subset.** The Python processor currently runs YARA over **loose files
+> only** and Hayabusa over **loose `.evtx` only**; Suricata is fully ported.
+> Disk-image scanning (read-only FUSE mount) and memory YARA (Volatility
+> `vadyarascan`) are implemented in the bash `scripts/process-signatures.sh` but
+> **not yet ported** here — a `disk`/`memory` source records a note and produces
+> nothing. Use `process-signatures.sh` for disk/memory coverage until the port
+> lands.
 
 ## Role variables
 | Variable | Default | Description |
@@ -24,15 +28,16 @@ extracts files out of images.
 | `dfir_signatures_adx_out_dir` | `<repo>/data_store/processed/signatures` | ADX-path output base. |
 | `dfir_signatures_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/signatures` | SOF-ELK-path output base. |
 | `dfir_signatures_lanes` | `[]` (all) | Lanes to run — any of `yara`, `suricata`, `hayabusa`. |
-| `dfir_signatures_fetch` | `false` | Provision rules/binaries when online. |
+| `dfir_signatures_fetch` | `false` | Accepted for parity with the bash script; rule/binary provisioning is **not yet ported** to the Python processor (currently a no-op). |
 | `dfir_signatures_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
 | `dfir_signatures_force` | `false` | Regenerate lane outputs that already exist. |
 
 ## Rules / binaries
-Operator-supplied (or `--fetch` while online): YARA rules under
-`data_store/dependencies/yara-rules`, ET Open under `.../suricata-rules`, the Hayabusa
-binary under `.../hayabusa`. A lane with no rules/inputs notes it and produces nothing
-(not a failure).
+Operator-supplied: YARA rules under `data_store/dependencies/yara-rules`, ET Open
+under `.../suricata-rules`, the Hayabusa binary under `.../hayabusa`.
+(`dfir_signatures_fetch` / `--fetch` is a no-op in the Python processor —
+provisioning lives in the bash `process-signatures.sh`.) A lane with no rules/inputs
+notes it and produces nothing (not a failure).
 
 ## Idempotence
 A lane whose output already exists is skipped — the skip lives in the Python

--- a/ansible/collections/get_sybers.dfir/roles/dfir_signatures/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_signatures/meta/argument_specs.yml
@@ -4,11 +4,12 @@ argument_specs:
     short_description: "YARA / Suricata / Hayabusa detection lanes -> JSONL."
     description:
       - >-
-        Runs the three signature engines over the evidence (YARA over files / mounted
-        disk images / process memory; Suricata over PCAPs; Hayabusa over Windows
-        Event Logs) and writes one <lane>/ folder of detection JSONL under the output
-        dir. Idempotent: a lane whose output already exists is skipped. Disk-image
-        mounting needs /dev/fuse; a lane that can't mount notes it and moves on.
+        Runs the signature engines over the evidence and writes one <lane>/ folder of
+        detection JSONL under the output dir. As ported to Python here: YARA over loose
+        files, Suricata over PCAPs, Hayabusa over loose Windows Event Logs. Disk-image
+        and memory YARA and disk-image Hayabusa are not yet ported (they live in
+        scripts/process-signatures.sh); such a source notes it and produces nothing.
+        Idempotent: a lane whose output already exists is skipped.
     options:
       dfir_signatures_pipeline:
         type: str
@@ -23,7 +24,7 @@ argument_specs:
       dfir_signatures_sofelk_out_dir:
         type: str
         required: false
-        description: "SOF-ELK-path output base (its Logstash watch dir)."
+        description: "SOF-ELK-path output base (delivered into SOF-ELK by dfir_ingest_sofelk)."
       dfir_signatures_lanes:
         type: list
         elements: str
@@ -34,7 +35,7 @@ argument_specs:
         type: bool
         required: false
         default: false
-        description: "Provision rules/binaries when online (never in an air-gapped run)."
+        description: "Accepted for parity with the bash script; provisioning is not yet ported to the Python processor (no-op)."
       dfir_signatures_python_path:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_velociraptor/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_velociraptor/meta/argument_specs.yml
@@ -26,7 +26,7 @@ argument_specs:
       dfir_velociraptor_sofelk_out_dir:
         type: str
         required: false
-        description: "SOF-ELK-path output dir (its Logstash watch dir)."
+        description: "SOF-ELK-path output dir (delivered into SOF-ELK by dfir_ingest_sofelk)."
       dfir_velociraptor_python_path:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/README.md
@@ -14,7 +14,7 @@ action** (one container run per plugin per image happens inside Python). One
 | `dfir_volatility_memory_dir` | `<repo>/data_store/raw/memory` | Memory-image tree to process (recursed). |
 | `dfir_volatility_adx_out_dir` | `<repo>/data_store/processed/volatility` | ADX-path output. |
 | `dfir_volatility_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/volatility` | SOF-ELK-path output. |
-| `dfir_volatility_symbols_dir` | `<repo>/data_store/dependencies/volatility3-symbols` | Kernel symbol cache (`VOLATILITY_SYMBOLS`). |
+| `dfir_volatility_symbols_dir` | `<repo>/data_store/dependencies/volatility3-symbols` | Volatility 3 kernel-symbol cache (passed as `--symbols-dir`). |
 | `dfir_volatility_renderer` | `<repo>/dev-scripts/volatility/jsonl_dfir_renderer.py` | Custom JSONL renderer. |
 | `dfir_volatility_plugins_dir` | `<repo>/dev-scripts/volatility/plugins` | Custom plugins (`dfir_processes`, `dfir_registry`). |
 | `dfir_volatility_image` | `sk4la/volatility3:latest` | Volatility 3 container image. |

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/defaults/main.yml
@@ -9,7 +9,7 @@ dfir_volatility_repo_root: "{{ role_path }}/../../../../.."
 dfir_volatility_memory_dir: "{{ dfir_volatility_repo_root }}/data_store/raw/memory"
 dfir_volatility_adx_out_dir: "{{ dfir_volatility_repo_root }}/data_store/processed/volatility"
 dfir_volatility_sofelk_out_dir: "{{ dfir_volatility_repo_root }}/data_store/processed/sofelk/volatility"
-# Kernel symbol cache (VOLATILITY_SYMBOLS). Windows plugins fetch ISF tables from
+# Kernel symbol cache (passed as --symbols-dir). Windows plugins fetch ISF tables from
 # the symbol servers on first use — pre-seed this on an isolated host.
 dfir_volatility_symbols_dir: "{{ dfir_volatility_repo_root }}/data_store/dependencies/volatility3-symbols"
 # Custom renderer + plugins live in the repo (dev-scripts), mounted into the run.

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/meta/argument_specs.yml
@@ -27,11 +27,11 @@ argument_specs:
       dfir_volatility_sofelk_out_dir:
         type: str
         required: false
-        description: "SOF-ELK-path output dir (its Logstash watch dir)."
+        description: "SOF-ELK-path output dir (delivered into SOF-ELK by dfir_ingest_sofelk)."
       dfir_volatility_symbols_dir:
         type: str
         required: false
-        description: "Volatility symbol cache (VOLATILITY_SYMBOLS); pre-seed when offline."
+        description: "Volatility 3 symbol cache (passed as --symbols-dir); pre-seed when offline."
       dfir_volatility_renderer:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_zeek/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_zeek/meta/argument_specs.yml
@@ -25,7 +25,7 @@ argument_specs:
       dfir_zeek_sofelk_out_dir:
         type: str
         required: false
-        description: "SOF-ELK-path output dir (its Logstash watch dir)."
+        description: "SOF-ELK-path output dir (delivered into SOF-ELK by dfir_ingest_sofelk)."
       dfir_zeek_image:
         type: str
         required: false

--- a/data_store/README.md
+++ b/data_store/README.md
@@ -1,222 +1,80 @@
 # 📂 `data_store`
 
-This directory contains **all raw and processed forensic data** utilized within the **DX_DFIR pipeline**.
+All raw and processed forensic data for the **DX_DFIR pipeline** lives here.
+Everything under `data_store/` is gitignored deny-by-default — read
+[Before You Run Anything](/README.md#before-you-run-anything) before you commit.
 
 ---
 
 ## 📁 Directory Structure
 
+The full annotated tree (including the analysis backend) is in
+[Dir-Structure.md](/docs/Dir-Structure.md); this is the evidence-side view.
+
 ```bash
 data_store/
-   └── raw/  # Unprocessed forensic data
-   │   └── disk_images/  # Forensic disk images (E01, AFF, etc.)
-   │   │   └── your-disk-image.E01
-   │   │   └── yanother-disk-image.E01
-   │   └── pcaps/  # Packet captures (PCAP files)
-   │   │   └── yyour-network-capture.pcap
-   │   │   └── yanother-net-capture.pcapng
-   │   └── other_raw_data/  # Additional raw data sources
+   ├── raw/                        # Unprocessed evidence — you place it here
+   │   ├── disk_images/            # Disk images (.E01, .raw/.dd, .vmdk, …)
+   │   ├── pcaps/                  # Packet captures (.pcap, .pcapng)
+   │   ├── VM_files/               # VMware VM exports (one folder per VM)
+   │   ├── memory/                 # Memory captures
+   │   └── other_raw_data/         # e.g. WinEvt/<host>/*.evtx for the EVTX path
    │
-   └── processed/
-      │   └── <your-disk-image>/
-      │       └── EventLogs/
-      │       │   └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │       │   └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │       │   └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │       │   
-      │       └── FileDeletion/
-      │       │   └── yyyymmddhhmmss_RBCmd_Output.csv
-      │       │
-      │       └── FileFolderAccess/
-      │       │   └── yyyyymmddhhmmss_<SID>.automaticDestinations-ms.json
-      │       │   └── yyyyymmddhhmmss_<SID>.customDestinations-ms.json
-      │       │   └── yyyyymmddhhmmss_LECmd_Output.json
-      │       │   └── yyyyymmddhhmmss>_<your-disk-image>_<User>_NTUSER.csv
-      │       │   └── yyyyymmddhhmmss>_<your-disk-image>_<User>_UsrClass.csv
-      │       │   └── yyyyymmddhhmmss>_<your-disk-image>_<User>.<HOSTNAME>_NTUSER.csv
-      │       │   └── yyyyymmddhhmmss>_<your-disk-image>_<User>.<HOSTNAME>_UsrClass.csv 
-      │       │   └── yyyyymmddhhmmss>_<your-disk-image>_<User>_NTUSER.csv
-      │       │
-      │       └── ProgramExecution/
-      │       │   └── yyyymmddhhmmss_PECmd_Output.json
-      │       │
-      │       └── SRUMDatabase/
-      │       │   └── yyyymmddhhmmss_SrumECmd_AppResourceUseInfo_Output.csv
-      │       │   └── yyyymmddhhmmss_SrumECmd_AppTimelineProvider_Output.csv
-      │       │   └── yyyymmddhhmmss_SrumECmd_EnergyUsage_Output.csv
-      │       │   └── yyyymmddhhmmss_SrumECmd_NetworkConnections_Output.csv
-      │       │   └── yyyymmddhhmmss_SrumECmd_NetworkUsages_Output.csv
-      │       │   └── yyyymmddhhmmss_SrumECmd_PushNotifications_Output.csv
-      │       │   └── yyyymmddhhmmss_SrumECmd_vfuprov_Output.csv
-      │       │
-      │       └── Registry/
-      │       │   └── yyyymmddhhmmss/
-      │       │       └── yyyymmddhhmmss_FileExts_Users_<User>.mfa_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_LastVisitedPidlMRU_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_UserAssist_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_CIDSizeMRU_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_FileExts_Users_.NET v4.5 Classic_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_FileExts_Users_.NET v4.5_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_FileExts_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_OpenSavePidlMRU_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_RecentDocs_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_Taskband_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_TaskCache_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_TaskCache_Windows_System32_config_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_TypedURLs_Users_<User>.<HOSTNAME>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_WindowsPortableDevices_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_WindowsPortableDevices_Windows_System32_config_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_AllRegExecutablesFoundOrRun_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_BasicSystemInfo_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_InstalledSoftware_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_Kroll_Batch_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_RECmd_Batch_MC_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_RegistryASEPs_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_SoftwareASEPs_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_SoftwareClassesASEPs_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_SoftwareWoW6432ASEPs_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_SystemASEPs_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_UserActivity_Output.csv
-      │       │       └── yyyymmddhhmmss_RECmd_Batch_UserClassesASEPs_Output.csv
-      │       │       └── yyyymmddhhmmss_AppCompatFlags_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_AppCompatFlags_Windows_System32_config_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_MountedDevices_Windows_System32_config_RegBack_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_MountedDevices_Windows_System32_config_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_TimeZoneInfo_Windows_System32_config_RegBack_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_TimeZoneInfo_Windows_System32_config_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_AppPaths_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_AppPaths_Windows_System32_config_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_DeviceClasses_Windows_System32_config_RegBack_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_DeviceClasses_Windows_System32_config_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_FirstFolder_Users_<User>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_KnownNetworks_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_KnownNetworks_Windows_System32_config_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_ProfileList_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_ProfileList_Windows_System32_config_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_Services_Windows_System32_config_RegBack_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_Services_Windows_System32_config_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_TerminalServerClient_Users_<User>_NTUSER.DAT.csv
-      │       │       └── yyyymmddhhmmss_UnInstall_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_UnInstall_Windows_System32_config_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_USB_Windows_System32_config_RegBack_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_USB_Windows_System32_config_SYSTEM.csv
-      │       │       └── yyyymmddhhmmss_UserAccounts_Windows_System32_config_RegBack_SAM.csv
-      │       │       └── yyyymmddhhmmss_UserAccounts_Windows_System32_config_SAM.csv
-      │       │       └── yyyymmddhhmmss_VolumeInfoCache_Windows_System32_config_RegBack_SOFTWARE.csv
-      │       │       └── yyyymmddhhmmss_VolumeInfoCache_Windows_System32_config_SOFTWARE.csv
-      │       │
-      │       └── SOF-ELK/
-      │           └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │           └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │           └── yyyymmddhhmmss_LECmd_Output.json
-      │           └── yyyymmddhhmmss_PECmd_Output.json
-      │           └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │           └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │           └── yyyymmddhhmmss_LECmd_Output.json
-      │           └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │           └── yyyymmddhhmmss_EvtxECmd_Output.json
-      │           └── yyyymmddhhmmss_PECmd_Output.json
-      │       
-      └── linux_logs/
-      │   └── linux_logs/
-      │
-      └── log2timeline
-      │   └── csv/
-      │   │   └── <your-disk-image>.csv
-      │   │   └── <your-disk-image>.csv
-      │   │   └── <your-disk-image>.csv
-      │   │ 
-      │   └── logs/
-      │       └── <your-disk-image>.log
-      │       └── <your-disk-image>.log
-      │       └── <your-disk-image>.log
-      │      
-      └── zeek/
-      │   └── your-pcap-filename/
-      │       └── packet_filter.log
-      │       └── weird.log
-      │       └── tunnel.log
-      │       └── ssl.log
-      │       └── dns.log
-      │       └── x509.log
-      │       └── ocsp.log
-      │       └── files.log
-      │       └── smb_mapping.log
-      │       └── http.log
-      │       └── analyzer.log
-      │       └── dpd.log
-      │       └── conn.log
-      │       └── dce_rpc.log
-      │       └── kerberos.log
-      │       └── ldap_search.log
-      │       └── ldap.log
-      │       └── ntlm.log
-      │       └── smb_files.log
-      │       └── ntp.log
-      │       └── dhcp.log
-      │       └── rdp.log
-      │       └── pe.log
-      │       └── socks.log
-      │ 
-      └── zimmerman/
-      │
-      └── csv/
-      │   └── csv-file.csv
-      │
-      └── json/
-         └── json-file.json
+   ├── dependencies/               # Operator-supplied tools (e.g. EvtxECmd)
+   │
+   └── processed/                  # Ingest-ready output, one subtree per source
+       ├── log2timeline/
+       │   ├── plaso/              # .plaso databases (reusable by Timesketch / SOF-ELK)
+       │   ├── jsonl/              # Plaso json_line  -> host.L2t<Parser> (one table per parser)
+       │   └── logs/               # Job logs
+       ├── windows_logs/           # EvtxECmd JSON     -> host.EvtxEcmdJson
+       ├── zeek/<capture>/         # Zeek JSON (conn.json, dns.json, …) -> network.ZeekConn + network.Zeek
+       ├── volatility/<image>/     # Volatility 3 JSONL per plugin      -> memory.VolatilityJson
+       ├── velociraptor/           # Velociraptor collector JSON        -> host.VelociraptorJson
+       ├── signatures/             # yara/ suricata/ hayabusa/ detection JSONL
+       ├── linux_logs/             # syslog/auth/utmp/… (not yet wired into the backend)
+       └── sofelk/<tool>/          # --pipeline sofelk output, delivered into SOF-ELK
 ```
 
 ---
 
 ## 🛠️ Usage & Workflow
 
-### 1️⃣ **Place Raw Data**
+**1. Place raw evidence** in the matching `raw/` subdirectory above.
 
-- **Disk Images**: Place `.E01` or similar forensic disk images into:
-  ```bash
-  data_store/raw/disk_images/
-  ```
+**2. Process it.** The `dxdfir` CLI is the front-end (see
+[How It Runs](/README.md#how-it-runs)); each source also has a legacy
+`process-*.sh` script:
 
-- **Network Captures**: Place `.pcap` and `.pcapng` files into:
-  ```bash
-  data_store/raw/pcaps/
-  ```
+```bash
+dxdfir process plaso        # disk images / VM exports   (or ./scripts/process-log2timeline-Dynamic.sh)
+dxdfir process zeek         # pcaps                       (or ./scripts/process-zeek-ALL.sh)
+dxdfir process evtx         # Windows event logs          (or ./scripts/process-evtx-EvtxECmd.sh)
+dxdfir process volatility   # memory                      (or ./scripts/process-volatility.sh)
+dxdfir process velociraptor # Velociraptor collections    (or ./scripts/process-velociraptor.sh)
+dxdfir process signatures   # yara / suricata / hayabusa  (or ./scripts/process-signatures.sh)
+```
 
-- **Other Data Sources**: Store any additional raw files in:
-  ```bash
-  data_store/raw/other_raw_data/
-  ```
+Add `--pipeline sofelk` to target the SOF-ELK backend instead of ADX (output
+lands under `processed/sofelk/<tool>/`).
 
-### 2️⃣ **Data Processing**
+**3. Load into the analysis backend** (ADX / Kusto emulator):
 
-- **Forensic Images**: Execute the following script to process disk images:
-  ```bash
-  ./scripts/process-log2timeline-Dynamic.sh
-  ```
-  Processed outputs are stored in `processed/log2timeline/csv/`, with job logs in `processed/log2timeline/logs/`.
+```bash
+dxdfir deploy               # stand up the emulator + apply schema
+dxdfir ingest               # load data_store/processed into it
+```
 
-- **Network Captures**: Execute the following script for packet analysis:
-  ```bash
-  ./scripts/process-zeek-ALL.sh
-  ```
-  Zeek outputs are stored in `processed/zeek/`.
-
-### 3️⃣ **Load into the analysis backend**
-
-- Load processed data into the Kusto emulator for analysis in KQL:
-  ```bash
-  ./scripts/deploy-kusto.sh          # once
-  ./scripts/apply-kusto-schema.sh    # once per deploy
-  ./scripts/ingest-kusto.sh          # after each processing run
-  ```
+The equivalent scripts are `./scripts/deploy-kusto.sh`,
+`./scripts/apply-kusto-schema.sh` and `./scripts/ingest-kusto.sh`.
 
 ---
 
 ## ⚠️ Notes
 
-- **Ensure data integrity** when moving forensic images (`E01`)—always verify hashes.
-- **Processed data should be version-controlled** where possible to track changes.
-- **Naming conventions should be followed** for consistency across ingestion and processing.
+- **Verify hashes** when moving forensic images (`.E01`).
+- **Never commit evidence.** `data_store/` is gitignored deny-by-default, but it
+  is a safety net, not a guarantee — check `git status` before every commit.
+- Follow the layout above so ingest finds each source.
 
 🚀 **Stay organized, process efficiently, and hunt smart!**

--- a/docker/sof-elk/README.md
+++ b/docker/sof-elk/README.md
@@ -32,6 +32,10 @@ Deliver each processor's `sofelk` output into the matching `<type>/` dir.
 - The non-default Logstash plugins are installed from **SOF-ELK's own declared list**
   (`ansible/roles/logstash/defaults/main.yaml` → `logstash_plugins`) read out of the
   clone — so a rebuild tracks upstream instead of drifting from a hardcoded copy.
+- **GeoLite2 databases are seeded** into `/usr/local/share/GeoIP/` (where SOF-ELK's
+  geoip filters expect them) from the copies the `logstash-filter-geoip` plugin
+  already bundles, so the image is config-valid out of the box; refresh them with a
+  MaxMind licence via SOF-ELK's `geoip_bootstrap.sh`.
 - The image only patches ONE upstream line — the Elasticsearch output's host, which
   SOF-ELK hardcodes to `localhost` — making it `${ES_HOSTS:localhost:9200}` so the
   containerised Logstash reaches the `elasticsearch` service. Everything else is

--- a/docs/Get-Started.md
+++ b/docs/Get-Started.md
@@ -21,9 +21,10 @@ dxdfir ingest            # load data_store/processed into it
 dxdfir validate          # run the repo check harness
 ```
 
-`dxdfir deploy`/`ingest` target the ADX emulator; the SOF-ELK path
-(`dxdfir process <source> --pipeline sofelk`, then the `dfir-*-sofelk.yml`
-playbooks) is delivered separately. `man dxdfir` for the manual.
+`dxdfir deploy`/`ingest` target the ADX emulator; the SOF-ELK path is
+`dxdfir process <source> --pipeline sofelk`, then the collection's
+`dfir-deploy-sofelk.yml` / `dfir-ingest-sofelk.yml` playbooks. `man dxdfir` for
+the manual.
 
 ### ⚙️ **Step 1: Setup Environment**
 - **Run setup-environment.sh:**
@@ -141,11 +142,12 @@ DX_DFIR/scripts/ingest-kusto.sh
 - Loads `data_store/processed/` into the emulator: Plaso `json_line` fanned out
   into per-parser `host.L2t<Parser>` tables, EvtxECmd JSON → `host.EvtxEcmdJson`,
   Zeek `conn` → `network.ZeekConn` (every other Zeek log → the generic
-  `network.Zeek`), and Volatility JSONL → `memory.VolatilityJson`.
-- The Velociraptor loader is **not implemented yet** — the table
-  exists, the loader does not. The script says so rather than pretending.
-  (Artefact collection is planned via Velociraptor offline collectors running
-  the EZ Tools; the KAPE path was removed.)
+  `network.Zeek`), Volatility JSONL → `memory.VolatilityJson`, and Velociraptor
+  JSON → `host.VelociraptorJson` (each record wrapped with its `Artefact`/`SourceFile`).
+- The Velociraptor **ingest** loader is wired; what's still partial is the
+  **upstream** collection path — the Velociraptor offline collectors running the
+  EZ Tools (the KAPE replacement) aren't built yet, so in practice there is
+  usually no processed Velociraptor data to load.
 - Ingestion is additive with no fishbucket: re-running duplicates rows. To
   start clean, redeploy (ephemeral default) and re-ingest.
 - `--only l2t|zeek|evtx|volatility|velociraptor` limits to one source;

--- a/docs/Kusto-Port.md
+++ b/docs/Kusto-Port.md
@@ -106,7 +106,7 @@ schema, kept for the reasoning even though the Splunk side is retired.
 |:---|:---|:---|
 | Index | **Database** | `host`, `network`, `memory`, `misc`, `mitre` → 5 databases |
 | Sourcetype | **Table** | Kusto entity names cannot contain `:`, so a colon-bearing sourcetype like `zeek:conn` → `ZeekConn` |
-| `props.conf INDEXED_EXTRACTIONS` | **Ingestion mapping** | CSV and JSON mappings, precreated and referenced |
+| `props.conf INDEXED_EXTRACTIONS` | **Ingestion mapping** | JSON ingestion mappings, precreated and referenced |
 | `props.conf` FIELDALIAS / EVAL | **Function**, or update policy | See below |
 | `transforms.conf` | **Update policy** | Only where a materialised second table is wanted |
 | `inputs.conf` monitor stanza | `.ingest into` | No monitoring. Batch, script-driven |

--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -9,6 +9,14 @@ types populate. It also records the defects the live run surfaced — every one
 of them a "parsed in review, failed the moment it ran" bug that no fake could
 have caught.
 
+> **This records the pre-refactor run.** The schema then had a single
+> `host.L2tCsv` table and the pipeline was script-driven. Plaso now emits
+> `json_line` into per-parser `host.L2t<Parser>` tables, and processing/ingest
+> moved to the `dxdfir` CLI + `get_sybers.dfir` collection (epic #46).
+> Re-validating host + network after those refactors is
+> [issue #44](https://github.com/Get-Sybers/DX_DFIR/issues/44) — so read the
+> `L2tCsv` table names below as of this run, not the current schema.
+
 > **What ran against real tooling vs. what was validated with a fixture.**
 > This distinction is load-bearing and is kept honest throughout:
 >

--- a/docs/scripts/Scripts-Overview.md
+++ b/docs/scripts/Scripts-Overview.md
@@ -11,8 +11,8 @@ collectors running the EZ Tools** (replacing the removed KAPE automation).
 > below has a matching `dfir_<source>` role (`dxdfir process <source>`); the
 > deploy/apply/ingest scripts map to the `dfir_deploy_adx` / `dfir_ingest_adx`
 > roles (`dxdfir deploy` / `dxdfir ingest`). Scripts are retired per source as each
-> role's full path is proven (epic #46); until then both work, and this page
-> documents the scripts.
+> role's full path is proven (epic #46); until then both are available, and this
+> page documents the scripts.
 
 ---
 

--- a/docs/scripts/Setup_Environment.md
+++ b/docs/scripts/Setup_Environment.md
@@ -13,8 +13,8 @@ processing scripts pull their images on first use.
 
 > **For the `dxdfir` CLI path** (the pipeline front-end): this script installs the
 > *scripts'* dependencies, not the CLI's. `dxdfir` additionally needs
-> `ansible-playbook` on `PATH` and the Python package installed
-> (`pip install ./python`, or `PYTHONPATH=python` for in-repo runs) — see
+> `ansible-playbook` on `PATH` and the Python package installed with
+> `pip install ./python` (which provides the `dxdfir` command and Typer) — see
 > [How It Runs](/README.md#how-it-runs).
 
 ## Prerequisites

--- a/project-progress.md
+++ b/project-progress.md
@@ -119,7 +119,9 @@ Things that are broken or unsafe right now.
   below and is worth more than any further code —
   [issue #14](https://github.com/Get-Sybers/DX_DFIR/issues/14) is the ranked
   checklist.
-- ⬜ Velociraptor ingestion. The table exists; the loader does not populate it.
+- ⬜ Velociraptor: the ingest loader is wired (`host.VelociraptorJson` via
+  `velociraptor_prepare`), but the upstream offline-collector path that feeds it
+  isn't built, and nothing has run against a real emulator.
 
 ### 🔹 **Data Models & MITRE CAR Mapping**
 - Validate the CAR field mappings against real Windows event logs, Zeek logs,

--- a/python/README.md
+++ b/python/README.md
@@ -21,7 +21,7 @@ Every processor prints a machine-readable JSON summary (`processed`/`skipped`/
 ## The `dxdfir` CLI
 ```bash
 dxdfir process zeek --pipeline adx      # drive the dfir_zeek role (preflight → process → verify)
-dxdfir process signatures -e dfir_signatures_lanes='["yara"]'
+dxdfir process signatures -e '{"dfir_signatures_lanes":["yara"]}'
 dxdfir ingest --only zeek               # load processed output into the ADX emulator
 dxdfir deploy                           # stand up + schema-load the emulator
 dxdfir validate                         # run the check harness

--- a/python/get_sybers_dfir/signatures/hayabusa.py
+++ b/python/get_sybers_dfir/signatures/hayabusa.py
@@ -1,11 +1,14 @@
 """Hayabusa lane — Sigma-based Windows event-log detection -> native JSONL.
 
-EVTX come from loose ``*.evtx`` under the raw tree and from disk images (mount
-read-only and scan winevt\\Logs in place when /dev/fuse is available; otherwise a
-TARGETED image_export of ONLY the event logs, scoped to Hayabusa, since its ``-J``
-JSON input yields 0 detections on Plaso/evtx_dump JSON vs 792 natively, #1324).
+Scans loose ``*.evtx`` under the raw tree. Disk-image EVTX (mount read-only and scan
+winevt\\Logs in place, or a targeted image_export of only the event logs) is NOT YET
+PORTED here — an image with no reachable EVTX records a note only; the working
+implementation is in scripts/signatures/hayabusa.sh. (Hayabusa's ``-J`` JSON input
+yields 0 detections on Plaso/evtx_dump JSON vs 792 natively, #1324, so real .evtx is
+required.)
 
-Native Rust binary (no official image); operator-supplied or ``--fetch``ed.
+Native Rust binary (no official image); operator-supplied. ``--fetch`` is accepted
+for parity with the bash script but not yet implemented here.
 """
 from __future__ import annotations
 

--- a/python/get_sybers_dfir/signatures/yara.py
+++ b/python/get_sybers_dfir/signatures/yara.py
@@ -1,14 +1,17 @@
-"""YARA lane — scan files / mounted disk images / process memory with a ruleset.
+"""YARA lane — scan a ruleset against evidence.
 
-Sources (YARA_SOURCES, default all three):
-  files   loose files                          -> matches.jsonl
-  disk    disk images MOUNTED read-only, in place (ewfmount+ntfs-3g via FUSE; needs
-          /dev/fuse) -> disk.jsonl. Never extracts files; skips if the host can't mount.
-  memory  process memory THROUGH Volatility 3 (windows.vadyarascan) -> memory.jsonl
+Sources (default all three):
+  files   loose files                          -> matches.jsonl   (implemented)
+  disk    disk images mounted read-only in place (ewfmount+ntfs-3g via FUSE) ->
+          disk.jsonl      -- NOT YET PORTED: records a note only; the working
+          implementation is in scripts/signatures/yara.sh
+  memory  process memory via Volatility 3 (windows.vadyarascan) -> memory.jsonl
+                          -- NOT YET PORTED: note only; see yara.sh
 
-YARA has no JSON output and the container's recursive scan hangs, so file/disk scans
-loop per-file inside ONE container (per-file scans print strings) and the stable text
-form is parsed here. Each match is a self-describing JSON object.
+YARA has no JSON output and the container's recursive scan hangs, so the file scan
+loops per-file inside ONE container (per-file scans print strings) and the stable text
+form is parsed here. Each match is a self-describing JSON object. parse_vadyarascan()
+exists (and is unit-tested) for when the memory source is wired up.
 """
 from __future__ import annotations
 

--- a/python/man/dxdfir.1
+++ b/python/man/dxdfir.1
@@ -126,6 +126,14 @@ Persist the emulator's data (opt-in; it is ephemeral by default).
 .TP
 .BI --port " PORT"
 Emulator port override.
+.TP
+.BR --repo-root " " \fIPATH\fR ", " --extra-var ", " -e " " \fIKEY=VALUE\fR
+As for
+.B process
+above; use
+.B -e
+to override role variables (e.g.
+.IR dfir_deploy_adx_host ).
 .SS ingest
 .TP
 .BI --only " SOURCE"
@@ -137,6 +145,11 @@ Re-ingest files already recorded in the ledger (additive; duplicates rows).
 .TP
 .B --dry-run
 List what would be loaded; contact nothing.
+.TP
+.BR --repo-root " " \fIPATH\fR ", " --extra-var ", " -e " " \fIKEY=VALUE\fR
+As for
+.B process
+above.
 .SH ENVIRONMENT
 .TP
 .B DFIR_REPO_ROOT
@@ -147,7 +160,7 @@ directory, then from the installed package's location.
 .TP
 .B ANSIBLE_ROLES_PATH
 Set by
-.B process
+.BR process ", " ingest " and " deploy
 to the collection's roles directory so the roles resolve without installing the
 collection.
 .SH EXIT STATUS

--- a/python/man/dxdfir.1
+++ b/python/man/dxdfir.1
@@ -118,7 +118,7 @@ Pass an extra Ansible variable through to the role; repeatable. Use it to overri
 a role default, e.g.
 .RB \(lq -e\  dfir_zeek_pcap_dir=/evidence/pcaps \(rq
 or
-.RB \(lq -e\  dfir_signatures_lanes=[\(dqyara\(dq] \(rq.
+.RB \(lq -e\  \(aq{\(dqdfir_signatures_lanes\(dq:[\(dqyara\(dq]}\(aq \(rq.
 .SS deploy
 .TP
 .B --persist
@@ -184,7 +184,7 @@ Reprocess memory images, overriding the input directory:
 .B dxdfir process volatility --force -e dfir_volatility_memory_dir=/evidence/mem
 .TP
 Run only the YARA signature lane:
-.B dxdfir process signatures -e dfir_signatures_lanes=[\(dqyara\(dq]
+.B dxdfir process signatures -e \(aq{\(dqdfir_signatures_lanes\(dq:[\(dqyara\(dq]}\(aq
 .TP
 Stand up the emulator, then load Zeek output:
 .B dxdfir deploy && dxdfir ingest --only zeek


### PR DESCRIPTION
## What & why

**PR #61 was merged at commit `aeafdca`** — but five commits of docs-alignment work landed on the branch *after* that point, so they never reached `dev`. This PR carries them forward, plus a few small cleanups. It matters: without it, `dev` still has the KAPE-era `data_store/README.md` and the `dfir_signatures` docs still claim disk/memory coverage the Python code doesn't have.

Docs-only, plus two module docstrings and two `galaxy.yml`/`meta` metadata lines; repo checks green.

### Recovered from after the #61 merge point
- **`data_store/README.md`** — rewritten from the removed KAPE/EZ-tools `processed/<image>/…` tree + `csv/` + Zeek `.log` to the real per-source `processed/` layout (the inconsistency Copilot flagged on #61).
- **Fable review fixes** — the Velociraptor *ingest* loader is wired (`host.VelociraptorJson` via `velociraptor_prepare`), so the "not implemented" contradiction is gone; `pip install ./python` is required for the CLI (`PYTHONPATH` alone doesn't give you `dxdfir`); man-page `ANSIBLE_ROLES_PATH` + ingest/deploy flags; the SOF-ELK playbooks exist today.
- **Collection audit (Fable)** — the big one: `get_sybers_dfir.signatures` does **files-only YARA + loose-EVTX-only Hayabusa + Suricata**; disk/memory YARA, disk-image Hayabusa and rule `--fetch` are **not yet ported** from the bash script (role docs + `yara.py`/`hayabusa.py` docstrings corrected). Also: dropped a `--config.test_and_exit` claim that exists nowhere; fixed `dfir_deploy_sofelk`'s stale galaxy meta; **declared the `community.docker` dependency in `galaxy.yml`**; fixed a broken `-e` list example (JSON-dict form) in the man page + `python/README`; six specs' "watch dir" wording; the `VOLATILITY_SYMBOLS` misnomer.
- **`Runtime-Validation.md`** — header note that it records the pre-refactor `L2tCsv` run (#44 is the re-validation).

### Small cleanups
- `galaxy.yml` → `build_ignore: roles/*/molecule` (bare `molecule` didn't exclude the per-role molecule dirs/fixtures from the built artifact).
- `docker/sof-elk/README.md` — note the image seeds GeoLite2 into `/usr/local/share/GeoIP`.
- `CONTRIBUTING.md` — contributions follow each subtree's licence (MIT for `python/` + the collection, Apache-2.0 elsewhere), matching the documented split. **Flag:** this touches the contribution-licence wording — revert if you'd rather keep it uniformly Apache-2.0.

## Validation
`./tests/run-checks.sh` → **103 passed / 0 failed** (documentation-links included).



---
