### PR TITLE
dfir_evtx: bundled dfir/evtxecmd image + real-log validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ hand-runs of the scripts, not the role path or any automated test.
 | VMware VM exports → Plaso | ✅ Works | Added recently, lightly tested |
 | PCAP → Zeek JSON logs | ✅ Works | `process-zeek-ALL.sh`; `use_json=T`, ISO8601 timestamps |
 | Zeek → Kusto (all log types) | ✅ Works | `conn` typed into `ZeekConn` by JSON path; every other log into the generic `Zeek` table |
-| Raw EVTX → EvtxECmd JSON | ⚠️ Built, untested | `process-evtx-EvtxECmd.sh`; operator-supplied EvtxECmd (MIT). **Never run against a real event log** |
+| Raw EVTX → EvtxECmd JSON → CAR | ✅ Run on real logs | `dfir_evtx` role; bundled `dfir/evtxecmd` image (MIT, or operator-supplied). Validated on 103 real logs carved from the LoneWolf image — 55,638 rows into `host.EvtxEcmdJson`, feeding `CarUserSession`/`CarProcess`/`CarService` (real 4624/4688/7045) |
 | Sysmon → EvtxECmd JSON → CAR | ✅ Mapping validated (fixtures) | Rides the EvtxECmd path; sources `driver`/`module`/`thread` and enriches `process`/`flow`/`registry`/`file`. Engine not run here (no Sysmon log in corpus) |
 | Velociraptor offline collectors (EZ Tools) | ❌ Not started | **The planned artefact-collection path, replacing the removed KAPE automation** — same Zimmerman parsers, no Kroll licence constraint |
 | Velociraptor processing | ⚠️ Partial | Normalisation script exists |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -110,11 +110,12 @@ repository.**
 | [Plaso / log2timeline](https://github.com/log2timeline/plaso) | `log2timeline/plaso:latest` container | Apache-2.0 | None |
 | [Zeek](https://zeek.org/) | `zeek/zeek:latest` container | BSD-3-Clause | None |
 | [Azure Data Explorer Kusto emulator](https://learn.microsoft.com/en-us/azure/data-explorer/kusto-emulator-overview) | `mcr.microsoft.com/azuredataexplorer/kustainer-linux:latest` container — **the analysis backend** | **Proprietary** — Microsoft Software License Terms | See below |
-| [EvtxECmd](https://github.com/EricZimmerman/evtx) | `scripts/process-evtx-EvtxECmd.sh` runs operator-supplied `EvtxECmd.dll` in a .NET container | **MIT** | None — no commercial-use restriction |
+| [EvtxECmd](https://github.com/EricZimmerman/evtx) | `get_sybers_dfir.evtx` runs `EvtxECmd.dll` in a .NET container — either the bundled `dfir/evtxecmd` image (`docker/evtxecmd`, fetches the release at build time) or an operator-supplied release | **MIT** | None — no commercial-use restriction |
 | [Velociraptor](https://github.com/Velocidex/velociraptor) | JSON output normalised by `dev-scripts/`; Kusto loader not yet implemented | AGPL-3.0 | None — output ingestion does not trigger AGPL |
 
 No tool binaries are vendored in this repository — every tool above is either
-pulled as a container image or supplied by the operator.
+pulled as a container image, fetched at image-build time from its upstream release
+(e.g. `docker/evtxecmd`), or supplied by the operator.
 
 **Formerly invoked: KAPE** (Kroll Artifact Parser and Extractor). The KAPE
 PowerShell automation was removed in favour of the planned **Velociraptor

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/README.md
@@ -2,10 +2,30 @@
 
 Parse **Windows Event Logs (`.evtx`)** with **EvtxECmd** into normalised JSON for
 the ADX or SOF-ELK pipeline. The role is structure only — it asserts inputs, runs a
-preflight (docker, input dir, **the operator-supplied `EvtxECmd.dll`**), then invokes
-the `get_sybers_dfir.evtx` Python processor as a **single action** (one dotnet
+preflight (docker, input dir, **the EvtxECmd image or operator-supplied release**),
+then invokes the `get_sybers_dfir.evtx` Python processor as a **single action** (one
 container run per log happens inside Python). One `<base>_EvtxECmd_Output.json` per
 log (+ an `.xml` sidecar, not ingested), grouped by the source sub-dir (host).
+
+## Supplying EvtxECmd — two modes
+Selected by `dfir_evtx_use_bundled_image` (default **bundled**):
+
+- **Bundled (default).** The `dfir/evtxecmd` image (built from
+  [`docker/evtxecmd`](/docker/evtxecmd)) bakes `EvtxECmd.dll` **and `Maps/`** onto a
+  .NET runtime. Build it once and forget it — no files to place by hand:
+  ```bash
+  docker build -t dfir/evtxecmd:latest docker/evtxecmd
+  ```
+- **Operator-supplied.** Set `dfir_evtx_use_bundled_image=false` and drop the .NET
+  EvtxECmd release (incl. `Maps/`) under `dfir_evtx_evtxecmd_dir`. Download it from
+  <https://github.com/EricZimmerman/evtx/releases>. It is mounted read-only into a
+  stock .NET runtime image (`dfir_evtx_dotnet_image`, which **must be .NET 9.x** —
+  EvtxECmd's current build targets net9.0). Without `Maps/`, `MapDescription` /
+  `signature` comes out empty.
+
+Both modes produce byte-identical output; the bundled image is just the release run
+without a mount. EvtxECmd is **not vendored** either way — the Dockerfile *fetches*
+the MIT-licensed release at build time; the repo ships the recipe, not the binary.
 
 ## Role variables
 | Variable | Default | Description |
@@ -14,15 +34,13 @@ log (+ an `.xml` sidecar, not ingested), grouped by the source sub-dir (host).
 | `dfir_evtx_evtx_dir` | `<repo>/data_store/raw/other_raw_data/WinEvt` | `.evtx` tree to parse (recursed). |
 | `dfir_evtx_adx_out_dir` | `<repo>/data_store/processed/windows_logs` | ADX-path output. |
 | `dfir_evtx_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/windows_logs` | SOF-ELK-path output. |
+| `dfir_evtx_use_bundled_image` | `true` | Use the bundled `dfir/evtxecmd` image; `false` = mount an operator release. |
+| `dfir_evtx_bundled_image` | `dfir/evtxecmd:latest` | Bundled image tag (built from `docker/evtxecmd`). |
 | `dfir_evtx_evtxecmd_dir` | `<repo>/data_store/dependencies/evtxecmd` | Operator-supplied EvtxECmd release (must hold `EvtxECmd.dll`; include `Maps/`). |
-| `dfir_evtx_dotnet_image` | `mcr.microsoft.com/dotnet/sdk:8.0` | dotnet runtime image for EvtxECmd. |
+| `dfir_evtx_dotnet_image` | `mcr.microsoft.com/dotnet/runtime:9.0` | Operator mode: the .NET **9.x** runtime image the release mounts into. |
+| `dfir_evtx_image` | (computed) | The image actually run; override to pin a digest. |
 | `dfir_evtx_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
 | `dfir_evtx_force` | `false` | Reparse logs that already have output. |
-
-## Operator dependency
-EvtxECmd is **not vendored** — download the .NET release (incl. `Maps/`) from
-<https://github.com/EricZimmerman/evtx/releases> and extract it under
-`dfir_evtx_evtxecmd_dir`. Without `Maps/`, `MapDescription`/`signature` is empty.
 
 ## Idempotence
 A log whose `.json` output already exists (non-empty) is skipped — the skip lives in

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/defaults/main.yml
@@ -9,11 +9,27 @@ dfir_evtx_repo_root: "{{ role_path }}/../../../../.."
 dfir_evtx_evtx_dir: "{{ dfir_evtx_repo_root }}/data_store/raw/other_raw_data/WinEvt"
 dfir_evtx_adx_out_dir: "{{ dfir_evtx_repo_root }}/data_store/processed/windows_logs"
 dfir_evtx_sofelk_out_dir: "{{ dfir_evtx_repo_root }}/data_store/processed/sofelk/windows_logs"
-# EvtxECmd is operator-supplied (not vendored — we don't redistribute other
-# people's builds). Drop the .NET release, incl. Maps/, under this dir.
+
+# How EvtxECmd is supplied — two modes:
+#   bundled  (default): the dfir/evtxecmd image (docker/evtxecmd) bakes EvtxECmd.dll
+#            + Maps/. Nothing to place by hand; build it once with
+#            `docker build -t dfir/evtxecmd:latest docker/evtxecmd`.
+#   operator: set dfir_evtx_use_bundled_image=false and drop the .NET EvtxECmd
+#            release (incl. Maps/) under dfir_evtx_evtxecmd_dir. EvtxECmd is MIT but
+#            we don't vendor it; the operator supplies the build.
+dfir_evtx_use_bundled_image: true
+dfir_evtx_bundled_image: "dfir/evtxecmd:latest"
+# Operator-supplied mode only: the release dir, and the stock .NET runtime image
+# that mounts it. EvtxECmd's current build targets net9.0, so the runtime is 9.x
+# (the old sdk:8.0 default silently fails against today's release).
 dfir_evtx_evtxecmd_dir: "{{ dfir_evtx_repo_root }}/data_store/dependencies/evtxecmd"
-# EvtxECmd targets .NET; this image supplies the runtime on Linux.
-dfir_evtx_dotnet_image: "mcr.microsoft.com/dotnet/sdk:8.0"
+dfir_evtx_dotnet_image: "mcr.microsoft.com/dotnet/runtime:9.0"
+
+# The image the processor actually runs — bundled or the mount-into-runtime one.
+# `| bool` so the string extra-var form (-e dfir_evtx_use_bundled_image=false) is
+# read the same way here as in every task (a bare non-empty string is Jinja-truthy).
+dfir_evtx_image: "{{ dfir_evtx_bundled_image if dfir_evtx_use_bundled_image | bool else dfir_evtx_dotnet_image }}"
+
 # In-repo runs use PYTHONPATH; a deployed run installs the package instead.
 dfir_evtx_python_path: "{{ dfir_evtx_repo_root }}/python"
 dfir_evtx_force: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
@@ -4,10 +4,14 @@ argument_specs:
     short_description: "Windows Event Logs (.evtx) -> EvtxECmd normalised JSON."
     description:
       - >-
-        Discovers .evtx under dfir_evtx_evtx_dir, runs EvtxECmd (via the dotnet
-        container) per log, and writes <base>_EvtxECmd_Output.json (+ .xml sidecar)
-        grouped by the source sub-dir (host). Idempotent: a log whose .json output
-        already exists is skipped. EvtxECmd is operator-supplied.
+        Discovers .evtx under dfir_evtx_evtx_dir, runs EvtxECmd (in a container) per
+        log, and writes <base>_EvtxECmd_Output.json (+ .xml sidecar) grouped by the
+        source sub-dir (host). Idempotent: a log whose .json output already exists is
+        skipped.
+      - >-
+        EvtxECmd is supplied one of two ways (dfir_evtx_use_bundled_image): the
+        bundled dfir/evtxecmd image (docker/evtxecmd) that bakes the DLL + Maps/, or
+        an operator-supplied .NET release mounted into a stock runtime image.
     options:
       dfir_evtx_pipeline:
         type: str
@@ -27,6 +31,24 @@ argument_specs:
         type: str
         required: false
         description: "SOF-ELK-path output dir (delivered into SOF-ELK by dfir_ingest_sofelk)."
+      dfir_evtx_use_bundled_image:
+        type: bool
+        required: false
+        default: true
+        description: >-
+          Use the bundled dfir/evtxecmd image (DLL + Maps/ baked in). When false,
+          mount an operator-supplied release from dfir_evtx_evtxecmd_dir instead.
+      dfir_evtx_bundled_image:
+        type: str
+        required: false
+        default: "dfir/evtxecmd:latest"
+        description: "The bundled EvtxECmd image tag (built from docker/evtxecmd)."
+      dfir_evtx_image:
+        type: str
+        required: false
+        description: >-
+          The image the processor runs; defaults to the bundled or operator image
+          per dfir_evtx_use_bundled_image. Override to pin a digest.
       dfir_evtx_evtxecmd_dir:
         type: str
         required: false
@@ -34,8 +56,10 @@ argument_specs:
       dfir_evtx_dotnet_image:
         type: str
         required: false
-        default: "mcr.microsoft.com/dotnet/sdk:8.0"
-        description: "dotnet runtime image that supplies .NET for EvtxECmd."
+        default: "mcr.microsoft.com/dotnet/runtime:9.0"
+        description: >-
+          Operator-supplied mode: the stock .NET runtime image the release mounts
+          into. Must be a .NET 9.x runtime (EvtxECmd's current build targets net9.0).
       dfir_evtx_python_path:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/molecule/default/converge.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/molecule/default/converge.yml
@@ -6,6 +6,9 @@
     dfir_evtx_pipeline: adx
     dfir_evtx_evtx_dir: /tmp/dfir_evtx_molecule/in
     dfir_evtx_adx_out_dir: /tmp/dfir_evtx_molecule/out
+    # This scenario supplies an EvtxECmd release, so it exercises the
+    # operator-supplied path (not the bundled image, which it doesn't build).
+    dfir_evtx_use_bundled_image: false
     dfir_evtx_evtxecmd_dir: "{{ molecule_evtxecmd_dir | default(lookup('env', 'EVTXECMD_DIR')) }}"
   tasks:
     - name: "converge | run dfir_evtx (ADX)"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/adx.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/adx.yml
@@ -1,7 +1,7 @@
 ---
 - name: "evtx-adx | parse .evtx into EvtxECmd JSON"
   ansible.builtin.command:
-    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--evtx-dir', dfir_evtx_evtx_dir, '--out-dir', dfir_evtx_adx_out_dir, '--evtxecmd-dir', dfir_evtx_evtxecmd_dir, '--dotnet-image', dfir_evtx_dotnet_image] + (['--force'] if dfir_evtx_force | bool else []) }}"
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--evtx-dir', dfir_evtx_evtx_dir, '--out-dir', dfir_evtx_adx_out_dir, '--image', dfir_evtx_image] + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
   environment:
     PYTHONPATH: "{{ dfir_evtx_python_path }}"
   register: dfir_evtx_adx_run

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/main.yml
@@ -8,10 +8,11 @@
     that:
       - dfir_evtx_pipeline in ['adx', 'sofelk']
       - dfir_evtx_evtx_dir | length > 0
-      - dfir_evtx_evtxecmd_dir | length > 0
+      # A release dir is required only in operator mode; bundled mode bakes it in.
+      - dfir_evtx_use_bundled_image | bool or dfir_evtx_evtxecmd_dir | length > 0
     fail_msg: >-
-      dfir_evtx needs dfir_evtx_pipeline (adx|sofelk), a non-empty dfir_evtx_evtx_dir
-      and dfir_evtx_evtxecmd_dir.
+      dfir_evtx needs dfir_evtx_pipeline (adx|sofelk), a non-empty dfir_evtx_evtx_dir,
+      and (in operator mode) dfir_evtx_evtxecmd_dir.
     quiet: true
   tags: [always]
 

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/preflight.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/preflight.yml
@@ -20,39 +20,66 @@
       dfir_evtx_evtx_dir ({{ dfir_evtx_evtx_dir }}) is missing or is not a directory.
     quiet: true
 
-- name: "evtx-preflight | stat the EvtxECmd release dir"
-  ansible.builtin.stat:
-    path: "{{ dfir_evtx_evtxecmd_dir }}"
-  register: dfir_evtx_evtxecmd_stat
+# Bundled mode: the dfir/evtxecmd image must already exist locally (it bakes the
+# DLL + Maps/). Build it once — docker build -t dfir/evtxecmd:latest docker/evtxecmd.
+- name: "evtx-preflight | bundled EvtxECmd image is present"
+  when: dfir_evtx_use_bundled_image | bool
+  block:
+    - name: "evtx-preflight | inspect the bundled EvtxECmd image"
+      # Inspect the image that will actually run (dfir_evtx_image), not just the
+      # default tag — so a dfir_evtx_image digest-pin override is validated too.
+      ansible.builtin.command: "docker image inspect {{ dfir_evtx_image }}"
+      register: dfir_evtx_bundled_inspect
+      changed_when: false
+      failed_when: false
 
-- name: "evtx-preflight | EvtxECmd release dir exists and is a directory"
-  ansible.builtin.assert:
-    that:
-      - dfir_evtx_evtxecmd_stat.stat.exists
-      - dfir_evtx_evtxecmd_stat.stat.isdir is defined and dfir_evtx_evtxecmd_stat.stat.isdir
-    fail_msg: >-
-      dfir_evtx_evtxecmd_dir ({{ dfir_evtx_evtxecmd_dir }}) is missing or is not a
-      directory — extract the operator-supplied EvtxECmd release there.
-    quiet: true
+    - name: "evtx-preflight | assert the bundled EvtxECmd image exists"
+      ansible.builtin.assert:
+        that:
+          - dfir_evtx_bundled_inspect.rc == 0
+        fail_msg: >-
+          Bundled image {{ dfir_evtx_image }} not found. Build it with
+          `docker build -t {{ dfir_evtx_bundled_image }} docker/evtxecmd`, or set
+          dfir_evtx_use_bundled_image=false to use an operator-supplied release.
+        quiet: true
 
-- name: "evtx-preflight | find the operator-supplied EvtxECmd.dll"
-  ansible.builtin.find:
-    paths: "{{ dfir_evtx_evtxecmd_dir }}"
-    patterns: "EvtxECmd.dll"
-    recurse: true
-    depth: 3           # matches the processor's locate_dll() maxdepth
-  register: dfir_evtx_dll
+# Operator-supplied mode: the release dir + EvtxECmd.dll must be in place.
+- name: "evtx-preflight | operator-supplied EvtxECmd release"
+  when: not dfir_evtx_use_bundled_image | bool
+  block:
+    - name: "evtx-preflight | stat the EvtxECmd release dir"
+      ansible.builtin.stat:
+        path: "{{ dfir_evtx_evtxecmd_dir }}"
+      register: dfir_evtx_evtxecmd_stat
 
-- name: "evtx-preflight | EvtxECmd.dll is present (operator-supplied)"
-  ansible.builtin.assert:
-    that:
-      - dfir_evtx_dll.matched | int > 0
-    fail_msg: >-
-      EvtxECmd.dll not found under dfir_evtx_evtxecmd_dir
-      ({{ dfir_evtx_evtxecmd_dir }}). EvtxECmd is not vendored — download the .NET
-      release (incl. Maps/) from https://github.com/EricZimmerman/evtx/releases and
-      extract it there.
-    quiet: true
+    - name: "evtx-preflight | EvtxECmd release dir exists and is a directory"
+      ansible.builtin.assert:
+        that:
+          - dfir_evtx_evtxecmd_stat.stat.exists
+          - dfir_evtx_evtxecmd_stat.stat.isdir is defined and dfir_evtx_evtxecmd_stat.stat.isdir
+        fail_msg: >-
+          dfir_evtx_evtxecmd_dir ({{ dfir_evtx_evtxecmd_dir }}) is missing or is not a
+          directory — extract the operator-supplied EvtxECmd release there.
+        quiet: true
+
+    - name: "evtx-preflight | find the operator-supplied EvtxECmd.dll"
+      ansible.builtin.find:
+        paths: "{{ dfir_evtx_evtxecmd_dir }}"
+        patterns: "EvtxECmd.dll"
+        recurse: true
+        depth: 3           # matches the processor's locate_dll() maxdepth
+      register: dfir_evtx_dll
+
+    - name: "evtx-preflight | EvtxECmd.dll is present (operator-supplied)"
+      ansible.builtin.assert:
+        that:
+          - dfir_evtx_dll.matched | int > 0
+        fail_msg: >-
+          EvtxECmd.dll not found under dfir_evtx_evtxecmd_dir
+          ({{ dfir_evtx_evtxecmd_dir }}). EvtxECmd is not vendored — download the .NET
+          release (incl. Maps/) from https://github.com/EricZimmerman/evtx/releases and
+          extract it there, or set dfir_evtx_use_bundled_image=true.
+        quiet: true
 
 - name: "evtx-preflight | the get_sybers_dfir.evtx module imports"
   ansible.builtin.command: python3 -c "import get_sybers_dfir.evtx"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/sofelk.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/sofelk.yml
@@ -4,7 +4,7 @@
 # tracked in #45.
 - name: "evtx-sofelk | parse .evtx into EvtxECmd JSON"
   ansible.builtin.command:
-    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--evtx-dir', dfir_evtx_evtx_dir, '--out-dir', dfir_evtx_sofelk_out_dir, '--evtxecmd-dir', dfir_evtx_evtxecmd_dir, '--dotnet-image', dfir_evtx_dotnet_image] + (['--force'] if dfir_evtx_force | bool else []) }}"
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--evtx-dir', dfir_evtx_evtx_dir, '--out-dir', dfir_evtx_sofelk_out_dir, '--image', dfir_evtx_image] + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
   environment:
     PYTHONPATH: "{{ dfir_evtx_python_path }}"
   register: dfir_evtx_sofelk_run

--- a/data_store/dependencies/evtxecmd/README.md
+++ b/data_store/dependencies/evtxecmd/README.md
@@ -1,17 +1,23 @@
 # EvtxECmd
 
-Extract the published EvtxECmd release here. Used by
-[`scripts/process-evtx-EvtxECmd.sh`](/scripts/process-evtx-EvtxECmd.sh) to turn
-raw `.evtx` files into something Splunk can index.
+> **You usually don't need this directory.** The `dfir_evtx` role defaults to the
+> **bundled** [`dfir/evtxecmd`](/docker/evtxecmd) image, which bakes `EvtxECmd.dll`
+> + `Maps/` for you — `docker build -t dfir/evtxecmd:latest docker/evtxecmd`. This
+> dir is the **operator-supplied** fallback, used only when you run with
+> `dfir_evtx_use_bundled_image=false`.
+
+Extract the published EvtxECmd release here for the operator-supplied path. The
+`get_sybers_dfir.evtx` processor mounts it read-only into a stock .NET runtime
+container to turn raw `.evtx` into normalised JSON.
 
 ## Get it
 
 - <https://github.com/EricZimmerman/evtx/releases>
 - or <https://ericzimmerman.github.io/>
 
-Take the **.NET** build — the script runs it on Linux inside a
-`mcr.microsoft.com/dotnet/sdk` container, so `EvtxECmd.dll` is what's needed,
-not `EvtxECmd.exe`.
+Take the **.NET** build — it runs on Linux inside a
+`mcr.microsoft.com/dotnet/runtime:9.0` container (EvtxECmd's current build targets
+net9.0), so `EvtxECmd.dll` is what's needed, not `EvtxECmd.exe`.
 
 Expected layout (either works):
 

--- a/docker/evtxecmd/.dockerignore
+++ b/docker/evtxecmd/.dockerignore
@@ -1,0 +1,4 @@
+# Build context is just the Dockerfile — everything EvtxECmd needs is fetched at
+# build time. Keep the context tiny.
+*
+!Dockerfile

--- a/docker/evtxecmd/Dockerfile
+++ b/docker/evtxecmd/Dockerfile
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1
+#
+# EvtxECmd image for the DX_DFIR pipeline — bakes Eric Zimmerman's EvtxECmd (.NET
+# build) and its Maps/ into an official .NET runtime image, so the dfir_evtx role
+# has one pinnable image to run instead of an operator hand-placing EvtxECmd.dll
+# under data_store/dependencies/evtxecmd/.
+#
+# EvtxECmd is MIT-licensed (Copyright (c) 2019 Eric Zimmerman) — redistribution is
+# permitted with attribution. We still don't COMMIT the binary; this Dockerfile
+# FETCHES the published release at build time, so the repo ships a recipe, not
+# someone else's build. See ./README.md for licensing and the LABELs below.
+#
+# Build (from the repo root or this dir):
+#   docker build -t dfir/evtxecmd:latest docker/evtxecmd
+#
+# Pin the release (recommended — the default URL serves "latest", so an unpinned
+# build is not reproducible over time):
+#   docker build -t dfir/evtxecmd:latest \
+#     --build-arg EVTXECMD_SHA256=<sha256 of EvtxECmd.zip> docker/evtxecmd
+#
+# Run (matches how get_sybers_dfir.evtx invokes it in bundled mode — WORKDIR holds
+# the DLL + Maps/, so EvtxECmd resolves its maps and needs no /evtxecmd mount):
+#   docker run --rm -v "$PWD/in:/input:ro" -v "$PWD/out:/output" dfir/evtxecmd:latest \
+#     dotnet /opt/evtxecmd/EvtxECmd.dll -f /input/Security.evtx \
+#     --json /output --jsonf Security_EvtxECmd_Output.json
+
+ARG DOTNET_VERSION=9.0
+# Global so BOTH the fetch stage AND the final stage's provenance LABEL see the same
+# default (ARG defaults do NOT cross a FROM — each stage redeclares it bare below).
+ARG EVTXECMD_URL=https://download.ericzimmermanstools.com/net9/EvtxECmd.zip
+
+# ---- fetch + unpack the EvtxECmd release -----------------------------------
+# A throwaway stage with curl + unzip (the runtime image has neither). The .NET
+# build's EvtxECmd.dll targets net9.0 (EvtxECmd.runtimeconfig.json), which is why
+# the runtime base below is 9.0.
+FROM debian:trixie-slim AS fetch
+ARG EVTXECMD_URL
+# Optional integrity pin: when non-empty, the downloaded zip must match this
+# sha256 or the build fails loudly. Empty (default) skips the check and takes
+# whatever "latest" currently serves.
+ARG EVTXECMD_SHA256=""
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl ca-certificates unzip; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL -o /tmp/EvtxECmd.zip "${EVTXECMD_URL}"; \
+    if [ -n "${EVTXECMD_SHA256}" ]; then \
+        echo "${EVTXECMD_SHA256}  /tmp/EvtxECmd.zip" | sha256sum -c -; \
+    fi; \
+    unzip -q /tmp/EvtxECmd.zip -d /tmp/unz; \
+    # Releases nest everything under an EvtxeCmd/ dir; flatten to /opt/evtxecmd.
+    # Guard the find result itself — an empty match makes `dirname ""` return "."
+    # (not empty), which would silently copy the whole stage root. Fail fast instead.
+    dll="$(find /tmp/unz -name EvtxECmd.dll -print -quit)"; \
+    test -n "${dll}"; \
+    src="$(dirname "${dll}")"; \
+    mkdir -p /opt/evtxecmd; \
+    cp -a "${src}/." /opt/evtxecmd/; \
+    test -f /opt/evtxecmd/EvtxECmd.dll; \
+    test -d /opt/evtxecmd/Maps; \
+    # The Windows single-file .exe is dead weight in a Linux image — drop it.
+    rm -f /opt/evtxecmd/EvtxECmd.exe
+
+# ---- the EvtxECmd image ----------------------------------------------------
+FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_VERSION}
+ARG EVTXECMD_URL
+LABEL org.opencontainers.image.title="dfir/evtxecmd" \
+      org.opencontainers.image.description="Eric Zimmerman's EvtxECmd (.NET) baked into a dotnet runtime image for the DX_DFIR dfir_evtx role" \
+      org.opencontainers.image.source="https://github.com/EricZimmerman/evtx" \
+      org.opencontainers.image.licenses="MIT" \
+      com.get-sybers.evtxecmd.url="${EVTXECMD_URL}"
+
+# DLL + Maps/ live together in WORKDIR so EvtxECmd finds its maps by default.
+COPY --from=fetch /opt/evtxecmd /opt/evtxecmd
+WORKDIR /opt/evtxecmd
+
+# Fail the build if the runtime can't load the tool (wrong .NET major, bad copy).
+RUN dotnet /opt/evtxecmd/EvtxECmd.dll --help > /dev/null
+
+# No ENTRYPOINT: callers pass the full `dotnet /opt/evtxecmd/EvtxECmd.dll …`
+# command (identical to the operator-supplied path, just without the mount), which
+# keeps get_sybers_dfir.evtx's two modes one code path apart.

--- a/docker/evtxecmd/README.md
+++ b/docker/evtxecmd/README.md
@@ -1,0 +1,59 @@
+# `dfir/evtxecmd` image
+
+Eric Zimmerman's **EvtxECmd** (.NET build) and its `Maps/` baked onto an official
+`.NET` runtime image, so the [`dfir_evtx`](/ansible/collections/get_sybers.dfir/roles/dfir_evtx)
+role has **one pinnable image** to run instead of an operator hand-placing
+`EvtxECmd.dll` under `data_store/dependencies/evtxecmd/`.
+
+The `.NET` build's `EvtxECmd.dll` targets **net9.0** (its `runtimeconfig.json`), so
+the base is `mcr.microsoft.com/dotnet/runtime:9.0`.
+
+## Build
+```bash
+# from the repo root
+docker build -t dfir/evtxecmd:latest docker/evtxecmd
+```
+The build fetches the release from `EVTXECMD_URL` (default the net9 "latest" zip),
+flattens `EvtxECmd.dll` + `Maps/` into `/opt/evtxecmd` (the image `WORKDIR`, so
+EvtxECmd finds its maps), drops the Windows `.exe`, and smoke-tests
+`dotnet EvtxECmd.dll --help` so a broken copy fails the build.
+
+### Pin the release (recommended)
+The default URL serves **latest**, so an unpinned build is not reproducible over
+time. Pass the expected checksum to fail loudly on drift:
+```bash
+sha256=$(curl -fsSL https://download.ericzimmermanstools.com/net9/EvtxECmd.zip | sha256sum | cut -d' ' -f1)
+docker build -t dfir/evtxecmd:latest --build-arg EVTXECMD_SHA256="$sha256" docker/evtxecmd
+```
+
+### Build args
+| Arg | Default | Purpose |
+|---|---|---|
+| `DOTNET_VERSION` | `9.0` | .NET runtime major (EvtxECmd's current build is net9.0). |
+| `EVTXECMD_URL` | net9 latest zip | Where to fetch the EvtxECmd `.NET` release. |
+| `EVTXECMD_SHA256` | *(empty)* | If set, the zip must match this sha256 or the build fails. |
+
+## Run
+The image sets no `ENTRYPOINT`: callers pass the full `dotnet …` command, identical
+to the operator-supplied path but with no `/evtxecmd` mount — which is what keeps the
+`get_sybers_dfir.evtx` processor's two modes one branch apart.
+```bash
+docker run --rm -v "$PWD/in:/input:ro" -v "$PWD/out:/output" dfir/evtxecmd:latest \
+  dotnet /opt/evtxecmd/EvtxECmd.dll -f /input/Security.evtx \
+  --json /output --jsonf Security_EvtxECmd_Output.json \
+  --xml  /output --xmlf  Security_EvtxECmd_Output.xml
+```
+Normally you don't run it by hand — `dfir_evtx` (bundled mode, the default) does.
+
+## Updating `Maps/`
+The maps are frozen at build time (whatever the release shipped). Rebuild the image
+to refresh them; there's no in-image `--sync` step (that needs network at run time
+and would make runs non-deterministic).
+
+## Licence & provenance
+EvtxECmd is **MIT** — Copyright (c) 2019 Eric Zimmerman
+(<https://github.com/EricZimmerman/evtx>). MIT permits redistribution with
+attribution, but this project still does **not commit the binary**: the Dockerfile
+*fetches* the published release at build time, so the repo ships a recipe, not
+someone else's build. The image records the source URL in an OCI label
+(`com.get-sybers.evtxecmd.url`) and `org.opencontainers.image.source`.

--- a/project-progress.md
+++ b/project-progress.md
@@ -44,7 +44,7 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 |:--------------------------------------------------------------|:-------------:|:---------------|:------------:|:-------------:|
 | [Log2timeline](https://github.com/log2timeline/plaso)         | ✅            | json_line       | ✅           |     ✅ (`file`) |
 | [Zeek](https://zeek.org/)                                     | ✅            | json            | ✅ (`conn` typed + all other logs generic) | ✅ (`flow`) |
-| [WinEvent Logs](https://www.sans.org/white-papers/32949/) (EvtxECmd) | ⚠️     | evtx → json     | ✅           |     ✅ (`process`/`user_session`/`service`) |
+| [WinEvent Logs](https://www.sans.org/white-papers/32949/) (EvtxECmd) | ✅ (bundled `dfir/evtxecmd` image; 103 real LoneWolf logs) | evtx → json     | ✅ (55,638 rows)           |     ✅ (`process`/`user_session`/`service`) |
 | Velociraptor offline collectors ([EZ Tools](https://ericzimmerman.github.io/)) | ✅ `process-velociraptor.sh` (unpack collection) | json | ✅ `host.VelociraptorJson` | ✅ (`registry`) |
 | [Velociraptor](https://github.com/Velocidex/velociraptor)     | ⚠️            | json            | ✅ `host.VelociraptorJson` | ✅ (`registry`) |
 | [Volatility 3](https://github.com/volatilityfoundation/volatility3) | ✅ `process-volatility.sh` | json (per plugin) | ✅ `memory.VolatilityJson` | n/a (memory ≠ CAR dead-box object) |
@@ -105,8 +105,10 @@ Things that are broken or unsafe right now.
 - **The emulator has no security features at all** — no auth, no access
   control, plaintext HTTP, no encryption at rest. The `127.0.0.1` binding is
   the only control; see [SECURITY.md](/SECURITY.md).
-- **Raw EVTX processing is built but unverified.** `process-evtx-EvtxECmd.sh`
-  has never been run against a real event log.
+- ~~**Raw EVTX processing is built but unverified.**~~ **Resolved.** The `dfir_evtx`
+  role ran on **103 real event logs** carved from the LoneWolf image (bundled
+  `dfir/evtxecmd` image), 55,638 rows into `host.EvtxEcmdJson`, feeding
+  `CarUserSession`/`CarProcess`/`CarService` from real 4624/4688/7045.
 
 ---
 
@@ -147,7 +149,8 @@ Things that are broken or unsafe right now.
   `registry` CAR object when it lands. If the collectors emit EZ-tool CSV,
   the answer is typed per-artefact tables or JSON conversion — a CSV mapping
   cannot populate a `dynamic` column.
-- Verify `process-evtx-EvtxECmd.sh` against a real event log.
+- ✅ Verify the EvtxECmd path against a real event log — done (see Known
+  Limitations; 103 real LoneWolf logs → `host.EvtxEcmdJson` → CAR).
 
 ### 🔹 **Environment & Dependencies**
 - Create a guide for **setting up the development environment**.

--- a/python/get_sybers_dfir/evtx.py
+++ b/python/get_sybers_dfir/evtx.py
@@ -31,7 +31,14 @@ import os
 import subprocess
 import sys
 
-_DOTNET_IMAGE = "mcr.microsoft.com/dotnet/sdk:8.0"
+# Operator-supplied mode: a stock .NET runtime image mounts the operator's release.
+# EvtxECmd's current .NET build targets net9.0, so the runtime must be 9.x — the old
+# sdk:8.0 default silently fails against today's release.
+_DOTNET_IMAGE = "mcr.microsoft.com/dotnet/runtime:9.0"
+# Bundled mode: DX_DFIR's own image (docker/evtxecmd) with the DLL + Maps/ baked in.
+_BUNDLED_IMAGE = "dfir/evtxecmd:latest"
+# Where the bundled image keeps EvtxECmd.dll (its WORKDIR, alongside Maps/).
+BUNDLED_DLL = "/opt/evtxecmd/EvtxECmd.dll"
 
 
 def discover(evtx_dir: str) -> list[str]:
@@ -80,21 +87,49 @@ def out_names(evtx_file: str) -> tuple[str, str]:
     return f"{base}_EvtxECmd_Output.json", f"{base}_EvtxECmd_Output.xml"
 
 
-def _run_evtxecmd(evtx_file, dest_dir, evtxecmd_dir, dll_rel, json_out, xml_out, image):
+def evtxecmd_argv(evtx_file, dest_dir, json_out, xml_out, image, *,
+                  evtxecmd_dir=None, dll_rel=None, bundled_dll=BUNDLED_DLL):
+    """The `docker run` argv for one EvtxECmd container run. Two modes, one shape:
+
+    - operator-supplied (``evtxecmd_dir`` given): mount the release read-only at
+      ``/evtxecmd`` and run ``dotnet /evtxecmd/<dll_rel>`` — the historic path.
+    - bundled image (``evtxecmd_dir`` falsy): the DLL + Maps/ are baked into
+      ``image`` at ``bundled_dll``'s dir (its WORKDIR), so no mount, and the DLL
+      path is fixed.
+
+    Pure (no I/O) so the argv is unit-testable without docker.
+    """
+    argv = [
+        "docker", "run", "--rm",
+        "-v", f"{os.path.dirname(evtx_file)}:/input:ro",
+        "-v", f"{dest_dir}:/output",
+    ]
+    if evtxecmd_dir:
+        argv += ["-v", f"{os.path.realpath(evtxecmd_dir)}:/evtxecmd:ro", "-w", "/evtxecmd"]
+        dll = f"/evtxecmd/{dll_rel}"
+    else:
+        dll = bundled_dll
+    argv += [
+        image,
+        "dotnet", dll,
+        "-f", f"/input/{os.path.basename(evtx_file)}",
+        "--json", "/output", "--jsonf", json_out,
+        "--xml", "/output", "--xmlf", xml_out,
+    ]
+    return argv
+
+
+def _run_evtxecmd(evtx_file, dest_dir, json_out, xml_out, image, *,
+                  evtxecmd_dir=None, dll_rel=None):
     """One EvtxECmd container run over one log, JSON + XML into dest_dir."""
     subprocess.run(
-        [
-            "docker", "run", "--rm",
-            "-v", f"{os.path.realpath(evtxecmd_dir)}:/evtxecmd:ro",
-            "-v", f"{os.path.dirname(evtx_file)}:/input:ro",
-            "-v", f"{dest_dir}:/output",
-            "-w", "/evtxecmd",
-            image,
-            "dotnet", f"/evtxecmd/{dll_rel}",
-            "-f", f"/input/{os.path.basename(evtx_file)}",
-            "--json", "/output", "--jsonf", json_out,
-            "--xml", "/output", "--xmlf", xml_out,
-        ],
+        evtxecmd_argv(evtx_file, dest_dir, json_out, xml_out, image,
+                      evtxecmd_dir=evtxecmd_dir, dll_rel=dll_rel),
+        # EvtxECmd is chatty (version banner + per-record "time went backwards"
+        # warnings). Capture it so nothing reaches OUR stdout, which carries only
+        # the machine-readable JSON summary the role parses. On failure the output
+        # is still attached to the CalledProcessError for the caller to surface.
+        capture_output=True,
         check=True,
     )
 
@@ -106,26 +141,65 @@ def _nonempty(path: str) -> bool:
         return False
 
 
-def process(evtx_dir, out_dir, evtxecmd_dir, image=_DOTNET_IMAGE, force=False) -> dict:
-    """Parse every .evtx under evtx_dir into out_dir/<host>/. Idempotent."""
+def _has_records(path: str) -> bool:
+    """True if the EvtxECmd JSON holds at least one record.
+
+    EvtxECmd exits 0 on a log with no events and still writes a file — just a UTF-8
+    BOM (3 bytes) and nothing else. That is NOT a real output: it has size > 0 but
+    zero records, and if left on disk it (a) miscounts as ``processed`` and (b) makes
+    the ADX multi-file ingest batch reject the whole batch ("0 bytes / ill formed").
+    So the emptiness test must look past the BOM/whitespace, not at the byte size.
+    """
+    try:
+        with open(path, "r", encoding="utf-8-sig") as fh:
+            for line in fh:
+                if line.strip():
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def process(evtx_dir, out_dir, evtxecmd_dir=None, image=None, force=False) -> dict:
+    """Parse every .evtx under evtx_dir into out_dir/<host>/. Idempotent.
+
+    Two ways to supply EvtxECmd, chosen by ``evtxecmd_dir``:
+
+    - given -> operator-supplied release: locate EvtxECmd.dll under it and mount it
+      into a stock .NET runtime ``image`` (defaults to ``_DOTNET_IMAGE``).
+    - falsy -> the bundled dfir/evtxecmd image (DLL + Maps/ baked in); no release dir
+      is needed and none is looked for. ``image`` defaults to ``_BUNDLED_IMAGE``.
+
+    Pass ``image`` to override either default.
+    """
     evtx_dir = os.path.realpath(evtx_dir)
     out_dir = os.path.realpath(out_dir)
     os.makedirs(out_dir, exist_ok=True)
-    dll_rel = locate_dll(evtxecmd_dir)
+    bundled = not evtxecmd_dir
+    # Default the image to match the mode, so a bare process(dir, out) is coherent
+    # (bundled mode -> bundled image, not the stock runtime that has no baked DLL).
+    if image is None:
+        image = _BUNDLED_IMAGE if bundled else _DOTNET_IMAGE
+    dll_rel = None if bundled else locate_dll(evtxecmd_dir)
     files = discover(evtx_dir)
 
     summary = {
         "tool": "evtx",
         "evtx_dir": evtx_dir,
         "out_dir": out_dir,
-        "evtxecmd_dll": dll_rel,
+        "image": image,
+        "bundled": bundled,
+        "evtxecmd_dll": BUNDLED_DLL if bundled else dll_rel,
         "files": len(files),
         "processed": 0,
         "skipped": 0,
+        # Empty logs are normal (a Windows channel with no events), NOT failures —
+        # counted apart so the role's failed==0 assert doesn't trip on them.
+        "empty": 0,
         "failed": 0,
         "results": [],
     }
-    if dll_rel is None:
+    if not bundled and dll_rel is None:
         summary["error"] = "EvtxECmd.dll not found under evtxecmd_dir"
         return summary
 
@@ -135,12 +209,15 @@ def process(evtx_dir, out_dir, evtxecmd_dir, image=_DOTNET_IMAGE, force=False) -
         json_out, xml_out = out_names(evtx)
         rel = os.path.relpath(evtx, evtx_dir)
         json_path = os.path.join(dest_dir, json_out)
-        if not force and _nonempty(json_path):
+        # Skip only a real prior output — one with records. A BOM-only leftover from
+        # an empty log is not "done"; re-checking it is cheap.
+        if not force and _has_records(json_path):
             summary["skipped"] += 1
             continue
         os.makedirs(dest_dir, exist_ok=True)
         try:
-            _run_evtxecmd(evtx, dest_dir, evtxecmd_dir, dll_rel, json_out, xml_out, image)
+            _run_evtxecmd(evtx, dest_dir, json_out, xml_out, image,
+                          evtxecmd_dir=evtxecmd_dir, dll_rel=dll_rel)
         except subprocess.CalledProcessError:
             for p in (json_path, os.path.join(dest_dir, xml_out)):
                 if os.path.exists(p):
@@ -148,17 +225,18 @@ def process(evtx_dir, out_dir, evtxecmd_dir, image=_DOTNET_IMAGE, force=False) -
             summary["failed"] += 1
             summary["results"].append({"log": rel, "error": "EvtxECmd failed"})
             continue
-        if _nonempty(json_path):
+        if _has_records(json_path):
             summary["processed"] += 1
             summary["results"].append({"log": rel, "output": os.path.join(host, json_out)})
         else:
-            # EvtxECmd exits 0 on an empty log — drop the empty artefact so the
-            # skip-guard doesn't treat it as done.
+            # EvtxECmd exits 0 on an empty log and writes a BOM-only file — drop it
+            # so it isn't ingested (an empty file fails the ADX batch) or miscounted
+            # as processed. This is expected, not a failure.
             for p in (json_path, os.path.join(dest_dir, xml_out)):
                 if os.path.exists(p):
                     os.remove(p)
-            summary["failed"] += 1
-            summary["results"].append({"log": rel, "error": "no records (empty or corrupt log)"})
+            summary["empty"] += 1
+            summary["results"].append({"log": rel, "empty": True})
     return summary
 
 
@@ -169,14 +247,24 @@ def main(argv: list[str] | None = None) -> int:
     )
     ap.add_argument("--evtx-dir", required=True, help="directory tree of .evtx logs (recursed)")
     ap.add_argument("--out-dir", required=True, help="output dir; grouped by source sub-dir (host)")
-    ap.add_argument("--evtxecmd-dir", required=True, help="operator-supplied EvtxECmd release dir")
-    ap.add_argument("--dotnet-image", default=_DOTNET_IMAGE, help="dotnet runtime image for EvtxECmd")
+    ap.add_argument(
+        "--evtxecmd-dir", default="",
+        help="operator-supplied EvtxECmd release dir (holds EvtxECmd.dll). Omit to "
+             "use the bundled image (docker/evtxecmd), which bakes the DLL + Maps/.",
+    )
+    ap.add_argument(
+        "--image", "--dotnet-image", dest="image", default=None,
+        help="container image: the bundled dfir/evtxecmd (default when --evtxecmd-dir "
+             "is omitted) or a stock .NET runtime that mounts the operator release.",
+    )
     ap.add_argument("--force", action="store_true", help="reparse logs that already have output")
     args = ap.parse_args(argv)
 
+    # Image and mode are coupled; process() picks the mode-appropriate default when
+    # --image is omitted (bundled image without a release dir, stock runtime with).
     summary = process(
-        args.evtx_dir, args.out_dir, args.evtxecmd_dir,
-        image=args.dotnet_image, force=args.force,
+        args.evtx_dir, args.out_dir, args.evtxecmd_dir or None,
+        image=args.image, force=args.force,
     )
     json.dump(summary, sys.stdout)
     sys.stdout.write("\n")

--- a/python/tests/test_evtx.py
+++ b/python/tests/test_evtx.py
@@ -72,6 +72,113 @@ def test_process_reports_missing_dll(tmp_path):
     evtx_dir = tmp_path / "in"
     evtx_dir.mkdir()
     (evtx_dir / "Security.evtx").write_bytes(b"x")
+    # operator-supplied mode with no DLL under the dir -> hard error
     s = evtx.process(str(evtx_dir), str(tmp_path / "out"), str(tmp_path / "noevtxecmd"))
     assert s["evtxecmd_dll"] is None and s.get("error")
     assert s["processed"] == 0
+
+
+# ---- two-mode container invocation ----------------------------------------
+def test_argv_operator_mode_mounts_release():
+    argv = evtx.evtxecmd_argv(
+        "/raw/HOST01/Security.evtx", "/out/HOST01",
+        "Security_EvtxECmd_Output.json", "Security_EvtxECmd_Output.xml",
+        "mcr.microsoft.com/dotnet/runtime:9.0",
+        evtxecmd_dir="/deps/evtxecmd", dll_rel="EvtxECmd.dll",
+    )
+    # the release is mounted read-only and run from that workdir
+    assert "-v" in argv and "/deps/evtxecmd:/evtxecmd:ro" in argv
+    assert argv[argv.index("-w") + 1] == "/evtxecmd"
+    assert "dotnet" in argv and "/evtxecmd/EvtxECmd.dll" in argv
+    # input dir mounted from the log's parent; output from dest_dir
+    assert "/raw/HOST01:/input:ro" in argv
+    assert "/out/HOST01:/output" in argv
+    assert argv[argv.index("-f") + 1] == "/input/Security.evtx"
+
+
+def test_argv_bundled_mode_has_no_release_mount():
+    argv = evtx.evtxecmd_argv(
+        "/raw/HOST01/Security.evtx", "/out/HOST01",
+        "Security_EvtxECmd_Output.json", "Security_EvtxECmd_Output.xml",
+        "dfir/evtxecmd:latest",
+    )
+    # no /evtxecmd mount, no -w; the baked-in DLL path is used
+    assert "-w" not in argv
+    assert not any(str(a).endswith(":/evtxecmd:ro") for a in argv)
+    assert evtx.BUNDLED_DLL in argv
+    assert argv[argv.index("dotnet") + 1] == evtx.BUNDLED_DLL
+    # input/output mounts are still there
+    assert "/raw/HOST01:/input:ro" in argv
+    assert "/out/HOST01:/output" in argv
+
+
+def test_argv_modes_differ_only_by_mount_and_dll():
+    common = ("/raw/x/S.evtx", "/out/x", "S.json", "S.xml")
+    op = evtx.evtxecmd_argv(*common, "img", evtxecmd_dir="/d", dll_rel="EvtxECmd.dll")
+    bd = evtx.evtxecmd_argv(*common, "img")
+    # both drive the same tool args after the image name
+    assert op[op.index("-f"):] == bd[bd.index("-f"):]
+
+
+def test_has_records_bom_only_is_empty(tmp_path):
+    # EvtxECmd writes a BOM-only file for a log with no events — size 3, zero records.
+    p = tmp_path / "HardwareEvents_EvtxECmd_Output.json"
+    p.write_bytes(b"\xef\xbb\xbf")
+    assert p.stat().st_size == 3          # non-empty by byte size...
+    assert evtx._has_records(str(p)) is False   # ...but no records
+
+
+def test_has_records_true_with_a_record(tmp_path):
+    p = tmp_path / "Security_EvtxECmd_Output.json"
+    p.write_bytes(b"\xef\xbb\xbf" + b'{"EventId":4624}\n')
+    assert evtx._has_records(str(p)) is True
+
+
+def test_has_records_whitespace_only_is_empty(tmp_path):
+    p = tmp_path / "x.json"
+    p.write_text("\n  \n")
+    assert evtx._has_records(str(p)) is False
+
+
+def test_process_counts_empty_log_apart_from_failed(tmp_path, monkeypatch):
+    evtx_dir = tmp_path / "in"
+    evtx_dir.mkdir()
+    (evtx_dir / "Empty.evtx").write_bytes(b"x")
+
+    def fake_run(evtx_file, dest_dir, json_out, xml_out, image, **kw):
+        # simulate EvtxECmd on an empty log: exits 0, writes a BOM-only file
+        with open(os.path.join(dest_dir, json_out), "wb") as f:
+            f.write(b"\xef\xbb\xbf")
+
+    monkeypatch.setattr(evtx, "_run_evtxecmd", fake_run)
+    s = evtx.process(str(evtx_dir), str(tmp_path / "out"), image="dfir/evtxecmd:latest")
+    assert s["empty"] == 1
+    assert s["failed"] == 0            # an empty log is not a failure
+    assert s["processed"] == 0
+    # the BOM-only artefact is dropped so it never reaches ingest
+    assert not (tmp_path / "out" / "unspecified_host" / "Empty_EvtxECmd_Output.json").exists()
+
+
+def test_process_bundled_mode_needs_no_dll(tmp_path, monkeypatch):
+    evtx_dir = tmp_path / "in"
+    evtx_dir.mkdir()
+    (evtx_dir / "Security.evtx").write_bytes(b"x")
+
+    calls = {}
+
+    def fake_run(evtx_file, dest_dir, json_out, xml_out, image, **kw):
+        calls["image"] = image
+        calls["kw"] = kw
+        # simulate EvtxECmd writing a non-empty json
+        with open(os.path.join(dest_dir, json_out), "w") as f:
+            f.write('{"EventId":1}\n')
+
+    monkeypatch.setattr(evtx, "_run_evtxecmd", fake_run)
+    s = evtx.process(str(evtx_dir), str(tmp_path / "out"), image="dfir/evtxecmd:latest")
+    assert s["bundled"] is True
+    assert s.get("error") is None
+    assert s["evtxecmd_dll"] == evtx.BUNDLED_DLL
+    assert s["processed"] == 1
+    # bundled mode passes no release dir down to the runner
+    assert calls["kw"].get("evtxecmd_dir") in (None, "")
+    assert calls["image"] == "dfir/evtxecmd:latest"


### PR DESCRIPTION
## What

Adds a purpose-built **`dfir/evtxecmd`** image (`docker/evtxecmd/`) so the `dfir_evtx` role runs **one pinnable image** instead of an operator hand-placing `EvtxECmd.dll` under `data_store/dependencies/evtxecmd/`. Bundled mode is the new default; operator-supplied mode still works.

- **Image** (`FROM dotnet/runtime:9.0`, ~88 MB): fetches the MIT-licensed EvtxECmd .NET-9 release at build time (repo ships the recipe, not the binary — keeps the no-vendoring stance), bakes `EvtxECmd.dll` + `Maps/` into `/opt/evtxecmd`, drops the Windows `.exe`, and smoke-tests `--help` so a bad build fails. Optional `EVTXECMD_SHA256` build-arg pins the release.
- **Processor** (`evtx.py`): two modes behind one code path (bundled = no mount; operator = mount a release into a stock runtime). Proven **byte-identical** — the same real 7,137-record `Security.evtx` through both paths gave the same 9,950,611 bytes, `diff` clean.
- **Role**: new `dfir_evtx_use_bundled_image` (default `true`), mode-aware preflight/argv/asserts, updated `argument_specs`/README/dependency-README. Corrected the stale default image `dotnet/sdk:8.0` → `runtime:9.0` (sdk:8.0 can't run today's net9 EvtxECmd).

## Real-data validation

103 event logs carved from the LoneWolf image → **55,638 rows** in `host.EvtxEcmdJson`, feeding `CarUserSession`/`CarProcess`/`CarService` from real 4624/4688/7045. Closes the board's "EVTX never run against a real event log" gap. Re-ingest is idempotent (no row doubling).

## Bugs fixed (surfaced by the real run)

- **stdout leak:** EvtxECmd's banner/warnings leaked onto the processor's JSON-summary stdout, failing the role's `from_json` `changed_when`. Now captured.
- **BOM-only empty logs:** EvtxECmd writes a 3-byte BOM-only file for an empty channel; `size>0` miscounted it as processed and it tripped the ADX multi-file batch ingest (**#39**). Now detected past the BOM, counted `empty` (not `failed`), and dropped before ingest.

## Adversarial review fixes

A 13-agent review confirmed and I fixed: `dfir_evtx_image` now uses `| bool` (so `-e use_bundled_image=false` selects the operator image consistently); bundled preflight inspects `dfir_evtx_image` (honours a digest-pin override); `main.yml` no longer demands a release dir in bundled mode; Dockerfile provenance URL label populated via a global ARG; the DLL-find guard fails fast on a missing DLL.

## Verification

- `python -m pytest` — **89 pass**
- `tests/run-checks.sh` — **103 pass / 0 fail**
- `ansible-playbook --syntax-check` on the evtx playbook — clean
- Bundled + operator mode both resolve the correct image (string and bool `-e` forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)