### PR TITLE
release: 0.2.0 — dxdfir CLI + get_sybers.dfir collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ script names, sourcetypes, field names, and app layouts included.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-21
+
+### Changed — pipeline rebuilt as the `dxdfir` CLI + `get_sybers.dfir` collection (#45/#46)
+
+The headline of this release. The pipeline is now a three-layer stack — the
+**`dxdfir` CLI** → the **`get_sybers.dfir` Ansible collection** (one role per
+source, one action per task) → the **`get_sybers_dfir` Python package** — driving
+two backends via `--pipeline adx|sofelk`.
+
+- **Ten per-source roles + processors**: `dfir_zeek`, `dfir_volatility`,
+  `dfir_velociraptor`, `dfir_evtx`, `dfir_plaso`, `dfir_signatures`,
+  `dfir_ingest_adx`, `dfir_ingest_sofelk`, `dfir_deploy_adx`, `dfir_deploy_sofelk`
+  — each role wraps a `python -m get_sybers_dfir.<source>` processor.
+- **`dxdfir` CLI** (Typer): `process` / `ingest` / `deploy` / `validate`, with a
+  man page and 80+ unit tests.
+- **Dual output**: every processor targets ADX (Kusto emulator) or SOF-ELK.
+- **From-source SOF-ELK image** (`docker/sof-elk/`) so `dfir_deploy_sofelk` has a
+  real image to run.
+- **Bundled `dfir/evtxecmd` image** (`docker/evtxecmd/`): one pinnable image for
+  the EvtxECmd path (DLL + Maps/ baked in), validated on 103 real LoneWolf event
+  logs → `host.EvtxEcmdJson` (55,638 rows) feeding CAR
+  `user_session`/`process`/`service`.
+- ADX ingest is idempotent via an in-DB ledger; a processed file vanishing
+  mid-read is tolerated.
+
+> The legacy `process-*.sh` scripts remain during per-source retirement; the roles
+> are the supported entry point.
+
 ### Added — deeper Linux CAR coverage (process / service / user_session)
 
 - **`CarProcess()` gains a Linux branch** from syslog cron `CMD` executions
@@ -713,5 +741,7 @@ when someone ran it. They are listed first, because how they got in matters.
   make that deliberate — deferred, because it is a decision about which version
   you want to run.
 
-[Unreleased]: https://github.com/Get-Sybers/DX_DFIR/compare/v0.2.0-beta...HEAD
+[Unreleased]: https://github.com/Get-Sybers/DX_DFIR/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Get-Sybers/DX_DFIR/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/Get-Sybers/DX_DFIR/releases/tag/v0.1.0
 [0.2.0-beta]: https://github.com/Get-Sybers/DX_DFIR/releases/tag/v0.2.0-beta

--- a/ansible/collections/get_sybers.dfir/galaxy.yml
+++ b/ansible/collections/get_sybers.dfir/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: get_sybers
 name: dfir
-version: 0.1.0
+version: 0.2.0
 readme: README.md
 authors:
   - Get-Sybers

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "get-sybers-dfir"
-version = "0.1.0"
+version = "0.2.0"
 description = "DX_DFIR forensic processing package (zeek, velociraptor, evtx, volatility, plaso, signatures) + dxdfir CLI"
 requires-python = ">=3.10"
 license = { text = "MIT" }


### PR DESCRIPTION
Release prep for **0.2.0** (minor bump from the current `0.1.0` pin). Merge this into `dev` so the promotion PR #64 carries it into `main`, then tag `v0.2.0` off `main`.

## Changes
- **Version pins** `0.1.0 → 0.2.0` in `python/pyproject.toml` and `galaxy.yml`.
- **CHANGELOG**: new `## [0.2.0] - 2026-08-21` section, headed by the #45/#46 rewrite (dxdfir CLI + `get_sybers.dfir` collection + dual ADX/SOF-ELK output + bundled `dfir/evtxecmd` image). Compare-links now base on `v0.1.0` (the actual last release tag); a `[0.1.0]` link is added.

## Lineage note
The changelog's newest dated section was `[0.2.0-beta]` (2026-08-04), but the actual latest release is `v0.1.0` (2026-08-15) — v0.1.0 never got a changelog section, so the prior links referenced `v0.2.0-beta`. This release bases its compare on `v0.1.0` (correct last release). Per `CONTRIBUTING.md`, `0.2.0-beta` is a *prerelease of a different line*, not part of this chain.

## Verify
- `tests/run-checks.sh` — 103 pass / 0 fail (versioning + doc-link groups included)
- No other `0.1.0` version references remain (CONTRIBUTING prose and raw evidence excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)