### PR TITLE
review: address Copilot feedback on the dev→main promotion (#64)

### DIFF
--- a/ansible/collections/get_sybers.dfir/galaxy.yml
+++ b/ansible/collections/get_sybers.dfir/galaxy.yml
@@ -16,7 +16,9 @@ tags:
   - forensics
   - security
 dependencies:
-  community.docker: ">=3.10.3"
+  # Bounded below the next major so a Galaxy install can't pull a breaking 4.x;
+  # requirements.yml pins the exact tested version (3.10.3) for reproducible installs.
+  community.docker: ">=3.10.3,<4.0.0"
 build_ignore:
   - "roles/*/molecule"
   - "*.pyc"

--- a/python/README.md
+++ b/python/README.md
@@ -26,7 +26,7 @@ dxdfir ingest --only zeek               # load processed output into the ADX emu
 dxdfir deploy                           # stand up + schema-load the emulator
 dxdfir validate                         # run the check harness
 dxdfir list                             # list processable sources
-man dxdfir                              # the manual (man/dxdfir.1)
+man dxdfir                              # the manual (python/man/dxdfir.1)
 ```
 `process` drives the collection with `ansible-playbook` (the role's one action calls
 the matching `python -m get_sybers_dfir.<source>` for the tight loop). `ingest` and
@@ -37,7 +37,7 @@ auto-detected (or pass `--repo-root` / `$DFIR_REPO_ROOT`).
 ## Install
 ```bash
 pip install ./python          # provides the `dxdfir` entry point + the package
-install -Dm644 man/dxdfir.1 ~/.local/share/man/man1/dxdfir.1   # optional: man page
+install -Dm644 python/man/dxdfir.1 ~/.local/share/man/man1/dxdfir.1   # optional: man page
 ```
 In-repo runs need no install — set `PYTHONPATH=python` (the roles do this via
 `dfir_<source>_python_path`). Without installing the man page, read it directly with

--- a/python/get_sybers_dfir/__init__.py
+++ b/python/get_sybers_dfir/__init__.py
@@ -1,8 +1,9 @@
 """get_sybers_dfir — the DX_DFIR processing package.
 
 Pure Python processors (zeek, plaso, volatility, evtx, signatures, ingest) and the
-`dfir` CLI. The Ansible collection `get_sybers.dfir` invokes these as single actions;
-the playbook holds the decisions. See docs/CAR-Extraction-Rules.md and epic #46.
+`dxdfir` CLI. The Ansible collection `get_sybers.dfir` invokes these as single
+actions; the playbook holds the decisions. See docs/CAR-Extraction-Rules.md and
+epic #46.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/python/get_sybers_dfir/signatures/__init__.py
+++ b/python/get_sybers_dfir/signatures/__init__.py
@@ -5,7 +5,8 @@ hayabusa}.sh`` lanes and ``lib/disk-image.sh``). Runs the three signature engine
 over the evidence and lands their native events as ingest-ready JSON Lines under
 ``<output_dir>/<lane>/``:
 
-    yara       files / mounted disk images / memory (Volatility vadyarascan)
+    yara       loose files (the mounted-disk-image and memory/vadyarascan sources
+               are not yet ported — those record a note only; see yara.py)
     suricata   PCAPs -> Suricata EVE alerts (+context event types)
     hayabusa   Windows Event Logs (.evtx) -> Sigma detection timeline
 

--- a/python/get_sybers_dfir/signatures/__main__.py
+++ b/python/get_sybers_dfir/signatures/__main__.py
@@ -17,7 +17,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--repo-root", required=True, help="repo root (lane input/dep defaults hang off it)")
     ap.add_argument("--only", action="append", choices=list(LANES),
                     help="run only this lane (repeatable); default all")
-    ap.add_argument("--fetch", action="store_true", help="provision rules/binaries when online")
+    ap.add_argument("--fetch", action="store_true",
+                    help="accepted for parity with the bash lanes; provisioning is "
+                         "not yet implemented (a lane missing its deps records a note)")
     ap.add_argument("--force", action="store_true", help="regenerate outputs that already exist")
     args = ap.parse_args(argv)
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -28,9 +28,11 @@ def _fake_repo(tmp_path: Path) -> Path:
 
 
 def test_version():
+    from get_sybers_dfir import __version__
     r = runner.invoke(cli.app, ["--version"])
     assert r.exit_code == 0
-    assert "0.1.0" in r.stdout
+    # assert against the package version so a bump doesn't require touching this test
+    assert __version__ in r.stdout
 
 
 def test_list_shows_all_sources():


### PR DESCRIPTION
Addresses the 6 automated-review comments on the promotion PR #64 (all pre-existing dev code surfaced by the dev→main diff). Each was verified against the source before changing:

| # | File | Fix |
|---|------|-----|
| 1 | `get_sybers_dfir/__init__.py` | docstring `dfir` → `dxdfir` (actual entry point); **bump `__version__` 0.1.0 → 0.2.0** (was out of sync with pyproject/galaxy, drives `dxdfir --version`) |
| 2 | `python/README.md` | man-page path `man/dxdfir.1` → `python/man/dxdfir.1` (repo-root form, 2 spots) |
| 3 | `signatures/__init__.py` | YARA docstring no longer claims disk-image/memory scanning — those sources are note-only, not yet ported (matches `yara.py`) |
| 4 | `signatures/__main__.py` | `--fetch` help now states it's a parity flag; provisioning not implemented |
| 5 | `galaxy.yml` | `community.docker` bounded `>=3.10.3,<4.0.0` so a Galaxy install can't pull a breaking 4.x; `requirements.yml` still pins exact 3.10.3 |

Also made `test_cli.test_version` assert against `__version__` so a future bump doesn't require touching the test.

## Verify
- `python -m pytest` — **89 pass** (`dxdfir --version` → `0.2.0`)
- `tests/run-checks.sh` — 103 / 0

Once merged to `dev`, these flow into promotion PR #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)