### PR TITLE
Promote dev → main: fold ingest OOM + concurrency fixes into 0.2.0

### DIFF
--- a/python/get_sybers_dfir/ingest/__init__.py
+++ b/python/get_sybers_dfir/ingest/__init__.py
@@ -207,33 +207,37 @@ def run_l2t(client, processed_dir, container, staging_dir, seen, dry_run, summar
         rel = os.path.relpath(f, processed_dir)
         fh = _file_hash(rel)
         prefix = prepare.staged_name(rel)
-        tables = prepare.split_l2t(f, rel)
-        if not tables:
+        if dry_run:
+            # cheap streaming scan — never holds the (multi-GB) file in memory
+            for _table in prepare.l2t_tables(f):
+                summary["submitted"] += 1
+            continue
+        # Stream the split to per-table files on disk (staging_dir), one record at a
+        # time — a Plaso json_line output can be many GB and must not be buffered.
+        table_files = prepare.split_l2t(f, rel, staging_dir, prefix)
+        if not table_files:
             continue
         file_ok = True
-        for table, lines in tables.items():
-            if not dry_run and table not in ensured:
+        for table, host_tmp in table_files.items():
+            if table not in ensured:
                 client.mgmt("host", f".create-merge table {table} "
                             "(SourceImage:string, Timestamp:datetime, Parser:string, Record:dynamic)")
                 client.mgmt("host", f'.create-or-alter table {table} ingestion json mapping '
                             f'"L2tMapping" ```{L2T_MAPPING}```')
                 ensured.add(table)
-            name = f"{prefix}.{table}"
-            dest = f"{CONTAINER_STAGE}/{name}"
-            if dry_run:
-                summary["submitted"] += 1
-                continue
-            host_tmp = os.path.join(staging_dir, name)
-            with open(host_tmp, "w") as w:
-                w.write("\n".join(lines) + "\n")
+            dest = f"{CONTAINER_STAGE}/{prefix}.{table}"
             if not _docker_cp(host_tmp, container, dest):
                 summary["failed"] += 1
                 file_ok = False
-                continue
-            if not _ingest_batched(client, "host", table, "L2tMapping", "multijson", False,
-                                   [dest], dry_run, summary):
+            elif not _ingest_batched(client, "host", table, "L2tMapping", "multijson", False,
+                                     [dest], dry_run, summary):
                 file_ok = False
-        if file_ok and not dry_run:
+            # free the host staging file as we go — keeps disk use bounded
+            try:
+                os.remove(host_tmp)
+            except OSError:
+                pass
+        if file_ok:
             record_hashes(client, [fh])
             ingested += 1
     summary["sources"]["Plaso l2t -> host.L2t<Parser>"] = {
@@ -264,7 +268,13 @@ def process(processed_dir, only=None, dry_run=False, force=False,
             summary["error"] = f"could not reach container '{container}'"
             return summary
 
-    with tempfile.TemporaryDirectory(prefix="dfir-ingest-") as staging_dir:
+    # Stage on the same (disk-backed) filesystem as the processed data, NOT the
+    # default /tmp — which is often tmpfs (RAM). The l2t split can write several GB
+    # of per-table staging files, and buffering that in RAM would OOM the box.
+    staging_base = os.path.dirname(processed_dir)
+    if not (staging_base and os.path.isdir(staging_base)):
+        staging_base = None  # fall back to the system default
+    with tempfile.TemporaryDirectory(prefix="dfir-ingest-", dir=staging_base) as staging_dir:
         for row in SOURCES:
             if only and only != row["key"]:
                 continue

--- a/python/get_sybers_dfir/ingest/prepare.py
+++ b/python/get_sybers_dfir/ingest/prepare.py
@@ -121,22 +121,73 @@ def table_name(parser: str) -> str:
     return "L2t" + "".join(p[:1].upper() + p[1:] for p in parts) if parts else "L2tUnknown"
 
 
-def split_l2t(path: str, source_rel: str) -> dict[str, list[str]]:
-    """Group a Plaso json_line file by top-level parser; return
-    {table -> [wrapped JSONL strings]} with {SourceImage, Timestamp, Parser, Record}.
-    A zero/absent/out-of-range timestamp is left unset (not 1970)."""
-    out: dict[str, list[str]] = {}
-    for rec in _records(path):
-        parser = str(rec.get("parser") or "unknown")
-        table = table_name(parser)
-        row = {"SourceImage": source_rel, "Parser": parser, "Record": rec}
-        ts = rec.get("timestamp")
-        if isinstance(ts, (int, float)) and ts > 0:
+def _iter_jsonl(path: str):
+    """Yield records from a JSON Lines file, ONE LINE AT A TIME (no whole-file read).
+
+    Unlike :func:`_records`, this never slurps the file into memory, so it is safe on
+    a multi-GB Plaso json_line output. Vanish-tolerant (missing file -> nothing) and
+    per-line error-tolerant (a bad line is skipped)."""
+    try:
+        fh = open(path, encoding="utf-8", errors="replace")
+    except OSError:
+        return
+    with fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
             try:
-                row["Timestamp"] = datetime.datetime.fromtimestamp(
-                    ts / 1_000_000, datetime.timezone.utc
-                ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            except (OverflowError, OSError, ValueError):
-                pass
-        out.setdefault(table, []).append(json.dumps(row))
-    return out
+                yield json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+
+def _l2t_row(rec: dict, source_rel: str) -> tuple[str, str]:
+    """(table, wrapped-JSONL-string) for one Plaso record — {SourceImage, Timestamp,
+    Parser, Record}. A zero/absent/out-of-range timestamp is left unset (not 1970)."""
+    parser = str(rec.get("parser") or "unknown")
+    row = {"SourceImage": source_rel, "Parser": parser, "Record": rec}
+    ts = rec.get("timestamp")
+    if isinstance(ts, (int, float)) and ts > 0:
+        try:
+            row["Timestamp"] = datetime.datetime.fromtimestamp(
+                ts / 1_000_000, datetime.timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        except (OverflowError, OSError, ValueError):
+            pass
+    return table_name(parser), json.dumps(row)
+
+
+def l2t_tables(path: str) -> dict[str, int]:
+    """Streaming scan of a Plaso json_line file -> {table: record_count}. Memory is
+    bounded (a small dict of table names). Used for a cheap dry-run report."""
+    counts: dict[str, int] = {}
+    for rec in _iter_jsonl(path):
+        table, _ = _l2t_row(rec, "")
+        counts[table] = counts.get(table, 0) + 1
+    return counts
+
+
+def split_l2t(path: str, source_rel: str, out_dir: str, prefix: str) -> dict[str, str]:
+    """Stream a Plaso json_line file into per-parser table files, WITHOUT holding the
+    file (or the split) in memory — the input can be many GB. Each record is wrapped
+    as {SourceImage, Timestamp, Parser, Record} and appended to ``out_dir/{prefix}.
+    {table}`` as it is read. Returns {table: filepath}. Only a handful of open file
+    handles (one per parser table) and one record are live at a time."""
+    handles: dict[str, "object"] = {}
+    paths: dict[str, str] = {}
+    try:
+        for rec in _iter_jsonl(path):
+            table, line = _l2t_row(rec, source_rel)
+            fh = handles.get(table)
+            if fh is None:
+                fp = os.path.join(out_dir, f"{prefix}.{table}")
+                fh = open(fp, "w", encoding="utf-8")
+                handles[table] = fh
+                paths[table] = fp
+            fh.write(line)
+            fh.write("\n")
+    finally:
+        for fh in handles.values():
+            fh.close()
+    return paths

--- a/python/tests/test_ingest.py
+++ b/python/tests/test_ingest.py
@@ -95,11 +95,34 @@ def test_split_l2t_groups_and_converts_timestamp(tmp_path):
         '{"parser":"filestat","timestamp":1609459200000000,"image_hostname":"H"}\n'
         '{"parser":"winreg/appcompatcache","timestamp":0}\n'
     )
-    out = prepare.split_l2t(str(f), "log2timeline/jsonl/host.jsonl")
+    out_dir = tmp_path / "stage"
+    out_dir.mkdir()
+    # streaming split: writes one file per table, returns {table: filepath}
+    out = prepare.split_l2t(str(f), "log2timeline/jsonl/host.jsonl", str(out_dir), "H")
     assert set(out) == {"L2tFilestat", "L2tWinreg"}
-    fs = json.loads(out["L2tFilestat"][0])
+    fs_lines = [json.loads(x) for x in open(out["L2tFilestat"]) if x.strip()]
+    assert len(fs_lines) == 1
+    fs = fs_lines[0]
     assert fs["Parser"] == "filestat" and fs["SourceImage"].endswith("host.jsonl")
     assert fs["Timestamp"] == "2021-01-01T00:00:00.000000Z"
+    # the staged file is named {prefix}.{table}
+    assert out["L2tFilestat"].endswith("H.L2tFilestat")
     # zero timestamp -> left unset (not 1970)
-    wr = json.loads(out["L2tWinreg"][0])
+    wr = [json.loads(x) for x in open(out["L2tWinreg"]) if x.strip()][0]
     assert "Timestamp" not in wr
+
+
+def test_l2t_tables_streaming_scan(tmp_path):
+    f = tmp_path / "host.jsonl"
+    f.write_text(
+        '{"parser":"filestat","timestamp":1}\n'
+        '{"parser":"filestat","timestamp":2}\n'
+        '{"parser":"winreg/appcompatcache","timestamp":0}\n'
+        '\n'                                  # blank line skipped
+        'not-json\n'                          # bad line skipped
+    )
+    assert prepare.l2t_tables(str(f)) == {"L2tFilestat": 2, "L2tWinreg": 1}
+
+
+def test_iter_jsonl_missing_file_yields_nothing(tmp_path):
+    assert list(prepare._iter_jsonl(str(tmp_path / "gone.jsonl"))) == []


### PR DESCRIPTION
Clean one-commit promotion (replaces #68, whose 3-way base was stale from the earlier history-rewriting promotion).

`main` and `dev` were content-identical except three files; this applies exactly that delta on top of `main`, so it's a **conflict-free fast-forward** and afterwards `main`'s tree matches `dev` exactly.

- ingest: stream the Plaso l2t split to disk — OOM fix on multi-GB json_line (#67)
- ingest: tolerate a processed file vanishing mid-read (concurrent processing, #59)

After merge, re-point `v0.2.0` and its release to the new `main` head (I can't move a published tag — commands below).