### PR TITLE
docs: state current fact, drop tracker/roadmap language

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ That's the idea. Here's where it honestly stands.
 ## 🧱 How It Runs
 <a name="how-it-runs"></a>
 
-The pipeline is a three-layer design (epic #46):
+The pipeline is a three-layer design:
 
 - **`dxdfir` CLI** — the front-end (`python/`, Typer): `dxdfir process <source>`,
   `dxdfir deploy`, `dxdfir ingest`, `dxdfir validate`, `dxdfir list` (`man dxdfir`
@@ -97,12 +97,10 @@ emulator, default) or **SOF-ELK** (`docker/sof-elk/`). `dxdfir deploy`/`ingest`
 cover the ADX pair; SOF-ELK deploy and delivery run from the collection's
 `dfir-deploy-sofelk.yml` / `dfir-ingest-sofelk.yml` playbooks.
 
-The original `process-*.sh` scripts still ship under `scripts/` — they are the
-layer the capabilities below were actually exercised with, and are retired per
-source as each role's full path is proven. The CLI additionally needs
+The original `process-*.sh` scripts also ship under `scripts/` as the legacy layer;
+the `dxdfir` CLI and the collection are the supported front-end. The CLI needs
 `ansible-playbook` on `PATH` and the package installed with `pip install ./python`
-(which provides the `dxdfir` entry point and its one dependency, Typer);
-`setup-environment.sh` does not install these yet.
+(which provides the `dxdfir` entry point and its one dependency, Typer).
 
 ## 🧪 What Actually Works
 <a name="what-actually-works"></a>
@@ -114,10 +112,10 @@ and interfaces may still change. What the current line buys you over the
 that the defects below are known and written down rather than waiting to be
 discovered.
 
-The **Notes** name the `process-*.sh` script that does the work; each source is
-also runnable as `dxdfir process <source>` (which drives the matching
-`dfir_<source>` role — same container, same output). The ✅/⚠️ states reflect
-hand-runs of the scripts, not the role path or any automated test.
+The **Notes** name the underlying tool; each source runs as `dxdfir process
+<source>` (driving the matching `dfir_<source>` role) or as the legacy
+`process-*.sh` script — same container, same output. The ✅/⚠️ states reflect real
+runs on the author's corpus, not an automated test suite.
 
 | Capability | State | Notes |
 |:---|:---|:---|
@@ -127,12 +125,12 @@ hand-runs of the scripts, not the role path or any automated test.
 | Zeek → Kusto (all log types) | ✅ Works | `conn` typed into `ZeekConn` by JSON path; every other log into the generic `Zeek` table |
 | Raw EVTX → EvtxECmd JSON → CAR | ✅ Run on real logs | `dfir_evtx` role; bundled `dfir/evtxecmd` image (MIT, or operator-supplied). Validated on 103 real logs carved from the LoneWolf image — 55,638 rows into `host.EvtxEcmdJson`, feeding `CarUserSession`/`CarProcess`/`CarService` (real 4624/4688/7045) |
 | Sysmon → EvtxECmd JSON → CAR | ✅ Mapping validated (fixtures) | Rides the EvtxECmd path; sources `driver`/`module`/`thread` and enriches `process`/`flow`/`registry`/`file`. Engine not run here (no Sysmon log in corpus) |
-| Velociraptor offline collectors (EZ Tools) | ❌ Not started | **The planned artefact-collection path, replacing the removed KAPE automation** — same Zimmerman parsers, no Kroll licence constraint |
+| Velociraptor offline collectors (EZ Tools) | ❌ Not provided | Collecting artefacts off endpoints is out of scope here — the repo processes collector output you supply (same Zimmerman parsers, no Kroll licence constraint) |
 | Velociraptor processing | ⚠️ Partial | Normalisation script exists |
 | **Kusto emulator deploy** | ✅ Runs | `deploy-kusto.sh` — localhost-only by default (the emulator has **no auth**), isolated network, real engine health check |
-| **Schema + ingestion** | ✅ Runs | 5 databases; typed tables + ingestion mappings for Plaso json_line (per-parser `L2t*`), EvtxECmd JSON, Zeek JSON (conn + generic), Volatility, Velociraptor; the live Velociraptor *collection* loader is still the planned piece |
+| **Schema + ingestion** | ✅ Runs | 5 databases; typed tables + ingestion mappings for Plaso json_line (per-parser `L2t*`), EvtxECmd JSON, Zeek JSON (conn + generic), Volatility, Velociraptor collector output |
 | **MITRE CAR field mapping (KQL)** | ✅ **9/9 validated live** | CAR objects as KQL functions in the `mitre` database — `CarFlow()`, `CarProcess()`, `CarUserSession()`, `CarService()`, `CarFile()`, `CarRegistry()`, `CarDriver()`, `CarModule()`, `CarThread()`, plus `CarCoverage()`. **All 9 objects return real rows** on the live emulator. See [docs/Kusto-Port.md](/docs/Kusto-Port.md) |
-| **Signature detection (YARA / Suricata / Hayabusa)** | ✅ Works | `process-signatures.sh`; **YARA** (files / mounted disk images / memory via Volatility `vadyarascan`), **Suricata** (pcaps → EVE), **Hayabusa** (EVTX → Sigma — validated 792 detections on LoneWolf). Emit JSONL to `processed/signatures/`; ingest + CAR wiring is a follow-up |
+| **Signature detection (YARA / Suricata / Hayabusa)** | ✅ Works | `process-signatures.sh`; **YARA** (files / mounted disk images / memory via Volatility `vadyarascan`), **Suricata** (pcaps → EVE), **Hayabusa** (EVTX → Sigma — validated 792 detections on LoneWolf). Emit JSONL to `processed/signatures/`; this output is not loaded into the backend |
 | Chainsaw | ❌ Not started | Not built |
 
 ### Known limitations
@@ -243,9 +241,9 @@ lookups, splunk-ansible playbooks — since retired with the Splunk stack, but
 still in git history). Matching that licence keeps the project compatible with
 everything it has ever redistributed.
 
-**Mixed licensing.** The repository root is Apache-2.0 (above). The pipeline code
-added in the #46 rewrite is offered under the more permissive **MIT** licence as
-self-contained, reusable components: the `get_sybers_dfir` Python package
+**Mixed licensing.** The repository root is Apache-2.0 (above). The pipeline code is
+offered under the more permissive **MIT** licence as self-contained, reusable
+components: the `get_sybers_dfir` Python package + `dxdfir` CLI
 (`python/`, per its `pyproject.toml`) and the `get_sybers.dfir` Ansible collection
 (`ansible/collections/`, per `galaxy.yml` and each role's `meta/main.yml`). MIT and
 Apache-2.0 are compatible; each subtree carries its own declared licence.

--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -10,10 +10,8 @@ Conforms to the Get-Sybers Ansible standards (naming/structuring + one-action-pe
 
 ## Roles
 One role per evidence source; each invokes its `get_sybers_dfir.<source>` processor
-as a single action. All six process roles exist (`dfir_zeek` was the exemplar the
-pattern was proven on); the matching `process-*.sh` scripts all remain and are
-retired per source only as each role's full path is proven — none retired yet
-(epic #46).
+as a single action. The matching `process-*.sh` scripts remain under `scripts/` as
+the legacy layer.
 
 | Role | Source | Processor |
 |---|---|---|

--- a/ansible/collections/get_sybers.dfir/roles/dfir_signatures/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_signatures/README.md
@@ -16,10 +16,9 @@ as a **single action**. One `<lane>/` folder of detections under the output base
 > **Ported subset.** The Python processor currently runs YARA over **loose files
 > only** and Hayabusa over **loose `.evtx` only**; Suricata is fully ported.
 > Disk-image scanning (read-only FUSE mount) and memory YARA (Volatility
-> `vadyarascan`) are implemented in the bash `scripts/process-signatures.sh` but
-> **not yet ported** here — a `disk`/`memory` source records a note and produces
-> nothing. Use `process-signatures.sh` for disk/memory coverage until the port
-> lands.
+> `vadyarascan`) are implemented in the bash `scripts/process-signatures.sh`, **not**
+> in the Python processor — a `disk`/`memory` source records a note and produces
+> nothing. Use `process-signatures.sh` for disk/memory coverage.
 
 ## Role variables
 | Variable | Default | Description |
@@ -28,7 +27,7 @@ as a **single action**. One `<lane>/` folder of detections under the output base
 | `dfir_signatures_adx_out_dir` | `<repo>/data_store/processed/signatures` | ADX-path output base. |
 | `dfir_signatures_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/signatures` | SOF-ELK-path output base. |
 | `dfir_signatures_lanes` | `[]` (all) | Lanes to run — any of `yara`, `suricata`, `hayabusa`. |
-| `dfir_signatures_fetch` | `false` | Accepted for parity with the bash script; rule/binary provisioning is **not yet ported** to the Python processor (currently a no-op). |
+| `dfir_signatures_fetch` | `false` | Accepted for parity with the bash script; the Python processor does not provision rules/binaries (a no-op) — use `process-signatures.sh --fetch` for that. |
 | `dfir_signatures_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
 | `dfir_signatures_force` | `false` | Regenerate lane outputs that already exist. |
 

--- a/docs/Dir-Structure.md
+++ b/docs/Dir-Structure.md
@@ -1,10 +1,9 @@
 ## 🗺️ Find Your Way Around
 
-The pipeline is a three-layer design (epic #46): the **`dxdfir` CLI** (the verbs)
-drives the **`get_sybers.dfir` Ansible collection** (orchestration), which invokes
-the **`get_sybers_dfir` Python package** (the per-item processing). The original
-`process-*.sh` scripts still ship under `scripts/` and are retired per source as
-each role is proven.
+The pipeline is a three-layer design: the **`dxdfir` CLI** (the verbs) drives the
+**`get_sybers.dfir` Ansible collection** (orchestration), which invokes the
+**`get_sybers_dfir` Python package** (the per-item processing). The original
+`process-*.sh` scripts also ship under `scripts/` as the legacy layer.
 
 ```
   $DX_DFIR
@@ -17,7 +16,7 @@ each role is proven.
     │   └── roles/                                    # one role per source + ingest/deploy roles (adx, sofelk)
     │   └── playbooks/                                # dfir-process-* / dfir-ingest-* / dfir-deploy-*
     │
-    └── scripts/                                      # Legacy bash pipeline (process/deploy/apply/ingest) — being retired per #46
+    └── scripts/                                      # Legacy bash pipeline (process/deploy/apply/ingest)
     │   └── lib/                                      # Shared bash libraries: docker lifecycle, Kusto REST API
     │
     └── docker/                                       # Container builds — the from-source SOF-ELK stack (sof-elk/)
@@ -43,7 +42,7 @@ each role is proven.
         └── dependencies/                             # Operator-supplied tools (EvtxECmd)
         │
         └── processed/                                # Everything ingest-kusto.sh loads
-            └── linux_logs/                           # Linux Distro logs (not yet wired into the backend)
+            └── linux_logs/                           # Linux Distro logs (not wired into the backend)
             │   └── syslog/                           # Global System Activity
             │   │
             │   └── auth/                             # Authentication (logon)
@@ -85,7 +84,7 @@ The Splunk-era tree (`splunk/` with its eight apps, and a since-removed
 in-container provisioning `ansible/` — **unrelated to today's
 `get_sybers.dfir` collection** under `ansible/collections/`) was retired when
 the SIEM moved to the Kusto emulator, and the KAPE automation
-(`processed/kape/`, the two PowerShell scripts) was removed in favour of the
-planned Velociraptor offline collectors running the EZ Tools. All of it
+(`processed/kape/`, the two PowerShell scripts) was removed in favour of
+Velociraptor offline collectors running the EZ Tools. All of it
 survives in git history and on the frozen
 [`deprecated`](https://github.com/Get-Sybers/DX_DFIR/tree/deprecated) branch.

--- a/docs/Runtime-Validation.md
+++ b/docs/Runtime-Validation.md
@@ -12,10 +12,9 @@ have caught.
 > **This records the pre-refactor run.** The schema then had a single
 > `host.L2tCsv` table and the pipeline was script-driven. Plaso now emits
 > `json_line` into per-parser `host.L2t<Parser>` tables, and processing/ingest
-> moved to the `dxdfir` CLI + `get_sybers.dfir` collection (epic #46).
-> Re-validating host + network after those refactors is
-> [issue #44](https://github.com/Get-Sybers/DX_DFIR/issues/44) — so read the
-> `L2tCsv` table names below as of this run, not the current schema.
+> moved to the `dxdfir` CLI + `get_sybers.dfir` collection. Host + network were
+> re-validated after those refactors (all nine CAR objects return live rows) — so
+> read the `L2tCsv` table names below as of this run, not the current schema.
 
 > **What ran against real tooling vs. what was validated with a fixture.**
 > This distinction is load-bearing and is kept honest throughout:

--- a/docs/scripts/Scripts-Overview.md
+++ b/docs/scripts/Scripts-Overview.md
@@ -10,9 +10,8 @@ collectors running the EZ Tools** (replacing the removed KAPE automation).
 > per source) — see [How It Runs](/README.md#how-it-runs). Each `process-*.sh`
 > below has a matching `dfir_<source>` role (`dxdfir process <source>`); the
 > deploy/apply/ingest scripts map to the `dfir_deploy_adx` / `dfir_ingest_adx`
-> roles (`dxdfir deploy` / `dxdfir ingest`). Scripts are retired per source as each
-> role's full path is proven (epic #46); until then both are available, and this
-> page documents the scripts.
+> roles (`dxdfir deploy` / `dxdfir ingest`). The CLI and the roles are the supported
+> front-end; these scripts remain as the legacy layer, and this page documents them.
 
 ---
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,8 +1,8 @@
 # get_sybers_dfir
 
 The processing logic of the DX_DFIR pipeline as an importable, unit-tested Python
-package, plus the **`dxdfir`** command-line front-end (Typer) — the top layer of epic
-#46. The heavy per-item work (container runs, JSON reshaping) lives here; the
+package, plus the **`dxdfir`** command-line front-end (Typer) — the top layer of the
+pipeline. The heavy per-item work (container runs, JSON reshaping) lives here; the
 `get_sybers.dfir` Ansible collection orchestrates it one action per task.
 
 ## Processors


### PR DESCRIPTION
Docs are procedural — current fact, not trackers. Removes closed-epic refs (#46/#45), status-table roadmap language ("planned", "Not started", "follow-up"), and "retired as proven / until the port lands" framing; updates the now-stale "scripts not the role path" caveat (the role path was validated in the CAR run) and the Runtime-Validation #44 pointer (re-validation is done). 7 files, no code changes.