### PR TITLE
fix: CarFlow sub-second end_time (#37) + drop null Ja3 from ZeekSsl (#36)

### DIFF
--- a/kusto/schema/20-network.kql
+++ b/kusto/schema/20-network.kql
@@ -196,7 +196,7 @@ ZeekSsl() {
     | project Ts, Uid = tostring(Record.uid),
               SrcIp = tostring(Record.["id.orig_h"]), DestIp = tostring(Record.["id.resp_h"]),
               Version = tostring(Record.version), Cipher = tostring(Record.cipher),
-              ServerName = tostring(Record.server_name), Ja3 = tostring(Record.ja3), Record
+              ServerName = tostring(Record.server_name), Record
 }
 
 .create-or-alter function

--- a/kusto/schema/40-mitre.kql
+++ b/kusto/schema/40-mitre.kql
@@ -136,7 +136,7 @@ CarFlow_Zeek() {
         proto_info   = Service,
         ["flags"]    = History,   // `flags` is a KQL reserved word — must be bracket-quoted
         start_time   = Ts,
-        end_time     = iff(isnotnull(DurationSec), datetime_add('second', toint(DurationSec), Ts), datetime(null)),
+        end_time     = iff(isnotnull(DurationSec), datetime_add('microsecond', tolong(DurationSec * 1000000), Ts), datetime(null)),
         packet_count = coalesce(OrigPktsN, 0) + coalesce(RespPktsN, 0)
 }
 


### PR DESCRIPTION
Two field-mapping fixes found during Zeek validation (#29), both verified live against the running emulator (CarFlow: 70.6M rows; ZeekSsl: 3,050 rows).

## #37 — CarFlow `end_time` truncated sub-second duration to whole seconds
`CarFlow_Zeek()` computed `end_time` with `datetime_add('second', toint(DurationSec), Ts)`, truncating Zeek's float `duration` to whole seconds. Every sub-second flow collapsed to `end_time == start_time`.

**Fix:** `datetime_add('microsecond', tolong(DurationSec * 1000000), Ts)` — microsecond fidelity, plenty for flow records.

**Verified live:** real flows that previously showed 0 ms now carry 0.8–43 ms; the ~3.3K flows still at zero are genuine zero/null-duration records, not truncation.

## #36 — ZeekSsl projected `Ja3`, a field base Zeek never emits (always null)
JA3 is a separate Zeek package; `ssl.log` from the pipeline's own `process-zeek-ALL.sh` has no `ja3`, so `ZeekSsl().Ja3` was always null — the exact phantom-column anti-pattern the schema guards against.

**Fix:** dropped `Ja3` from the projection (option 1 in the issue). `ServerName` (which *is* emitted) stays.

**Verified live:** `ZeekSsl()` schema drops to 8 columns, `Ja3` gone, still returns 3,050 rows (1,875 with `ServerName`).

Closes #37
Closes #36