### PR TITLE
feat/fix: EvtxECmd lane — disk-image extraction + JSON Payload parsing (validate #31, #6)

### DIFF
--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/defaults/main.yml
@@ -10,6 +10,20 @@ dfir_evtx_evtx_dir: "{{ dfir_evtx_repo_root }}/data_store/raw/other_raw_data/Win
 dfir_evtx_adx_out_dir: "{{ dfir_evtx_repo_root }}/data_store/processed/windows_logs"
 dfir_evtx_sofelk_out_dir: "{{ dfir_evtx_repo_root }}/data_store/processed/sofelk/windows_logs"
 
+# Disk-image inputs (optional): a disk image (E01/raw/VMDK) or a directory of them.
+# When set, WindowsEventLogs (.evtx) are extracted with log2timeline/plaso
+# image_export.py into the stage dir and processed alongside dfir_evtx_evtx_dir, so
+# the lane consumes images directly. Empty (default) => loose .evtx only.
+dfir_evtx_image_src: ""
+# Where --image-src extractions land (empty => <out-dir>/_extracted_evtx). Per-image
+# subdirs, reused across runs (an image whose logs are already staged is not re-pulled).
+dfir_evtx_stage_dir: ""
+# Include Volume Shadow Copies when extracting from a disk image.
+dfir_evtx_vss: false
+# Container providing image_export.py for disk-image extraction (already shipped for
+# the disk/signature lanes).
+dfir_evtx_plaso_image: "log2timeline/plaso:latest"
+
 # How EvtxECmd is supplied — two modes:
 #   bundled  (default): the dfir/evtxecmd image (docker/evtxecmd) bakes EvtxECmd.dll
 #            + Maps/. Nothing to place by hand; build it once with

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
@@ -22,7 +22,31 @@ argument_specs:
       dfir_evtx_evtx_dir:
         type: str
         required: false
-        description: "Directory tree of .evtx logs to parse (recursed)."
+        description: "Directory tree of loose .evtx logs to parse (recursed)."
+      dfir_evtx_image_src:
+        type: str
+        required: false
+        description: >-
+          Optional disk image (E01/raw/VMDK) or directory of images. When set,
+          WindowsEventLogs (.evtx) are extracted with log2timeline/plaso
+          image_export.py into dfir_evtx_stage_dir and parsed alongside
+          dfir_evtx_evtx_dir, so the lane can consume images directly.
+      dfir_evtx_stage_dir:
+        type: str
+        required: false
+        description: >-
+          Where dfir_evtx_image_src extractions land (default <out-dir>/_extracted_evtx).
+          Per-image subdirs; an image already staged is not re-extracted.
+      dfir_evtx_vss:
+        type: bool
+        required: false
+        default: false
+        description: "Include Volume Shadow Copies when extracting from a disk image."
+      dfir_evtx_plaso_image:
+        type: str
+        required: false
+        default: "log2timeline/plaso:latest"
+        description: "Container providing image_export.py for disk-image extraction."
       dfir_evtx_adx_out_dir:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/adx.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/adx.yml
@@ -1,7 +1,7 @@
 ---
 - name: "evtx-adx | parse .evtx into EvtxECmd JSON"
   ansible.builtin.command:
-    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--evtx-dir', dfir_evtx_evtx_dir, '--out-dir', dfir_evtx_adx_out_dir, '--image', dfir_evtx_image] + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--out-dir', dfir_evtx_adx_out_dir, '--image', dfir_evtx_image] + (['--evtx-dir', dfir_evtx_evtx_dir] if dfir_evtx_evtx_dir | length > 0 else []) + (['--image-src', dfir_evtx_image_src, '--plaso-image', dfir_evtx_plaso_image] + (['--stage-dir', dfir_evtx_stage_dir] if dfir_evtx_stage_dir | length > 0 else []) + (['--vss'] if dfir_evtx_vss | bool else []) if dfir_evtx_image_src | length > 0 else []) + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
   environment:
     PYTHONPATH: "{{ dfir_evtx_python_path }}"
   register: dfir_evtx_adx_run

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/main.yml
@@ -7,12 +7,14 @@
   ansible.builtin.assert:
     that:
       - dfir_evtx_pipeline in ['adx', 'sofelk']
-      - dfir_evtx_evtx_dir | length > 0
+      # At least one input source: loose .evtx (evtx_dir) or disk images (image_src).
+      - (dfir_evtx_evtx_dir | length > 0) or (dfir_evtx_image_src | length > 0)
       # A release dir is required only in operator mode; bundled mode bakes it in.
       - dfir_evtx_use_bundled_image | bool or dfir_evtx_evtxecmd_dir | length > 0
     fail_msg: >-
-      dfir_evtx needs dfir_evtx_pipeline (adx|sofelk), a non-empty dfir_evtx_evtx_dir,
-      and (in operator mode) dfir_evtx_evtxecmd_dir.
+      dfir_evtx needs dfir_evtx_pipeline (adx|sofelk), an input source
+      (dfir_evtx_evtx_dir or dfir_evtx_image_src), and (in operator mode)
+      dfir_evtx_evtxecmd_dir.
     quiet: true
   tags: [always]
 

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/sofelk.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/sofelk.yml
@@ -4,7 +4,7 @@
 # tracked in #45.
 - name: "evtx-sofelk | parse .evtx into EvtxECmd JSON"
   ansible.builtin.command:
-    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--evtx-dir', dfir_evtx_evtx_dir, '--out-dir', dfir_evtx_sofelk_out_dir, '--image', dfir_evtx_image] + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--out-dir', dfir_evtx_sofelk_out_dir, '--image', dfir_evtx_image] + (['--evtx-dir', dfir_evtx_evtx_dir] if dfir_evtx_evtx_dir | length > 0 else []) + (['--image-src', dfir_evtx_image_src, '--plaso-image', dfir_evtx_plaso_image] + (['--stage-dir', dfir_evtx_stage_dir] if dfir_evtx_stage_dir | length > 0 else []) + (['--vss'] if dfir_evtx_vss | bool else []) if dfir_evtx_image_src | length > 0 else []) + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
   environment:
     PYTHONPATH: "{{ dfir_evtx_python_path }}"
   register: dfir_evtx_sofelk_run

--- a/dev-scripts/fetch-samples.sh
+++ b/dev-scripts/fetch-samples.sh
@@ -114,6 +114,15 @@ if [[ -t 1 ]]; then CURL_PROGRESS=(--progress-bar); else CURL_PROGRESS=(--no-pro
 # handling of keys with spaces); otherwise curl with a percent-encoded URL.
 download() { # rel dest
     local rel="$1" dest="$2"
+    # A path column that is itself a full URL (http/https) is fetched directly —
+    # for samples hosted outside Digital Corpora (e.g. GitHub). It is stored
+    # already percent-encoded in the manifest, so curl gets it verbatim; aws and
+    # the corpora base are bypassed.
+    case "$rel" in
+        http://*|https://*)
+            curl -fSL "${CURL_PROGRESS[@]}" --retry 3 --retry-delay 5 -C - -o "$dest" "$rel"
+            return ;;
+    esac
     if [[ "$DL_TOOL" == aws ]]; then
         aws s3 cp "$S3_BASE/$rel" "$dest" --no-sign-request --only-show-errors
     else
@@ -422,7 +431,7 @@ fetch_group() { # group
     total=$(awk -F'\t' '{b+=$3} END{print b+0}' <<< "$rows")
     echo "Group: $group"
     echo "Size:  $(human "$total") across $(wc -l <<< "$rows") file(s)"
-    echo "Source: Digital Corpora (public). Nothing here is case evidence."
+    echo "Source: public DFIR corpora. Nothing here is case evidence."
     disk_ok "$total" || return 1
     echo
 
@@ -448,7 +457,7 @@ fetch_file() { # pattern
     total=$(awk -F'\t' '{b+=$3} END{print b+0}' <<< "$rows")
     echo "Matched $(wc -l <<< "$rows") file(s), $(human "$total"):"
     awk -F'\t' '{printf "   %s / %s\n",$1,$2}' <<< "$rows"
-    echo "Source: Digital Corpora (public). Nothing here is case evidence."
+    echo "Source: public DFIR corpora. Nothing here is case evidence."
     disk_ok "$total" || return 1
     echo
 

--- a/dev-scripts/samples-manifest.tsv
+++ b/dev-scripts/samples-manifest.tsv
@@ -1,4 +1,4 @@
-# group	name	bytes	sha256	path (under https://digitalcorpora.s3.amazonaws.com/corpora/)
+# group	name	bytes	sha256	path (under https://digitalcorpora.s3.amazonaws.com/corpora/, OR a full http(s):// URL — percent-encoded — for a sample hosted elsewhere, e.g. GitHub)
 # sha256 of '-' means size-verified only; see fetch-samples.sh --help
 dfrws-challenge-2021	1_Skimmer_mSD.zip	36665139	1c5ad394daa49573f4088a31fb7f6a3f537dbcd092fdfd5abc8b572ebedbc262	dfrws/challenge-2021/1_Skimmer_mSD.zip
 dfrws-challenge-2021	2_Raspberry_Pi_mSD.zip	1814397882	-	dfrws/challenge-2021/2_Raspberry_Pi_mSD.zip
@@ -860,3 +860,15 @@ scenarios-magnet	2022 CTF - Linux.7z	14552740705	-	scenarios/magnet/2022 CTF - L
 scenarios-magnet	2022 CTF - Takeout.zip	2580941	-	scenarios/magnet/2022 CTF - Takeout.zip
 scenarios-magnet	2022 CTF - Windows.zip	37725211173	-	scenarios/magnet/2022 CTF - Windows.zip
 scenarios-magnet	2022 CTF - iOS Full File System.zip	4711962945	-	scenarios/magnet/2022 CTF - iOS Full File System.zip
+
+# sysmon-attack-samples — real Sysmon .evtx from sbousseaden/EVTX-ATTACK-SAMPLES (MIT),
+#   covering the Sysmon EventIDs the CAR schema maps: 1/5 process, 3 network, 6 driver,
+#   7 module, 8 remote-thread, 11 file, 12/13 registry. Validates the Sysmon CAR objects
+#   (the corpus disk images carry no Sysmon). Routed to other_raw_data/WinEvt/<group>/.
+sysmon-attack-samples	DSE_bypass_BYOV_TDL_dummydriver_sysmon_6_7_13.evtx	69632	1162521cb06986ddef24bff7c044b05d63f37ea8faeaa6acd8cc2529b05c7618	https://raw.githubusercontent.com/sbousseaden/EVTX-ATTACK-SAMPLES/master/Defense%20Evasion/DSE_bypass_BYOV_TDL_dummydriver_sysmon_6_7_13.evtx
+sysmon-attack-samples	apt10_jjs_sideloading_prochollowing_persist_as_service_sysmon_1_7_8_13.evtx	69632	a623b11315eacd9732da5ebeabdb7c72d0f641fdf0ec5d2ec43e360abd13837e	https://raw.githubusercontent.com/sbousseaden/EVTX-ATTACK-SAMPLES/master/Defense%20Evasion/apt10_jjs_sideloading_prochollowing_persist_as_service_sysmon_1_7_8_13.evtx
+sysmon-attack-samples	DE_UAC_Disabled_Sysmon_12_13.evtx	69632	06d462b8367cfc620bc84dbda970cf34bff761e02d9d6e1d33bc48f56bc66e6d	https://raw.githubusercontent.com/sbousseaden/EVTX-ATTACK-SAMPLES/master/Defense%20Evasion/DE_UAC_Disabled_Sysmon_12_13.evtx
+sysmon-attack-samples	Sysmon_12_DE_AntiForensics_MRU_DeleteKey.evtx	69632	1eb4fc9d4fc6c4c36db7c4ec2ae5a6833e6cfb8d26e4c1f8d0653d5a78c533f3	https://raw.githubusercontent.com/sbousseaden/EVTX-ATTACK-SAMPLES/master/Defense%20Evasion/Sysmon_12_DE_AntiForensics_MRU_DeleteKey.evtx
+sysmon-attack-samples	discovery_UEFI_Settings_rweverything_sysmon_6.evtx	69632	1f1903ca9c4a89b9e463c0c0de671da0862b0aa06af9145cfabd0255468b5eba	https://raw.githubusercontent.com/sbousseaden/EVTX-ATTACK-SAMPLES/master/Discovery/discovery_UEFI_Settings_rweverything_sysmon_6.evtx
+sysmon-attack-samples	privesc_rotten_potato_from_webshell_metasploit_sysmon_1_8_3.evtx	69632	03d1d202bdf50f7290da06e816ddf9535705f90acebbb0ccae7d2e62dcbf6699	https://raw.githubusercontent.com/sbousseaden/EVTX-ATTACK-SAMPLES/master/Privilege%20Escalation/privesc_rotten_potato_from_webshell_metasploit_sysmon_1_8_3.evtx
+sysmon-attack-samples	Sysmon_UACME_23.evtx	69632	c742e7767e11e4810cbbe77f53d04e855241b85b1df30c954e9210e50b5ba772	https://raw.githubusercontent.com/sbousseaden/EVTX-ATTACK-SAMPLES/master/Privilege%20Escalation/Sysmon_UACME_23.evtx

--- a/kusto/schema/40-mitre.kql
+++ b/kusto/schema/40-mitre.kql
@@ -95,16 +95,26 @@
 // Sysmon PID, so it is called out at each Sysmon branch.
 
 //=============================================================================
-// Helper — pull a value out of an EvtxECmd Payload XML fragment by Name.
+// Helper — pull a value out of an EvtxECmd Payload by Name.
 //
-// EvtxECmd puts EventData in Payload as <Data Name="X">value</Data>, and its
-// PayloadData1..6 summary fields vary by map, so they are not dependable for a
-// specific value. Same approach as the Splunk-era EXTRACT rules.
+// EvtxECmd's --json output stores EventData in Payload as JSON: an array of
+// {"@Name":"X","#text":"value"} objects under EventData.Data (a field with no
+// value has no "#text"). Its PayloadData1..6 summary fields vary by map, so they
+// are not dependable for a specific value — hence extracting from Payload.
+//
+// The value is captured with an escape-aware regex, then round-tripped through
+// parse_json so JSON escapes are decoded (\\ -> \ in paths, \" -> " in command
+// lines). A legacy fallback matches the old XML shape (<Data Name="X">value</Data>)
+// so payloads captured before the JSON switch still resolve.
 //=============================================================================
 .create-or-alter function
-with (docstring = "Extract <Data Name='key'> from an EvtxECmd Payload fragment", folder = "Helpers")
+with (docstring = "Extract a field from an EvtxECmd Payload by Name (JSON output; falls back to the legacy XML shape)", folder = "Helpers")
 EvtxPayload(payload:string, key:string) {
-    extract(strcat(@'<Data Name="', key, @'">([^<]*)</Data>'), 1, payload)
+    let j = tostring(parse_json(strcat('"',
+        extract(strcat(@'"@Name":"', key, @'","#text":"((?:[^"\\]|\\.)*)"'), 1, payload),
+        '"')));
+    iff(isnotempty(j), j,
+        extract(strcat(@'<Data Name="', key, @'">([^<]*)</Data>'), 1, payload))
 }
 
 //=============================================================================

--- a/python/get_sybers_dfir/evtx.py
+++ b/python/get_sybers_dfir/evtx.py
@@ -18,10 +18,19 @@ EvtxECmd exits 0 on an empty/corrupt log, so a zero-record output is removed and
 counted as failed (not treated as done). Emits a machine-readable summary as JSON on
 stdout so the Ansible task can set an honest ``changed_when`` (``processed > 0``).
 
-Run standalone or via the ``dfir`` CLI:
+Inputs may be loose ``.evtx`` (``--evtx-dir``) or a disk image / directory of images
+(``--image-src``): WindowsEventLogs are pulled out of the image with log2timeline's
+``image_export.py`` (see ``imageexport``) into a stage dir, then parsed like any other
+log — so the lane consumes E01/raw/VMDK evidence without a hand-extraction step.
 
-    python -m get_sybers_dfir.evtx --evtx-dir RAW/WinEvt --out-dir PROCESSED/windows_logs \
-        --evtxecmd-dir DEPENDENCIES/evtxecmd
+Run standalone or via the ``dxdfir`` CLI:
+
+    # loose logs, bundled EvtxECmd image
+    python -m get_sybers_dfir.evtx --evtx-dir RAW/WinEvt --out-dir PROCESSED/windows_logs
+
+    # straight from a disk image
+    python -m get_sybers_dfir.evtx --image-src RAW/disk_images/Host.E01 \
+        --out-dir PROCESSED/windows_logs
 """
 from __future__ import annotations
 
@@ -30,6 +39,8 @@ import json
 import os
 import subprocess
 import sys
+
+from . import imageexport
 
 # Operator-supplied mode: a stock .NET runtime image mounts the operator's release.
 # EvtxECmd's current .NET build targets net9.0, so the runtime must be 9.x — the old
@@ -240,12 +251,57 @@ def process(evtx_dir, out_dir, evtxecmd_dir=None, image=None, force=False) -> di
     return summary
 
 
+def extract_images(image_src, stage_dir, *, plaso_image=imageexport.PLASO_IMAGE,
+                   vss=False, force=False) -> dict:
+    """Pull WindowsEventLogs (``.evtx``) out of every disk image at ``image_src`` into
+    ``stage_dir/<image_stem>/``, so ``process()`` can then run over ``stage_dir`` as if
+    the logs had been supplied loose. Per-image subdirs keep hosts separated.
+
+    Idempotent: an image whose stage subdir already holds ``.evtx`` is skipped unless
+    ``force`` (re-extraction is the slow part). Returns a summary of what was extracted.
+    """
+    stage_dir = os.path.realpath(stage_dir)
+    images = imageexport.discover_images(image_src)
+    summary = {"image_src": os.path.realpath(image_src), "stage_dir": stage_dir,
+               "images": len(images), "extracted": 0, "reused": 0, "failed": 0,
+               "results": []}
+    for img in images:
+        stem = os.path.splitext(os.path.basename(img))[0]
+        dest = os.path.join(stage_dir, stem)
+        have = [os.path.join(r, f) for r, _d, fs in os.walk(dest) for f in fs
+                if f.lower().endswith(".evtx")] if os.path.isdir(dest) else []
+        if have and not force:
+            summary["reused"] += 1
+            summary["results"].append({"image": img, "evtx": len(have), "reused": True})
+            continue
+        try:
+            written = imageexport.extract(img, dest, plaso_image=plaso_image, vss=vss)
+        except subprocess.CalledProcessError:
+            summary["failed"] += 1
+            summary["results"].append({"image": img, "error": "image_export failed"})
+            continue
+        evtx = [f for f in written if f.lower().endswith(".evtx")]
+        summary["extracted"] += len(evtx)
+        summary["results"].append({"image": img, "evtx": len(evtx)})
+    return summary
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         prog="get_sybers_dfir.evtx",
         description="Windows Event Logs (.evtx) -> EvtxECmd normalised JSON",
     )
-    ap.add_argument("--evtx-dir", required=True, help="directory tree of .evtx logs (recursed)")
+    ap.add_argument("--evtx-dir", help="directory tree of loose .evtx logs (recursed). "
+                    "Optional if --image-src is given.")
+    ap.add_argument("--image-src", help="disk image (E01/raw/VMDK) or a directory of them; "
+                    "WindowsEventLogs (.evtx) are extracted with log2timeline/plaso "
+                    "image_export.py, then processed. Combine with or use instead of --evtx-dir.")
+    ap.add_argument("--stage-dir", help="where --image-src extractions land "
+                    "(default: <out-dir>/_extracted_evtx). Per-image subdirs; reused across runs.")
+    ap.add_argument("--plaso-image", default=imageexport.PLASO_IMAGE,
+                    help="container image providing image_export.py (default: %(default)s)")
+    ap.add_argument("--vss", action="store_true",
+                    help="also extract from Volume Shadow Copies during --image-src extraction")
     ap.add_argument("--out-dir", required=True, help="output dir; grouped by source sub-dir (host)")
     ap.add_argument(
         "--evtxecmd-dir", default="",
@@ -260,12 +316,40 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--force", action="store_true", help="reparse logs that already have output")
     args = ap.parse_args(argv)
 
-    # Image and mode are coupled; process() picks the mode-appropriate default when
-    # --image is omitted (bundled image without a release dir, stock runtime with).
-    summary = process(
-        args.evtx_dir, args.out_dir, args.evtxecmd_dir or None,
-        image=args.image, force=args.force,
-    )
+    if not args.evtx_dir and not args.image_src:
+        ap.error("provide --evtx-dir, --image-src, or both")
+
+    out_dir = os.path.realpath(args.out_dir)
+
+    # Disk-image inputs first: extract WindowsEventLogs into the stage dir, then treat
+    # that stage dir as an evtx source alongside any loose --evtx-dir.
+    extract_summary = None
+    sources = []
+    if args.evtx_dir:
+        sources.append(os.path.realpath(args.evtx_dir))
+    if args.image_src:
+        stage_dir = os.path.realpath(args.stage_dir) if args.stage_dir \
+            else os.path.join(out_dir, "_extracted_evtx")
+        extract_summary = extract_images(
+            args.image_src, stage_dir, plaso_image=args.plaso_image,
+            vss=args.vss, force=args.force,
+        )
+        sources.append(stage_dir)
+
+    # Process each source; merge the per-source summaries into one honest total.
+    summary = {"tool": "evtx", "out_dir": out_dir, "sources": [],
+               "files": 0, "processed": 0, "skipped": 0, "empty": 0, "failed": 0}
+    if extract_summary is not None:
+        summary["extract"] = extract_summary
+    for src in sources:
+        s = process(src, out_dir, args.evtxecmd_dir or None,
+                    image=args.image, force=args.force)
+        summary["sources"].append(s)
+        if s.get("error"):
+            summary["error"] = s["error"]
+        for k in ("files", "processed", "skipped", "empty", "failed"):
+            summary[k] += s.get(k, 0)
+
     json.dump(summary, sys.stdout)
     sys.stdout.write("\n")
     if summary.get("error"):

--- a/python/get_sybers_dfir/imageexport.py
+++ b/python/get_sybers_dfir/imageexport.py
@@ -1,0 +1,96 @@
+"""Targeted artefact extraction from disk images, via log2timeline/plaso.
+
+The evtx lane needs real ``.evtx`` files, but evidence often arrives as a disk image
+(E01/raw/VMDK), not loose logs. This module pulls ONLY a named artefact set out of an
+image with Plaso's ``image_export.py`` (dfVFS, userspace, E01-capable) — the default
+``WindowsEventLogs`` copies just ``winevt\\Logs\\*.evtx``, a triage-style collection,
+never the whole filesystem.
+
+It is the Python twin of ``scripts/signatures/lib/disk-image.sh:sig_extract_artifacts``
+(the Hayabusa lane's extractor) — same container, same flags — so the evtx and
+signature lanes source disk-image EVTX the one proven way. Reusing the already-shipped
+``log2timeline/plaso`` image keeps the .NET evtxecmd image free of a dfVFS/pytsk3 stack.
+
+``image_export_argv`` is pure (no I/O) so the container invocation is unit-testable
+without docker.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+# The disk lane already ships this image (scripts/lib + the signature lanes pin it).
+PLASO_IMAGE = "log2timeline/plaso:latest"
+
+# Formats dfVFS can open. Mirrors sig_list_images() in disk-image.sh.
+IMAGE_EXTS = (".e01", ".ex01", ".raw", ".img", ".dd", ".vmdk", ".001", ".aff4")
+
+
+def discover_images(path: str) -> list[str]:
+    """Disk images at ``path``: the file itself if it is one, else every image under
+    it (recursed), sorted, absolute."""
+    path = os.path.realpath(path)
+    if os.path.isfile(path):
+        return [path] if path.lower().endswith(IMAGE_EXTS) else []
+    found = []
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            if name.lower().endswith(IMAGE_EXTS):
+                found.append(os.path.join(root, name))
+    return sorted(found)
+
+
+def image_export_argv(image, out_dir, *, artifact_filters=("WindowsEventLogs",),
+                      plaso_image=PLASO_IMAGE, vss=False):
+    """The ``docker run`` argv for one ``image_export.py`` extraction.
+
+    The image's directory is mounted read-only at ``/data`` and the output dir at
+    ``/out``; ``--artifact_filters`` scopes the copy to the named artefact set(s).
+    ``--partitions all`` so a multi-partition Windows image is fully searched;
+    ``--vss_stores none`` by default (skip shadow copies — set ``vss`` to include them).
+
+    Matches disk-image.sh's invocation exactly. Pure (no I/O).
+    """
+    argv = [
+        "docker", "run", "--rm",
+        "-v", f"{os.path.dirname(image)}:/data:ro",
+        "-v", f"{out_dir}:/out",
+        plaso_image,
+        "image_export.py", "-q", "--partitions", "all",
+        "--vss_stores", "all" if vss else "none",
+        "--artifact_filters", ",".join(artifact_filters),
+        "-w", "/out",
+        f"/data/{os.path.basename(image)}",
+    ]
+    return argv
+
+
+def extract(image, out_dir, *, artifact_filters=("WindowsEventLogs",),
+            plaso_image=PLASO_IMAGE, vss=False) -> list[str]:
+    """Extract the named artefacts from one image into ``out_dir``; return the files
+    written (absolute paths). Creates ``out_dir``. Raises ``CalledProcessError`` if
+    image_export fails; an image with none of the artefacts simply yields ``[]``.
+    """
+    image = os.path.realpath(image)
+    out_dir = os.path.realpath(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    # image_export runs as a non-root user inside the plaso container and creates
+    # nested dirs (Windows/System32/winevt/Logs/...) under /out, so the mount point
+    # must be writable by that uid. Mirrors sig_extract_artifacts's `chmod 777`.
+    try:
+        os.chmod(out_dir, 0o777)
+    except OSError:
+        pass
+    subprocess.run(
+        image_export_argv(image, out_dir, artifact_filters=artifact_filters,
+                          plaso_image=plaso_image, vss=vss),
+        # image_export is chatty on stderr (progress, per-file notes); capture it so
+        # only the caller's own output (e.g. evtx's JSON summary) reaches stdout.
+        capture_output=True,
+        check=True,
+    )
+    written = []
+    for root, _dirs, files in os.walk(out_dir):
+        for name in files:
+            written.append(os.path.join(root, name))
+    return sorted(written)

--- a/python/tests/test_evtx.py
+++ b/python/tests/test_evtx.py
@@ -182,3 +182,43 @@ def test_process_bundled_mode_needs_no_dll(tmp_path, monkeypatch):
     # bundled mode passes no release dir down to the runner
     assert calls["kw"].get("evtxecmd_dir") in (None, "")
     assert calls["image"] == "dfir/evtxecmd:latest"
+
+
+def test_extract_images_reuses_existing(tmp_path, monkeypatch):
+    """An image whose stage subdir already holds .evtx is reused, not re-extracted."""
+    img = tmp_path / "Host.E01"
+    img.write_bytes(b"x")
+    stage = tmp_path / "stage"
+    # pre-seed the stage subdir (image stem) with an already-extracted log
+    dest = stage / "Host"
+    dest.mkdir(parents=True)
+    (dest / "System.evtx").write_bytes(b"x")
+
+    def boom(*a, **k):
+        raise AssertionError("extract() must not run when logs are already staged")
+
+    monkeypatch.setattr(evtx.imageexport, "extract", boom)
+    s = evtx.extract_images(str(img), str(stage))
+    assert s["images"] == 1 and s["reused"] == 1 and s["extracted"] == 0
+
+
+def test_extract_images_runs_and_counts(tmp_path, monkeypatch):
+    img = tmp_path / "Host.raw"
+    img.write_bytes(b"x")
+    stage = tmp_path / "stage"
+
+    def fake_extract(image, out_dir, **kw):
+        os.makedirs(out_dir, exist_ok=True)
+        p = os.path.join(out_dir, "Security.evtx")
+        open(p, "wb").write(b"x")
+        return [p, os.path.join(out_dir, "ignored.txt")]
+
+    monkeypatch.setattr(evtx.imageexport, "extract", fake_extract)
+    s = evtx.extract_images(str(img), str(stage))
+    assert s["extracted"] == 1 and s["reused"] == 0 and s["failed"] == 0
+
+
+def test_main_requires_a_source(capsys):
+    import pytest
+    with pytest.raises(SystemExit):
+        evtx.main(["--out-dir", "/tmp/x"])

--- a/python/tests/test_imageexport.py
+++ b/python/tests/test_imageexport.py
@@ -1,0 +1,71 @@
+"""Unit tests for the pure logic of the disk-image extractor (no docker needed)."""
+import os
+
+from get_sybers_dfir import imageexport
+
+
+def test_argv_matches_disk_image_sh_recipe(tmp_path):
+    img = tmp_path / "Host.E01"
+    img.write_bytes(b"x")
+    out = tmp_path / "out"
+    argv = imageexport.image_export_argv(str(img), str(out))
+    # container + mounts
+    assert argv[:3] == ["docker", "run", "--rm"]
+    assert "-v" in argv and f"{tmp_path}:/data:ro" in argv
+    assert f"{out}:/out" in argv
+    # the plaso tool and its flags (mirrors sig_extract_artifacts)
+    assert "image_export.py" in argv
+    assert argv[argv.index("--partitions") + 1] == "all"
+    assert argv[argv.index("--vss_stores") + 1] == "none"
+    assert argv[argv.index("--artifact_filters") + 1] == "WindowsEventLogs"
+    # the image is referenced by its basename under the /data mount, and is last
+    assert argv[-1] == "/data/Host.E01"
+    assert argv[argv.index("-w") + 1] == "/out"
+
+
+def test_argv_vss_and_multiple_filters(tmp_path):
+    img = tmp_path / "Host.raw"
+    img.write_bytes(b"x")
+    argv = imageexport.image_export_argv(
+        str(img), str(tmp_path / "o"),
+        artifact_filters=("WindowsEventLogs", "WindowsRegistry"), vss=True)
+    assert argv[argv.index("--vss_stores") + 1] == "all"
+    # multiple filters are comma-joined into the single flag image_export expects
+    assert argv[argv.index("--artifact_filters") + 1] == "WindowsEventLogs,WindowsRegistry"
+
+
+def test_argv_custom_plaso_image(tmp_path):
+    img = tmp_path / "d.vmdk"
+    img.write_bytes(b"x")
+    argv = imageexport.image_export_argv(str(img), str(tmp_path / "o"),
+                                         plaso_image="log2timeline/plaso:20240101")
+    assert "log2timeline/plaso:20240101" in argv
+
+
+def test_discover_single_image_file(tmp_path):
+    img = tmp_path / "Host.E01"
+    img.write_bytes(b"x")
+    assert imageexport.discover_images(str(img)) == [os.path.realpath(str(img))]
+
+
+def test_discover_non_image_file_is_empty(tmp_path):
+    f = tmp_path / "notes.txt"
+    f.write_bytes(b"x")
+    assert imageexport.discover_images(str(f)) == []
+
+
+def test_discover_dir_recurses_and_filters_by_ext(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "one.E01").write_bytes(b"x")
+    (tmp_path / "two.raw").write_bytes(b"x")
+    (tmp_path / "skip.evtx").write_bytes(b"x")   # a log, not an image
+    (tmp_path / "readme.md").write_bytes(b"x")
+    found = imageexport.discover_images(str(tmp_path))
+    assert [os.path.basename(p) for p in found] == ["one.E01", "two.raw"]
+    assert all(os.path.isabs(p) for p in found)
+
+
+def test_discover_is_case_insensitive(tmp_path):
+    (tmp_path / "UPPER.E01").write_bytes(b"x")
+    (tmp_path / "lower.e01").write_bytes(b"x")
+    assert len(imageexport.discover_images(str(tmp_path))) == 2


### PR DESCRIPTION
Validating the EvtxECmd lane (#31, #6) end-to-end surfaced two things: the lane couldn't source `.evtx` from disk images, and once it could, a field-mapping bug meant most CAR fields came back empty. Both are fixed here and verified live against the emulator, sourcing logs straight from `LoneWolf.E01`.

## 1. Disk-image EVTX extraction (feature)
The lane needed real `.evtx`, but evidence usually arrives as a disk image. New `--image-src` (a disk image or a directory of them) pulls **only** WindowsEventLogs out of the image with `log2timeline/plaso image_export.py` (dfVFS, E01-capable), into a stage dir, then parses them like any loose log.

This reuses the already-shipped plaso image and mirrors `scripts/signatures/lib/disk-image.sh` (the Hayabusa lane's extractor) exactly — same container, same flags — rather than bolting a dfVFS/pytsk3 stack onto the .NET evtxecmd image (the two options offered on the issue; log2timeline chosen as the DRY, lower-risk one).

- New `get_sybers_dfir.imageexport` (pure argv builder + runner) with unit tests.
- `get_sybers_dfir.evtx`: `--image-src`, `--stage-dir`, `--vss`, `--plaso-image`; extraction is idempotent (an image already staged isn't re-pulled) and merges with any `--evtx-dir`.
- `dfir_evtx` role: `dfir_evtx_image_src` and friends threaded through both pipelines + argument_specs; the input-source assert now accepts either loose logs or images.

**Verified:** 109 `.evtx` extracted from `LoneWolf.E01` in ~12s.

## 2. EvtxPayload parses JSON, not XML (correctness bug — #31, #6)
`EvtxPayload()` matched the legacy XML Payload shape (`<Data Name="X">value</Data>`), but **100% of current EvtxEcmdJson rows store Payload as JSON** (`{"EventData":{"Data":[{"@Name":"X","#text":"value"}]}}`). So every EvtxPayload-derived field was silently empty on current-pipeline data — CarProcess `command_line`/`parent_exe`, CarService `name`/`image_path`/`exe`, CarFlow_Sysmon src/dest ip+port, and the Sysmon CAR objects.

**Fix:** capture the value with an escape-aware regex over the JSON, round-trip through `parse_json` to decode escapes (so `\\` in paths and `\"` in command lines come out right), with a legacy XML fallback so older payloads still resolve.

**Verified live (LoneWolf via the new extraction path → EvtxECmd → ingest):**
| CAR object | before | after |
|---|---|---|
| CarService_Evtx (7045) `name`/`exe` | 0 / 114 | **114 / 114** |
| CarProcess_Security (4688) `parent_exe` | 0 | **72 / 80** |
| CarUserSession (4624/4634) | login 11,036 / logout 96 | unchanged (didn't use EvtxPayload) |

(4688 `command_line` stays empty — confirmed genuine: LoneWolf's 4688 events carry the `CommandLine` field with no value, i.e. command-line auditing wasn't recording it.)

## Notes
- No Sysmon channel in the LoneWolf corpus, so #32 (Sysmon → CarDriver/Module/Thread) stays blocked on inputs, but the same EvtxPayload fix covers it once a Sysmon log is available.
- The `40-mitre.kql` change here is EvtxPayload only; the CarFlow/ZeekSsl fixes are in #74 (different regions, no conflict).
- `tests/run-checks.sh`: 103 passed / 0 failed; Python suite: 101 passed.

Relates to #31, #6

---

## Update — #32 (Sysmon → CAR) validated across ALL mapped Sysmon EventIDs

The corpus has no Sysmon (every distinct Windows image 2009–2022 checked; 211 channels, none Sysmon — it post-dates the older sets). Validated instead against real, recent Sysmon telemetry from `sbousseaden/EVTX-ATTACK-SAMPLES` (loose `.evtx`, gitignored under `data_store/raw`, not committed). Every field below is `EvtxPayload`-derived, so this independently confirms the JSON Payload fix across all seven Sysmon-sourced CAR objects — not just Driver/Module/Thread.

| CAR object | Sysmon EID | rows | fields | real evidence |
|---|---|---|---|---|
| CarProcess_Sysmon | 1 create, 5 terminate | 17 | cmd 14, parent 14 | apt10 sideload chain |
| CarFlow_Sysmon | 3 network | 7 | src/dest ip+port 7/7 | injected `notepad.exe` conns |
| CarFile_Sysmon | 11 create | 2 | file_path 2/2 | `VBoxDrv.sys` dropped by `Furutaka.exe` |
| CarRegistry_Sysmon | 12 key±, 13 value | 11 | key 11/11 (add/remove/edit) | `…\Services\VBoxDrv\*` |
| CarModule_Sysmon | 7 image load | 3 | module_path 3/3 | `ntoskrnl.exe`←`Furutaka.exe` |
| CarDriver_Sysmon | 6 driver load | 2 | image+signer 2/2 | `VBoxDrv.sys`, `RwDrv.sys` (BYOVD) |
| CarThread_Sysmon | 8 remote thread | 3 | tgt_pid+addr 3/3 | cross-process injection |

The two remaining action-variants — CarFile **delete** (EID 23) and CarRegistry **rename** (EID 14) — have no public sample (rare events needing specific Sysmon config). Both use the identical `EvtxPayload` extraction as their validated siblings, so the mapping mechanism is proven. Closes #32.
