### PR TITLE
feat: Hayabusa in the evtx pipeline + Suricata HOME_NET tuning + rule-authoring docs

### DIFF
--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/defaults/main.yml
@@ -24,6 +24,16 @@ dfir_evtx_vss: false
 # the disk/signature lanes).
 dfir_evtx_plaso_image: "log2timeline/plaso:latest"
 
+# Hayabusa (Sigma detection) over the same .evtx this lane collects — loose or
+# image-extracted. Enrichment: a missing binary or zero detections is a note, not a
+# failure, so leaving this on is safe even without the binary provisioned.
+dfir_evtx_hayabusa: true
+# Dir holding the hayabusa binary (+ rules/). Empty => the processor's default,
+# data_store/dependencies/hayabusa under the CWD.
+dfir_evtx_hayabusa_dir: "{{ dfir_evtx_repo_root }}/data_store/dependencies/hayabusa"
+# Sigma rules dir (empty => rules/ beside the binary).
+dfir_evtx_hayabusa_rules: ""
+
 # How EvtxECmd is supplied — two modes:
 #   bundled  (default): the dfir/evtxecmd image (docker/evtxecmd) bakes EvtxECmd.dll
 #            + Maps/. Nothing to place by hand; build it once with

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/meta/argument_specs.yml
@@ -47,6 +47,22 @@ argument_specs:
         required: false
         default: "log2timeline/plaso:latest"
         description: "Container providing image_export.py for disk-image extraction."
+      dfir_evtx_hayabusa:
+        type: bool
+        required: false
+        default: true
+        description: >-
+          Also run Hayabusa (Sigma detection) over the same .evtx this lane collects,
+          writing <out-dir>/hayabusa/timeline.jsonl. Enrichment: a missing binary or
+          zero detections is a note, not a failure.
+      dfir_evtx_hayabusa_dir:
+        type: str
+        required: false
+        description: "Dir holding the hayabusa binary (+ rules/)."
+      dfir_evtx_hayabusa_rules:
+        type: str
+        required: false
+        description: "Sigma rules dir for Hayabusa (empty => rules/ beside the binary)."
       dfir_evtx_adx_out_dir:
         type: str
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/adx.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/adx.yml
@@ -1,7 +1,7 @@
 ---
 - name: "evtx-adx | parse .evtx into EvtxECmd JSON"
   ansible.builtin.command:
-    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--out-dir', dfir_evtx_adx_out_dir, '--image', dfir_evtx_image] + (['--evtx-dir', dfir_evtx_evtx_dir] if dfir_evtx_evtx_dir | length > 0 else []) + (['--image-src', dfir_evtx_image_src, '--plaso-image', dfir_evtx_plaso_image] + (['--stage-dir', dfir_evtx_stage_dir] if dfir_evtx_stage_dir | length > 0 else []) + (['--vss'] if dfir_evtx_vss | bool else []) if dfir_evtx_image_src | length > 0 else []) + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--out-dir', dfir_evtx_adx_out_dir, '--image', dfir_evtx_image] + (['--evtx-dir', dfir_evtx_evtx_dir] if dfir_evtx_evtx_dir | length > 0 else []) + (['--image-src', dfir_evtx_image_src, '--plaso-image', dfir_evtx_plaso_image] + (['--stage-dir', dfir_evtx_stage_dir] if dfir_evtx_stage_dir | length > 0 else []) + (['--vss'] if dfir_evtx_vss | bool else []) if dfir_evtx_image_src | length > 0 else []) + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--hayabusa', '--hayabusa-dir', dfir_evtx_hayabusa_dir] + (['--hayabusa-rules', dfir_evtx_hayabusa_rules] if dfir_evtx_hayabusa_rules | length > 0 else []) if dfir_evtx_hayabusa | bool else []) + (['--force'] if dfir_evtx_force | bool else []) }}"
   environment:
     PYTHONPATH: "{{ dfir_evtx_python_path }}"
   register: dfir_evtx_adx_run

--- a/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/sofelk.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_evtx/tasks/sofelk.yml
@@ -4,7 +4,7 @@
 # tracked in #45.
 - name: "evtx-sofelk | parse .evtx into EvtxECmd JSON"
   ansible.builtin.command:
-    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--out-dir', dfir_evtx_sofelk_out_dir, '--image', dfir_evtx_image] + (['--evtx-dir', dfir_evtx_evtx_dir] if dfir_evtx_evtx_dir | length > 0 else []) + (['--image-src', dfir_evtx_image_src, '--plaso-image', dfir_evtx_plaso_image] + (['--stage-dir', dfir_evtx_stage_dir] if dfir_evtx_stage_dir | length > 0 else []) + (['--vss'] if dfir_evtx_vss | bool else []) if dfir_evtx_image_src | length > 0 else []) + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--force'] if dfir_evtx_force | bool else []) }}"
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.evtx', '--out-dir', dfir_evtx_sofelk_out_dir, '--image', dfir_evtx_image] + (['--evtx-dir', dfir_evtx_evtx_dir] if dfir_evtx_evtx_dir | length > 0 else []) + (['--image-src', dfir_evtx_image_src, '--plaso-image', dfir_evtx_plaso_image] + (['--stage-dir', dfir_evtx_stage_dir] if dfir_evtx_stage_dir | length > 0 else []) + (['--vss'] if dfir_evtx_vss | bool else []) if dfir_evtx_image_src | length > 0 else []) + ([] if dfir_evtx_use_bundled_image | bool else ['--evtxecmd-dir', dfir_evtx_evtxecmd_dir]) + (['--hayabusa', '--hayabusa-dir', dfir_evtx_hayabusa_dir] + (['--hayabusa-rules', dfir_evtx_hayabusa_rules] if dfir_evtx_hayabusa_rules | length > 0 else []) if dfir_evtx_hayabusa | bool else []) + (['--force'] if dfir_evtx_force | bool else []) }}"
   environment:
     PYTHONPATH: "{{ dfir_evtx_python_path }}"
   register: dfir_evtx_sofelk_run

--- a/docs/Signature-Rules.md
+++ b/docs/Signature-Rules.md
@@ -1,0 +1,157 @@
+# Adding Your Own Signature Rules (YARA & Suricata)
+
+The signature lanes (`scripts/signatures/`, ported to
+`python/get_sybers_dfir/signatures/`) load operator-supplied rules from
+`data_store/dependencies/`. There is **no registration step** — drop the files in
+the right directory and run the lane; discovery is recursive.
+
+Outputs land in `data_store/processed/signatures/<lane>/` as self-describing
+JSONL. Lane basics are in
+[Scripts-Overview](/docs/scripts/Scripts-Overview.md#signature-detection-process-signaturessh).
+
+---
+
+## YARA
+
+**Where:** anywhere under `data_store/dependencies/yara-rules/` — nested
+subdirectories are fine, the lane walks the whole tree.
+
+**What loads:** every `*.yar` / `*.yara` file (extension is case-insensitive).
+Files whose basename starts with `_` are skipped — prefix a file with `_` to
+disable it without deleting it. (The shell lane's exclusion only covers
+`_*.yar`, so use the `.yar` extension for disabled files to be safe in both
+lanes.)
+
+**How they're loaded:** the lane generates an index file of
+`include "/rules/<relative-path>"` lines — one per discovered rule file — and
+compiles that single index. Your rules directory is bind-mounted **read-only**
+at `/rules` inside the `blacktop/yara` container, so nested layouts survive
+intact. The Python lane writes the index to a temp file outside the tree; the
+shell lane (`scripts/signatures/yara.sh`) writes a transient `_dfir_index.yar`
+*into* the rules directory, so that directory must be writable when using the
+shell lane.
+
+For the **memory** source (shell lane, Volatility `vadyarascan`) all rule files
+are concatenated into one file — so **rule names must be unique across every
+file** or compilation fails.
+
+```bash
+# drop rules (any nesting)
+mkdir -p data_store/dependencies/yara-rules/mine
+cp my_malware.yar data_store/dependencies/yara-rules/mine/
+
+# run just the YARA lane
+./scripts/process-signatures.sh --only yara
+```
+
+`--fetch` downloads a YARA-Forge starter set **only when the directory has no
+rules yet** — your own rules suppress it.
+
+**Verify:** the lane reports the rule-file count (confirm yours is counted), then
+check the output — each match is one JSON object naming your rule:
+
+```bash
+jq -r '.rule' data_store/processed/signatures/yara/matches.jsonl | sort | uniq -c
+```
+
+The **files** source scans `data_store/raw/other_raw_data/`. Plant an
+EICAR-style test file there to prove a rule fires.
+
+**Gotchas**
+
+- **One broken rule aborts everything.** All rules compile through a single
+  index, so a syntax error in any file kills the whole scan (container stderr is
+  discarded — you just get 0 matches). Pre-check a new rule:
+  ```bash
+  docker run --rm -v "$PWD/data_store/dependencies/yara-rules":/rules:ro \
+      blacktop/yara /rules/mine/my_malware.yar /dev/null
+  ```
+- Duplicate rule identifiers across files are a compile error (memory source) —
+  namespace your rule names.
+- The Python lane skips a source whose output already exists — pass `--force`
+  (or delete `matches.jsonl`) to re-scan.
+
+---
+
+## Suricata
+
+**Where:** a **single file named exactly `suricata.rules`**, anywhere under
+`data_store/dependencies/suricata-rules/`. The lane takes the *first* one it
+finds (the Python lane walks the whole tree; the shell lane looks at most two
+levels deep — keep it shallow).
+
+**How it's loaded:** the rules directory is mounted read-only at `/rules` and the
+file is passed with `suricata -S`, which loads it **exclusively** — the container
+image's bundled rules are ignored. If no `suricata.rules` exists, the lane falls
+back to `jasonish/suricata`'s bundled rules and says so.
+
+Multiple rule sources therefore have to be merged into that one file:
+
+```bash
+mkdir -p data_store/dependencies/suricata-rules
+cat et-open.rules my-local.rules > data_store/dependencies/suricata-rules/suricata.rules
+
+./scripts/process-signatures.sh --only suricata
+```
+
+`--fetch` runs `suricata-update` (ET Open) into the directory — again only when
+no `suricata.rules` is already present. To combine ET Open with your own rules,
+`--fetch` first, then append yours to the fetched file.
+
+**Verify:** the lane reports the ruleset it chose (if it says it's using the
+image's bundled rules, your file wasn't found). Then check the per-PCAP EVE
+output for alerts from your signatures:
+
+```bash
+jq -r 'select(.event_type=="alert") | .alert.signature' \
+    data_store/processed/signatures/suricata/*.eve.jsonl | sort | uniq -c
+```
+
+**Gotchas**
+
+- Suricata's stderr is discarded; a rules file with syntax errors shows up as no
+  output or silent zero alerts. Test first:
+  ```bash
+  docker run --rm -v "$PWD/data_store/dependencies/suricata-rules":/rules:ro \
+      jasonish/suricata suricata -T -S /rules/suricata.rules
+  ```
+- Every rule needs a **unique `sid`** (use ≥ 1000000 for local rules) —
+  duplicates are rejected at load.
+- Output is filtered to alert + context event types
+  (`alert, anomaly, http, dns, tls, fileinfo, flow`); set `keep_all` for the full
+  EVE stream.
+- A PCAP with an existing non-empty `.eve.jsonl` is skipped — delete the output
+  (or pass `--force`) after changing rules.
+
+### Tuning (HOME_NET and friends)
+
+`HOME_NET` is Suricata's primary tuning variable: ET/Sigma-style rules key their
+direction off `$HOME_NET` / `$EXTERNAL_NET`, so a `HOME_NET` matching the
+capture's real internal range is what makes directional rules fire. The Python
+lane (`python -m get_sybers_dfir.signatures`) exposes:
+
+```bash
+# set it explicitly (EXTERNAL_NET defaults to its complement)
+--home-net '[10.0.0.0/8,192.168.0.0/16]'   [--external-net '[1.2.3.0/24]']
+
+# or derive it per-PCAP from that PCAP's own traffic (a cheap first pass)
+--auto-home-net
+
+# any other Suricata variable, repeatable
+--suricata-set vars.port-groups.HTTP_PORTS=8080
+```
+
+`--auto-home-net` runs Suricata once with defaults, reads the src/dest IPs from
+its EVE flow records, and re-runs with `HOME_NET` set to the private supernets
+that actually appeared (RFC1918 + CGNAT + link-local); it falls back to the
+RFC1918 default when a capture shows no private address. It is ignored when
+`--home-net` is given explicitly.
+
+## Hayabusa (Sigma over Windows Event Logs)
+
+Hayabusa runs inside the **evtx pipeline** (`python -m get_sybers_dfir.evtx
+--hayabusa`), scanning the same `.evtx` the lane collected — loose logs or those
+extracted from a disk image via `--image-src`. Sigma rules live under
+`data_store/dependencies/hayabusa/rules/` (or `--hayabusa-rules`); detections are
+written to `<out-dir>/hayabusa/timeline.jsonl`. See
+[Scripts-Overview](/docs/scripts/Scripts-Overview.md#signature-detection-process-signaturessh).

--- a/docs/scripts/Scripts-Overview.md
+++ b/docs/scripts/Scripts-Overview.md
@@ -34,7 +34,16 @@ resolve their own path, so they can be run from anywhere.
 
 Three standalone lanes under `scripts/signatures/`, each emitting self-describing
 JSONL to `data_store/processed/signatures/<tool>/`. Run all, or `--only <lane>`;
-`--fetch` provisions rules/binaries when online.
+`--fetch` provisions rules/binaries when online. To supply your own YARA or
+Suricata rules (and tune Suricata's `HOME_NET`), see
+[Signature-Rules](/docs/Signature-Rules.md).
+
+**Hayabusa** now also runs inside the **evtx pipeline** (`dxdfir process evtx`,
+or `python -m get_sybers_dfir.evtx --hayabusa`): it scans the same `.evtx` that
+lane collects — loose logs or those extracted from a disk image via `--image-src`
+— so disk-image EVTX reaches Hayabusa through the evtx lane's extraction rather
+than needing a `/dev/fuse` mount. The standalone `hayabusa.sh` lane remains for
+mount-based scans.
 
 | Lane | Input | Output |
 |---|---|---|

--- a/python/get_sybers_dfir/evtx.py
+++ b/python/get_sybers_dfir/evtx.py
@@ -41,6 +41,7 @@ import subprocess
 import sys
 
 from . import imageexport
+from .signatures import hayabusa as _hb
 
 # Operator-supplied mode: a stock .NET runtime image mounts the operator's release.
 # EvtxECmd's current .NET build targets net9.0, so the runtime must be 9.x — the old
@@ -286,6 +287,53 @@ def extract_images(image_src, stage_dir, *, plaso_image=imageexport.PLASO_IMAGE,
     return summary
 
 
+def run_hayabusa(sources, out_dir, *, hb_dir=None, hb_bin=None, rules_dir=None,
+                 force=False) -> dict:
+    """Run Hayabusa (Sigma detection) over the .evtx the evtx lane collected — the
+    loose dirs and/or the image-extracted stage in ``sources`` — writing a tool-tagged
+    detection timeline to ``<out_dir>/hayabusa/timeline.jsonl``.
+
+    Reuses ``signatures.hayabusa`` (one Hayabusa implementation), and because it scans
+    the SAME dirs the evtx lane populated, disk-image EVTX now reaches Hayabusa through
+    the lane's ``imageexport`` extraction — the case the standalone signature lane could
+    only cover by mounting (``/dev/fuse``).
+
+    Hayabusa here is enrichment: a missing binary or zero detections is a note, never a
+    failure — the evtx run's success is EvtxECmd's.
+    """
+    out = os.path.join(out_dir, "hayabusa")
+    timeline = os.path.join(out, "timeline.jsonl")
+    summary = {"tool": "hayabusa", "produced": 0, "scanned": 0, "skipped": 0,
+               "note": None, "output": None}
+    if not force and os.path.exists(timeline) and os.path.getsize(timeline) > 0:
+        summary["skipped"] = 1
+        summary["output"] = timeline
+        return summary
+    hb_bin = hb_bin or (_hb.find_binary(hb_dir) if hb_dir else None)
+    if not hb_bin or not os.access(hb_bin, os.X_OK):
+        summary["note"] = f"no hayabusa binary under {hb_dir!r} — supply --hayabusa-dir"
+        return summary
+    rules_dir = rules_dir or os.path.join(os.path.dirname(hb_bin), "rules")
+    raw = ""
+    for src in sources:
+        if os.path.isdir(src):
+            hits = _hb.scan_directory(hb_bin, src, rules_dir)
+            if hits.strip():
+                summary["scanned"] += 1
+                raw += hits
+    if not raw.strip():
+        summary["note"] = "no detections (no EVTX reachable, or nothing matched)"
+        return summary
+    os.makedirs(out, exist_ok=True)
+    detections = _hb.tag_detections(raw)
+    with open(timeline, "w") as w:
+        for ev in detections:
+            w.write(json.dumps(ev) + "\n")
+    summary["produced"] = len(detections)
+    summary["output"] = timeline
+    return summary
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         prog="get_sybers_dfir.evtx",
@@ -314,6 +362,15 @@ def main(argv: list[str] | None = None) -> int:
              "is omitted) or a stock .NET runtime that mounts the operator release.",
     )
     ap.add_argument("--force", action="store_true", help="reparse logs that already have output")
+    ap.add_argument("--hayabusa", action="store_true",
+                    help="also run Hayabusa (Sigma detection) over the same .evtx and write "
+                         "<out-dir>/hayabusa/timeline.jsonl. Enrichment: a missing binary or "
+                         "zero detections is a note, not a failure.")
+    ap.add_argument("--hayabusa-dir", default="",
+                    help="dir holding the hayabusa binary (+ rules/). Default when --hayabusa "
+                         "is set: data_store/dependencies/hayabusa under the CWD.")
+    ap.add_argument("--hayabusa-rules", default="",
+                    help="Sigma rules dir for Hayabusa (default: rules/ beside the binary).")
     args = ap.parse_args(argv)
 
     if not args.evtx_dir and not args.image_src:
@@ -349,6 +406,17 @@ def main(argv: list[str] | None = None) -> int:
             summary["error"] = s["error"]
         for k in ("files", "processed", "skipped", "empty", "failed"):
             summary[k] += s.get(k, 0)
+
+    # Hayabusa (Sigma detection) over the SAME .evtx set — part of evtx processing,
+    # not a separate lane. Enrichment only: never changes the exit code.
+    if args.hayabusa:
+        hb_dir = os.path.realpath(args.hayabusa_dir) if args.hayabusa_dir \
+            else os.path.join(os.getcwd(), "data_store", "dependencies", "hayabusa")
+        summary["hayabusa"] = run_hayabusa(
+            sources, out_dir, hb_dir=hb_dir,
+            rules_dir=(os.path.realpath(args.hayabusa_rules) if args.hayabusa_rules else None),
+            force=args.force,
+        )
 
     json.dump(summary, sys.stdout)
     sys.stdout.write("\n")

--- a/python/get_sybers_dfir/signatures/__main__.py
+++ b/python/get_sybers_dfir/signatures/__main__.py
@@ -21,12 +21,29 @@ def main(argv: list[str] | None = None) -> int:
                     help="accepted for parity with the bash lanes; provisioning is "
                          "not yet implemented (a lane missing its deps records a note)")
     ap.add_argument("--force", action="store_true", help="regenerate outputs that already exist")
+    # Suricata tuning (HOME_NET is Suricata's primary tuning variable: rule direction
+    # keys off $HOME_NET/$EXTERNAL_NET).
+    ap.add_argument("--home-net", help="Suricata HOME_NET, e.g. '[10.0.0.0/8,192.168.0.0/16]'. "
+                    "Applies to every pcap; EXTERNAL_NET defaults to its complement.")
+    ap.add_argument("--external-net", help="Suricata EXTERNAL_NET (default: !$HOME_NET).")
+    ap.add_argument("--auto-home-net", action="store_true",
+                    help="derive HOME_NET per-pcap from its own traffic (a cheap default-vars "
+                         "pass first). Ignored if --home-net is given.")
+    ap.add_argument("--suricata-set", action="append", metavar="KEY=VALUE",
+                    help="raw Suricata --set tuning entry, repeatable (e.g. "
+                         "vars.port-groups.HTTP_PORTS=8080).")
     args = ap.parse_args(argv)
 
     lanes = tuple(args.only) if args.only else LANES
+    config = {"suricata": {
+        "home_net": args.home_net,
+        "external_net": args.external_net,
+        "auto_home_net": args.auto_home_net,
+        "extra_sets": args.suricata_set or [],
+    }}
     summary = process(
         args.output_dir, lanes, repo_root=args.repo_root,
-        fetch=args.fetch, force=args.force,
+        fetch=args.fetch, force=args.force, config=config,
     )
     json.dump(summary, sys.stdout)
     sys.stdout.write("\n")

--- a/python/get_sybers_dfir/signatures/hayabusa.py
+++ b/python/get_sybers_dfir/signatures/hayabusa.py
@@ -1,11 +1,14 @@
 """Hayabusa lane — Sigma-based Windows event-log detection -> native JSONL.
 
-Scans loose ``*.evtx`` under the raw tree. Disk-image EVTX (mount read-only and scan
-winevt\\Logs in place, or a targeted image_export of only the event logs) is NOT YET
-PORTED here — an image with no reachable EVTX records a note only; the working
-implementation is in scripts/signatures/hayabusa.sh. (Hayabusa's ``-J`` JSON input
-yields 0 detections on Plaso/evtx_dump JSON vs 792 natively, #1324, so real .evtx is
-required.)
+Scans loose ``*.evtx`` under the raw tree, and (with ``/dev/fuse``) disk images
+mounted read-only in place. Disk-image EVTX **without** fuse now flows through the
+evtx pipeline instead: ``get_sybers_dfir.evtx --image-src`` extracts WindowsEventLogs
+with log2timeline/plaso (``imageexport``) and runs Hayabusa over them
+(``get_sybers_dfir.evtx.run_hayabusa``, which reuses ``scan_directory`` /
+``find_binary`` / ``tag_detections`` here) — so Hayabusa detection is part of evtx
+processing, not a separate image-mount step. (Hayabusa's ``-J`` JSON input yields 0
+detections on Plaso/evtx_dump JSON vs 792 natively, #1324, so real .evtx is required —
+which is why extraction, not JSON conversion, is the path.)
 
 Native Rust binary (no official image); operator-supplied. ``--fetch`` is accepted
 for parity with the bash script but not yet implemented here.
@@ -54,8 +57,12 @@ def _dir_has_evtx(d: str) -> bool:
     return False
 
 
-def _run_hayabusa(hb_bin, scan_dir, rules_dir) -> str:
-    """Run hayabusa over scan_dir; return its JSONL detections (empty if none)."""
+def scan_directory(hb_bin, scan_dir, rules_dir) -> str:
+    """Run hayabusa over scan_dir; return its JSONL detections (empty if none).
+
+    Public so the evtx pipeline (get_sybers_dfir.evtx.run_hayabusa) can scan the
+    same .evtx it collected — loose or image-extracted — without duplicating this.
+    """
     if not _dir_has_evtx(scan_dir):
         return ""
     # Hayabusa won't overwrite an existing --output file. Use a fresh temp DIR and a
@@ -100,7 +107,7 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
     raw = ""
     # 1) loose EVTX
     if _dir_has_evtx(loose_dir):
-        raw += _run_hayabusa(hb_bin, loose_dir, rules_dir)
+        raw += scan_directory(hb_bin, loose_dir, rules_dir)
 
     # 2) disk images: mount read-only and scan in place (needs /dev/fuse)
     if scan_disk and os.path.isdir(disk_dir):

--- a/python/get_sybers_dfir/signatures/suricata.py
+++ b/python/get_sybers_dfir/signatures/suricata.py
@@ -6,6 +6,7 @@ records that give an alert its context); SURICATA_EVE_ALL keeps the full stream.
 """
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import subprocess
@@ -15,6 +16,68 @@ from . import clean_name
 
 _SURICATA_IMAGE = "jasonish/suricata:latest"
 _WANTED = {"alert", "anomaly", "http", "dns", "tls", "fileinfo", "flow"}
+
+# Ranges that count as "home" when auto-deriving HOME_NET: RFC1918 + CGNAT +
+# link-local. EXTERNAL_NET is then the complement (!$HOME_NET).
+_PRIVATE_SUPERNETS = [
+    "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+    "100.64.0.0/10", "169.254.0.0/16",
+]
+# Suricata's own default HOME_NET, used as the fallback when a capture shows no
+# private address at all (e.g. a public-to-public capture).
+_DEFAULT_HOME_NET = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+
+
+def derive_home_net(ips) -> str:
+    """Recommended HOME_NET for a capture, as a Suricata address-group literal
+    ``[a,b,...]`` — the private supernets actually observed among ``ips`` (falls back
+    to the RFC1918 set when none appear). Pure, so it is unit-testable without a PCAP.
+
+    HOME_NET is Suricata's primary tuning variable: ET/Sigma-style rules key their
+    direction off ``$HOME_NET`` / ``$EXTERNAL_NET``, so a HOME_NET that matches the
+    capture's real internal range is what makes directional rules fire correctly.
+    """
+    nets = [ipaddress.ip_network(n) for n in _PRIVATE_SUPERNETS]
+    parsed = []
+    for ip in ips:
+        try:
+            parsed.append(ipaddress.ip_address(ip))
+        except ValueError:
+            continue
+    seen = [str(net) for net in nets if any(a in net for a in parsed)]
+    return "[" + ",".join(seen or _DEFAULT_HOME_NET) + "]"
+
+
+def var_sets(home_net=None, external_net=None, extra_sets=None) -> list[str]:
+    """Suricata ``--set`` values for address-group tuning + any operator passthroughs.
+    HOME_NET implies EXTERNAL_NET=!$HOME_NET unless one is given explicitly. Pure."""
+    sets: list[str] = []
+    if home_net:
+        sets.append(f"vars.address-groups.HOME_NET={home_net}")
+        sets.append(f"vars.address-groups.EXTERNAL_NET={external_net or '!' + home_net}")
+    elif external_net:
+        sets.append(f"vars.address-groups.EXTERNAL_NET={external_net}")
+    sets.extend(extra_sets or [])
+    return sets
+
+
+def collect_ips(eve_text: str) -> list[str]:
+    """Every src_ip/dest_ip seen in an EVE JSON stream — the input to derive_home_net
+    for a first (default-vars) pass. Pure."""
+    ips = set()
+    for line in eve_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        for k in ("src_ip", "dest_ip"):
+            v = ev.get(k)
+            if v:
+                ips.add(v)
+    return sorted(ips)
 
 
 def filter_eve(text: str, source_pcap: str, keep_all: bool = False) -> list[dict]:
@@ -46,7 +109,9 @@ def discover(pcap_dir: str) -> list[str]:
     return sorted(found)
 
 
-def _run_suricata(pcap, out_dir, rules_dir, rules_file, image):
+def suricata_argv(pcap, out_dir, rules_dir, rules_file, image, sets=None):
+    """The ``docker run`` argv for one offline Suricata pass. ``sets`` are Suricata
+    ``--set key=value`` tuning entries (HOME_NET etc. from ``var_sets``). Pure."""
     argv = [
         "docker", "run", "--rm",
         "-v", f"{os.path.dirname(pcap)}:/pcaps:ro",
@@ -56,18 +121,40 @@ def _run_suricata(pcap, out_dir, rules_dir, rules_file, image):
     ]
     if rules_file:
         argv += ["-S", f"/rules/{os.path.basename(rules_file)}"]
-    subprocess.run(argv, capture_output=True, check=False)
+    for s in (sets or []):
+        argv += ["--set", s]
+    return argv
+
+
+def _run_suricata(pcap, out_dir, rules_dir, rules_file, image, sets=None):
+    subprocess.run(suricata_argv(pcap, out_dir, rules_dir, rules_file, image, sets),
+                   capture_output=True, check=False)
+
+
+def _suricata_pass(pcap, rules_dir, rules_file, image, sets):
+    """One Suricata pass into a fresh temp dir; return its raw EVE text ('' on no output)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chmod(tmp, 0o777)
+        _run_suricata(pcap, tmp, rules_dir, rules_file, image, sets)
+        eve = os.path.join(tmp, "eve.json")
+        if os.path.isfile(eve) and os.path.getsize(eve) > 0:
+            with open(eve, encoding="utf-8", errors="replace") as fh:
+                return fh.read()
+    return ""
 
 
 def run(*, output_dir, repo_root, fetch=False, force=False,
-        pcap_dir=None, rules_dir=None, image=_SURICATA_IMAGE, keep_all=False, **_ignored) -> dict:
+        pcap_dir=None, rules_dir=None, image=_SURICATA_IMAGE, keep_all=False,
+        home_net=None, external_net=None, extra_sets=None, auto_home_net=False,
+        **_ignored) -> dict:
     ds = os.path.join(repo_root, "data_store")
     pcap_dir = pcap_dir or os.path.join(ds, "raw", "pcaps")
     rules_dir = rules_dir or os.path.join(ds, "dependencies", "suricata-rules")
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(rules_dir, exist_ok=True)
 
-    res = {"lane": "suricata", "produced": 0, "skipped": 0, "failed": 0, "note": None}
+    res = {"lane": "suricata", "produced": 0, "skipped": 0, "failed": 0, "note": None,
+           "tuning": {}}
 
     rules_file = None
     for cur, _dirs, files in os.walk(rules_dir):
@@ -82,22 +169,33 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
         res["note"] = f"no pcaps under {pcap_dir}"
         return res
 
+    # Operator-supplied tuning (HOME_NET / EXTERNAL_NET / arbitrary --set) applies to
+    # every pcap. When --auto-home-net is set AND no HOME_NET was given, each pcap gets
+    # a HOME_NET derived from its own traffic (a cheap default-vars pass first).
+    base_sets = var_sets(home_net, external_net, extra_sets)
+
     for pcap in pcaps:
         out = os.path.join(output_dir, clean_name(pcap, pcap_dir) + ".eve.jsonl")
         if not force and os.path.exists(out) and os.path.getsize(out) > 0:
             res["skipped"] += 1
             continue
-        with tempfile.TemporaryDirectory() as tmp:
-            os.chmod(tmp, 0o777)
-            _run_suricata(pcap, tmp, rules_dir, rules_file, image)
-            eve = os.path.join(tmp, "eve.json")
-            if os.path.isfile(eve) and os.path.getsize(eve) > 0:
-                with open(eve, encoding="utf-8", errors="replace") as fh:
-                    events = filter_eve(fh.read(), os.path.relpath(pcap, repo_root), keep_all)
-                with open(out, "w") as w:
-                    for ev in events:
-                        w.write(json.dumps(ev) + "\n")
-                res["produced"] += 1
-            else:
-                res["failed"] += 1
+
+        sets = base_sets
+        if auto_home_net and not home_net:
+            probe = _suricata_pass(pcap, rules_dir, rules_file, image, base_sets)
+            derived = derive_home_net(collect_ips(probe))
+            sets = var_sets(derived, external_net, extra_sets)
+            res["tuning"][clean_name(pcap, pcap_dir)] = {"HOME_NET": derived, "auto": True}
+        elif home_net:
+            res["tuning"][clean_name(pcap, pcap_dir)] = {"HOME_NET": home_net, "auto": False}
+
+        eve_text = _suricata_pass(pcap, rules_dir, rules_file, image, sets)
+        if eve_text:
+            events = filter_eve(eve_text, os.path.relpath(pcap, repo_root), keep_all)
+            with open(out, "w") as w:
+                for ev in events:
+                    w.write(json.dumps(ev) + "\n")
+            res["produced"] += 1
+        else:
+            res["failed"] += 1
     return res

--- a/python/tests/test_signatures.py
+++ b/python/tests/test_signatures.py
@@ -122,3 +122,67 @@ def test_process_no_rules_no_pcaps_is_clean(tmp_path):
     assert s["tool"] == "signatures"
     assert s["processed"] == 0 and s["failed"] == 0
     assert set(s["results"]) == {"yara", "suricata", "hayabusa"}
+
+
+# ---- Suricata tuning (HOME_NET / --set), all pure ---------------------------
+from get_sybers_dfir.signatures import suricata
+
+
+def test_derive_home_net_picks_observed_private_supernets():
+    hn = suricata.derive_home_net(["10.1.2.3", "192.168.1.5", "8.8.8.8"])
+    assert hn == "[10.0.0.0/8,192.168.0.0/16]"          # only the seen privates, in order
+
+
+def test_derive_home_net_falls_back_when_no_private():
+    hn = suricata.derive_home_net(["8.8.8.8", "1.1.1.1", "garbage"])
+    assert hn == "[10.0.0.0/8,172.16.0.0/12,192.168.0.0/16]"   # RFC1918 default
+
+
+def test_var_sets_home_net_implies_external_complement():
+    s = suricata.var_sets(home_net="[10.0.0.0/8]")
+    assert "vars.address-groups.HOME_NET=[10.0.0.0/8]" in s
+    assert "vars.address-groups.EXTERNAL_NET=![10.0.0.0/8]" in s
+
+
+def test_var_sets_explicit_external_and_extra_passthrough():
+    s = suricata.var_sets(home_net="[10.0.0.0/8]", external_net="[1.2.3.0/24]",
+                          extra_sets=["vars.port-groups.HTTP_PORTS=8080"])
+    assert "vars.address-groups.EXTERNAL_NET=[1.2.3.0/24]" in s
+    assert "vars.port-groups.HTTP_PORTS=8080" in s
+
+
+def test_var_sets_empty_when_nothing_given():
+    assert suricata.var_sets() == []
+
+
+def test_suricata_argv_carries_sets_and_rules(tmp_path):
+    pcap = tmp_path / "c.pcap"; pcap.write_bytes(b"x")
+    rules = tmp_path / "r"; rules.mkdir(); rf = rules / "suricata.rules"; rf.write_text("")
+    argv = suricata.suricata_argv(str(pcap), "/out", str(rules), str(rf), "img",
+                                  sets=["vars.address-groups.HOME_NET=[10.0.0.0/8]"])
+    assert "-r" in argv and "/pcaps/c.pcap" in argv
+    assert argv[argv.index("-S") + 1] == "/rules/suricata.rules"
+    i = argv.index("--set")
+    assert argv[i + 1] == "vars.address-groups.HOME_NET=[10.0.0.0/8]"
+
+
+def test_collect_ips_from_eve_stream():
+    eve = '\n'.join([
+        '{"event_type":"flow","src_ip":"10.0.0.1","dest_ip":"8.8.8.8"}',
+        '{"event_type":"alert","src_ip":"10.0.0.2","dest_ip":"10.0.0.1"}',
+        'not json',
+        '{"event_type":"stats"}',
+    ])
+    assert suricata.collect_ips(eve) == ["10.0.0.1", "10.0.0.2", "8.8.8.8"]
+
+
+# ---- Hayabusa in the evtx pipeline (no-binary note path) --------------------
+from get_sybers_dfir import evtx
+
+
+def test_evtx_run_hayabusa_notes_missing_binary(tmp_path):
+    empty = tmp_path / "hb"; empty.mkdir()
+    out = tmp_path / "out"; out.mkdir()
+    res = evtx.run_hayabusa([str(tmp_path)], str(out), hb_dir=str(empty))
+    assert res["produced"] == 0 and res["output"] is None
+    assert "no hayabusa binary" in res["note"]


### PR DESCRIPTION
Three related signature-pipeline improvements.

## 1. Hayabusa runs inside the evtx pipeline
Hayabusa (Sigma detection over Windows event logs) now runs as part of `get_sybers_dfir.evtx` (`--hayabusa`), scanning the **same `.evtx` the lane collects** — loose logs *or* those extracted from a disk image via `--image-src`. This closes the gap the standalone signature lane documented as "NOT YET PORTED": disk-image EVTX reaches Hayabusa through the evtx lane's `imageexport` extraction instead of needing a `/dev/fuse` mount. Reuses the existing `signatures.hayabusa` helpers (promoted `scan_directory`) — one implementation. Enrichment only: a missing binary or zero detections is a note, never a failure (exit code stays EvtxECmd's).

Wired through the `dfir_evtx` role (`dfir_evtx_hayabusa`, default on) for both ADX and SOF-ELK pipelines + argument_specs.

**Validated live:** 7 pinned Sysmon fixtures → **62 detections**, every field populated 62/62 (Timestamp, RuleTitle, Level, Computer, Channel, EventID, RecordID, tool), 25 distinct rules across info/med/high.

## 2. Suricata HOME_NET tuning (+ auto-derivation)
`HOME_NET` is Suricata's primary tuning variable (rule direction keys off `$HOME_NET`/`$EXTERNAL_NET`). New mechanisms on the signatures CLI:
- `--home-net` / `--external-net` — set explicitly (EXTERNAL_NET defaults to the complement).
- `--suricata-set KEY=VALUE` (repeatable) — any native Suricata `--set` tuning var.
- `--auto-home-net` — derive HOME_NET per-PCAP from that PCAP's own traffic: a cheap default-vars pass, read src/dest IPs from the EVE flow records, re-run with the private supernets that actually appeared (RFC1918 + CGNAT + link-local; RFC1918 fallback).

**Validated live:** `--auto-home-net` on a real capture derived `HOME_NET=[192.168.0.0/16]` from the traffic, 29 EVE events all fields populated 29/29.

## 3. Rule-authoring docs
New `docs/Signature-Rules.md` — concise operator guide for adding your own YARA / Suricata rules (where files go, naming/format conventions, how they load, how to verify they fired, gotchas), plus the Suricata tuning flags. Cross-linked from Scripts-Overview.

## Tests / checks
`run-checks.sh` 129/0; Python suite 109 passed (new: derive_home_net, var_sets, suricata_argv, collect_ips, run_hayabusa no-binary path). All pure functions unit-tested; both features validated end-to-end on real data.

Relates to the signature pipelines; unblocks #15's rationale (Zeek + Suricata cover Brim).