### PR TITLE
signatures: DetectRaptor YARA provisioning behind --fetch (pinned + verified)

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -56,6 +56,30 @@ The terms still bind whoever downloads them, and they are not uniform:
 None of these are case evidence. `data_store/` remains deny-by-default and
 holds nothing, and `samples/` is now written the same way.
 
+### DetectRaptor YARA content — fetched, not redistributed
+
+**This repository ships none of it.** The YARA lane's `--fetch`
+(`get_sybers_dfir/signatures/detectraptor.py`) downloads the YARA rulesets from
+[mgreen27/DetectRaptor](https://github.com/mgreen27/DetectRaptor) — commit-pinned,
+sha256-verified — and merges them into
+`data_store/dependencies/yara-rules/detectraptor/detectraptor.yar`, which is
+deny-by-default gitignored. Only the manifest (URLs + hashes) lives in this
+repository, so no redistribution obligation attaches — the same position as the
+sample corpora above.
+
+Terms still bind the operator who fetches, and they are layered:
+
+- **DetectRaptor itself declares no repository-level licence.** Treat the
+  aggregation as all-rights-reserved beyond the fetching-for-use its README
+  invites; do not redistribute the merged file.
+- **Each rule carries its own provenance** — upstream is a YARA-Forge-style
+  aggregation and every rule's `meta` block records `author`, `source_url` and
+  `license_url` (Neo23x0 signature-base, Mandiant, Arkbird_SOLG, …). The merge
+  keeps those blocks byte-for-byte; the per-rule licences (mostly DRL/CC/Apache)
+  govern the rules.
+- DetectRaptor's **VQL artifacts and CSV lookups are not fetched** — they need a
+  Velociraptor server this pipeline does not run.
+
 ---
 
 ---

--- a/ansible/collections/get_sybers.dfir/roles/dfir_signatures/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_signatures/README.md
@@ -27,16 +27,18 @@ as a **single action**. One `<lane>/` folder of detections under the output base
 | `dfir_signatures_adx_out_dir` | `<repo>/data_store/processed/signatures` | ADX-path output base. |
 | `dfir_signatures_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/signatures` | SOF-ELK-path output base. |
 | `dfir_signatures_lanes` | `[]` (all) | Lanes to run — any of `yara`, `suricata`, `hayabusa`. |
-| `dfir_signatures_fetch` | `false` | Accepted for parity with the bash script; the Python processor does not provision rules/binaries (a no-op) — use `process-signatures.sh --fetch` for that. |
+| `dfir_signatures_fetch` | `false` | Provision rules when online: the YARA lane fetches the pinned DetectRaptor ruleset into `yara-rules/detectraptor/` (sha256-verified, merged, idempotent) when it has no rules yet. The other lanes still record a note when their deps are missing — use `process-signatures.sh --fetch` for those. |
 | `dfir_signatures_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
 | `dfir_signatures_force` | `false` | Regenerate lane outputs that already exist. |
 
 ## Rules / binaries
 Operator-supplied: YARA rules under `data_store/dependencies/yara-rules`, ET Open
 under `.../suricata-rules`, the Hayabusa binary under `.../hayabusa`.
-(`dfir_signatures_fetch` / `--fetch` is a no-op in the Python processor —
-provisioning lives in the bash `process-signatures.sh`.) A lane with no rules/inputs
-notes it and produces nothing (not a failure).
+`dfir_signatures_fetch` / `--fetch` provisions the DetectRaptor YARA ruleset when
+the tree has no rules yet (see `docs/Signature-Rules.md` → *DetectRaptor
+content*); Suricata/Hayabusa provisioning still lives in the bash
+`process-signatures.sh`. A lane with no rules/inputs notes it and produces
+nothing (not a failure).
 
 ## Idempotence
 A lane whose output already exists is skipped — the skip lives in the Python

--- a/ansible/collections/get_sybers.dfir/roles/dfir_signatures/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_signatures/meta/argument_specs.yml
@@ -35,7 +35,7 @@ argument_specs:
         type: bool
         required: false
         default: false
-        description: "Accepted for parity with the bash script; provisioning is not yet ported to the Python processor (no-op)."
+        description: "Provision rules when online: the YARA lane fetches the pinned DetectRaptor ruleset when it has no rules yet (sha256-verified, idempotent); other lanes note missing deps."
       dfir_signatures_python_path:
         type: str
         required: false

--- a/docs/Signature-Rules.md
+++ b/docs/Signature-Rules.md
@@ -45,7 +45,47 @@ cp my_malware.yar data_store/dependencies/yara-rules/mine/
 ```
 
 `--fetch` downloads a YARA-Forge starter set **only when the directory has no
-rules yet** — your own rules suppress it.
+rules yet** — your own rules suppress it. The Python lane's `--fetch` provisions
+[DetectRaptor](https://github.com/mgreen27/DetectRaptor) instead — see below.
+
+### DetectRaptor content
+
+[DetectRaptor](https://github.com/mgreen27/DetectRaptor) (Matt Green / mgreen27)
+is bulk Velociraptor detection content. The part this pipeline can consume is its
+**YARA** sets — a curated webshell ruleset plus per-OS file and process sets,
+YARA-Forge-derived with per-rule provenance metadata. Enable either way:
+
+```bash
+# implicitly — the Python YARA lane's --fetch (also dfir_signatures_fetch=true)
+python3 -m get_sybers_dfir.signatures --only yara --fetch \
+    --output-dir data_store/processed/signatures --repo-root .
+
+# explicitly — the provisioning module itself
+python3 -m get_sybers_dfir.signatures.detectraptor \
+    --rules-dir data_store/dependencies/yara-rules
+```
+
+Both download a **commit-pinned, sha256-verified** set of assets and merge them
+into `yara-rules/detectraptor/detectraptor.yar` (~10,700 rules). The merge is
+required: upstream publishes each set for a separate Velociraptor artifact and
+freely repeats rule identifiers across files, but this lane compiles one index —
+so duplicates are dropped first-wins, and rules needing module features the
+`blacktop/yara` build lacks (`telfhash`) are skipped. Per-rule `meta` blocks
+(author, `source_url`, `license_url`) are kept byte-for-byte.
+
+- **Idempotent** — an existing `detectraptor.yar` is left alone; delete it or
+  `--force` (module CLI) to refresh. The lane's `--fetch` also stands down when
+  the tree already has *any* rules, exactly like the shell lane's starter.
+- **Do not combine with YARA-Forge packages** (e.g. the shell `yara.sh --fetch`
+  starter) in one rules dir — DetectRaptor's sets are largely YARA-Forge
+  extracts, and duplicate identifiers fail the whole single-index compile.
+- **Advancing the pin:** bump `_PIN` in
+  `python/get_sybers_dfir/signatures/detectraptor.py`, run
+  `python3 -m get_sybers_dfir.signatures.detectraptor --print-hashes`, paste the
+  digests into `ASSETS`.
+- **Not consumed:** DetectRaptor's VQL artifacts and CSV lookups (they need a
+  Velociraptor server); it ships no Sigma or Suricata rules. Licensing and
+  attribution: [THIRD_PARTY_NOTICES.md](/THIRD_PARTY_NOTICES.md).
 
 **Verify:** the lane reports the rule-file count (confirm yours is counted), then
 check the output — each match is one JSON object naming your rule:

--- a/docs/scripts/Scripts-Overview.md
+++ b/docs/scripts/Scripts-Overview.md
@@ -34,8 +34,9 @@ resolve their own path, so they can be run from anywhere.
 
 Three standalone lanes under `scripts/signatures/`, each emitting self-describing
 JSONL to `data_store/processed/signatures/<tool>/`. Run all, or `--only <lane>`;
-`--fetch` provisions rules/binaries when online. To supply your own YARA or
-Suricata rules (and tune Suricata's `HOME_NET`), see
+`--fetch` provisions rules/binaries when online (the Python YARA lane fetches the
+pinned [DetectRaptor](https://github.com/mgreen27/DetectRaptor) ruleset). To supply
+your own YARA or Suricata rules (and tune Suricata's `HOME_NET`), see
 [Signature-Rules](/docs/Signature-Rules.md).
 
 **Hayabusa** now also runs inside the **evtx pipeline** (`dxdfir process evtx`,

--- a/python/get_sybers_dfir/signatures/__main__.py
+++ b/python/get_sybers_dfir/signatures/__main__.py
@@ -18,8 +18,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--only", action="append", choices=list(LANES),
                     help="run only this lane (repeatable); default all")
     ap.add_argument("--fetch", action="store_true",
-                    help="accepted for parity with the bash lanes; provisioning is "
-                         "not yet implemented (a lane missing its deps records a note)")
+                    help="provision rules when online: the yara lane fetches the pinned "
+                         "DetectRaptor ruleset when it has no rules yet (see "
+                         "signatures/detectraptor.py); the other lanes still record a "
+                         "note when their deps are missing")
     ap.add_argument("--force", action="store_true", help="regenerate outputs that already exist")
     # Suricata tuning (HOME_NET is Suricata's primary tuning variable: rule direction
     # keys off $HOME_NET/$EXTERNAL_NET).

--- a/python/get_sybers_dfir/signatures/detectraptor.py
+++ b/python/get_sybers_dfir/signatures/detectraptor.py
@@ -1,0 +1,219 @@
+"""DetectRaptor YARA provisioning — fetch, verify, merge into one ruleset.
+
+`mgreen27/DetectRaptor <https://github.com/mgreen27/DetectRaptor>`_ ships bulk
+Velociraptor detection content. Most of it (VQL artifacts + the CSV lookups that
+drive them) needs a Velociraptor server and has no consuming lane here; what THIS
+pipeline can run is its ``yara/`` directory — curated YARA rulesets (webshells,
+plus per-OS file and process sets, YARA-Forge-derived with per-rule provenance
+metadata).
+
+Upstream publishes each set for a *separate* Velociraptor artifact, so the sets
+freely repeat rule identifiers (every pair of files collides). The YARA lane
+compiles ONE index of everything under the rules dir, and yara errors on duplicate
+identifiers — so this module downloads the pinned assets, verifies their sha256,
+and merges them into a single deduplicated ``detectraptor/detectraptor.yar``
+(imports hoisted, first occurrence of each rule identifier wins, per-rule ``meta``
+provenance kept intact). Nothing third-party is vendored in the repository: the
+merged file lands under ``data_store/dependencies/yara-rules/`` (deny-by-default
+gitignored) and is re-fetchable from the pin.
+
+CAUTION: the sets are largely YARA-Forge extracts, so the merged file repeats rule
+names from the YARA-Forge packages. Do not put both in one rules dir (e.g. the
+bash ``yara.sh --fetch`` starter) — the lane's single index would fail to compile.
+
+Stdlib only (urllib, gzip, hashlib), like the rest of the signatures package.
+
+    python -m get_sybers_dfir.signatures.detectraptor --rules-dir <yara-rules>
+
+or implicitly: the yara lane's ``--fetch`` calls :func:`fetch` when the merged
+file is absent.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import os
+import re
+import sys
+import urllib.request
+
+# Pinned upstream state: repo commit + sha256 of each downloaded object (the .gz
+# bytes for gzipped assets). A mismatch means upstream moved or the download was
+# tampered with — same discipline as dev-scripts/samples-manifest.tsv. To advance
+# the pin: bump _PIN, re-run with --print-hashes, paste the new digests.
+_REPO = "mgreen27/DetectRaptor"
+_PIN = "4c3cdddcfff334edeeda8875d5839be43978ea8b"  # master @ 2026-08-23
+_RAW = f"https://raw.githubusercontent.com/{_REPO}/{_PIN}/yara/"
+
+# name -> (upstream file, sha256 of the download, gzipped?). Merge precedence is
+# this order: first occurrence of a duplicate rule identifier wins.
+ASSETS: dict[str, tuple[str, str, bool]] = {
+    "webshells": (
+        "webshells.yar",
+        "3a44da109b7033c059aca99b1b8c04ebb8886cf03daacb9fefc435d44f28361a", False),
+    "windows_file": (
+        "full_windows_file.yar.gz",
+        "0b10ae6bd90258bcf1819f56544ffc61de8ec7cca7a3915b825c261053b333c7", True),
+    "linux_file": (
+        "full_linux_file.yar.gz",
+        "d7a764a599fc2b5092d6145d4c2c099fa663242d6a482eba931569bb57c34256", True),
+    "macos_file": (
+        "full_macos_file.yar.gz",
+        "242ac57b50f3ea76e4fad44a6c09fcea1dbdadacd548b6285929daa7b95edb4b", True),
+    "windows_process": (
+        "full_windows_process.yar",
+        "6bd4d1344c810441726450c4b9a1a75c644dc488fe7e8c6dd03a37c0bb567dd4", False),
+    "linux_process": (
+        "full_linux_process.yar",
+        "87415b8adf088a34d6a12a9dc63b6ebfce1e0a123420ec3ba76b656dc947318c", False),
+    "macos_process": (
+        "full_macos_process.yar",
+        "1891f46edecb4a6ac51748be4be1f426499540bf591a15953ce2905331a0869a", False),
+}
+
+# NOT fetched: yara/yara-rules-full.yar (20 MB) — it IS the YARA-Forge "full"
+# package, which the bash yara.sh --fetch already provisions; fetching it here
+# would only duplicate (and collide with) the targeted sets above.
+
+_MERGED_NAME = "detectraptor.yar"
+_RULE_START = re.compile(r"(?m)^(?:private\s+)?rule\s+([A-Za-z0-9_]+)")
+_IMPORT = re.compile(r'(?m)^import\s+"([^"]+)"\s*$')
+
+# Module features the lane's yara build (blacktop/yara, plain libyara) does not
+# have; a rule using one fails the WHOLE single-index compile, so drop it at
+# merge time and count it. telfhash needs a tlsh-enabled build.
+_INCOMPATIBLE = ("telfhash",)
+
+
+def merge_rules(named_texts: list[tuple[str, str]],
+                incompatible: tuple[str, ...] = _INCOMPATIBLE) -> tuple[str, dict]:
+    """Merge YARA sources into one compilable text. Pure.
+
+    Hoists ``import`` statements (deduplicated) to the top and keeps the FIRST
+    occurrence of each rule identifier — upstream repeats identifiers across sets
+    because each set targets its own Velociraptor artifact, but one yara compile
+    must see each name once. Rules using a feature in ``incompatible`` are dropped
+    (one bad rule fails the whole compile). Returns
+    (text, {source: {"kept": n, "dropped": n, "incompatible": n}}).
+    """
+    imports: list[str] = []
+    seen_imports: set[str] = set()
+    seen_rules: set[str] = set()
+    chunks: list[str] = []
+    stats: dict = {}
+    for source, text in named_texts:
+        for mod in _IMPORT.findall(text):
+            if mod not in seen_imports:
+                seen_imports.add(mod)
+                imports.append(f'import "{mod}"')
+        kept = dropped = skipped = 0
+        starts = list(_RULE_START.finditer(text))
+        for i, m in enumerate(starts):
+            end = starts[i + 1].start() if i + 1 < len(starts) else len(text)
+            name = m.group(1)
+            if name in seen_rules:
+                dropped += 1
+                continue
+            body = text[m.start():end]
+            if any(feat in body for feat in incompatible):
+                skipped += 1
+                continue
+            seen_rules.add(name)
+            kept += 1
+            chunks.append(f"// source: {source}\n" + body.rstrip() + "\n")
+        stats[source] = {"kept": kept, "dropped": dropped, "incompatible": skipped}
+    body = "\n".join(chunks)
+    return ("\n".join(imports) + ("\n\n" if imports else "") + body, stats)
+
+
+def _download(url: str, want_sha256: str, gzipped: bool) -> bytes:
+    with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 — pinned https URL
+        blob = resp.read()
+    got = hashlib.sha256(blob).hexdigest()
+    if got != want_sha256:
+        raise ValueError(f"sha256 mismatch for {url}: expected {want_sha256}, got {got}")
+    return gzip.decompress(blob) if gzipped else blob
+
+
+def print_hashes(pin: str) -> None:
+    """Print the sha256 of every asset at ``pin`` — the pin-advance workflow:
+    bump ``_PIN``, run ``--print-hashes``, paste the digests into ``ASSETS``."""
+    raw = f"https://raw.githubusercontent.com/{_REPO}/{pin}/yara/"
+    for name, (fname, _sha, _gz) in ASSETS.items():
+        with urllib.request.urlopen(raw + fname, timeout=120) as resp:  # noqa: S310
+            digest = hashlib.sha256(resp.read()).hexdigest()
+        print(f"{name}: {digest}  # {fname} @ {pin}")
+
+
+def fetch(rules_dir: str, *, assets: list[str] | None = None, force: bool = False) -> dict:
+    """Provision the merged DetectRaptor ruleset under ``rules_dir``.
+
+    Downloads each pinned asset (in-memory, nothing staged on disk), verifies its
+    sha256, merges, and writes ``<rules_dir>/detectraptor/detectraptor.yar``.
+    Skips everything if the merged file already exists (delete it or pass
+    ``force=True`` to refresh). Returns a summary dict; raises on hash mismatch.
+    """
+    names = list(assets) if assets else list(ASSETS)
+    unknown = [n for n in names if n not in ASSETS]
+    if unknown:
+        raise ValueError(f"unknown asset(s): {', '.join(unknown)} (have: {', '.join(ASSETS)})")
+    out = os.path.join(rules_dir, "detectraptor", _MERGED_NAME)
+    if os.path.exists(out) and not force:
+        return {"tool": "detectraptor", "output": out, "skipped": True}
+
+    named_texts = []
+    for name in names:
+        fname, sha, gz = ASSETS[name]
+        blob = _download(_RAW + fname, sha, gz)
+        named_texts.append((fname, blob.decode("utf-8", errors="replace")))
+    merged, stats = merge_rules(named_texts)
+
+    header = (
+        "// DetectRaptor YARA rules — fetched and merged by get_sybers_dfir, do not edit.\n"
+        f"// Upstream: https://github.com/{_REPO} @ {_PIN}\n"
+        f"// Assets:   {', '.join(ASSETS[n][0] for n in names)}\n"
+        "// Duplicate rule identifiers across upstream sets are dropped (first wins);\n"
+        "// per-rule meta (author, source_url, license_url) is upstream's, unmodified.\n"
+        "// Provenance/licensing: THIRD_PARTY_NOTICES.md (DetectRaptor section).\n\n"
+    )
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    tmp = out + ".part"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(header + merged)
+    os.replace(tmp, out)
+    rules = sum(s["kept"] for s in stats.values())
+    return {"tool": "detectraptor", "output": out, "skipped": False,
+            "rules": rules, "sources": stats}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="get_sybers_dfir.signatures.detectraptor",
+        description="Fetch DetectRaptor YARA content (pinned + sha256-verified) and "
+                    "merge it into <rules-dir>/detectraptor/detectraptor.yar",
+    )
+    ap.add_argument("--rules-dir",
+                    help="YARA rules dir (normally data_store/dependencies/yara-rules); "
+                         "required unless --print-hashes")
+    ap.add_argument("--assets", action="append", choices=list(ASSETS),
+                    help="asset to include (repeatable); default all")
+    ap.add_argument("--force", action="store_true", help="refresh an existing merged file")
+    ap.add_argument("--print-hashes", metavar="PIN", nargs="?", const=_PIN, default=None,
+                    help="print each asset's sha256 at PIN (default: the current pin) "
+                         "and exit — the pin-advance workflow")
+    args = ap.parse_args(argv)
+    if args.print_hashes:
+        print_hashes(args.print_hashes)
+        return 0
+    if not args.rules_dir:
+        ap.error("--rules-dir is required (unless --print-hashes)")
+    res = fetch(args.rules_dir, assets=args.assets, force=args.force)
+    import json
+    json.dump(res, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/get_sybers_dfir/signatures/yara.py
+++ b/python/get_sybers_dfir/signatures/yara.py
@@ -12,6 +12,10 @@ YARA has no JSON output and the container's recursive scan hangs, so the file sc
 loops per-file inside ONE container (per-file scans print strings) and the stable text
 form is parsed here. Each match is a self-describing JSON object. parse_vadyarascan()
 exists (and is unit-tested) for when the memory source is wired up.
+
+Rules are operator-supplied under data_store/dependencies/yara-rules. ``--fetch``
+provisions the DetectRaptor ruleset (pinned + sha256-verified, merged into
+detectraptor/detectraptor.yar) when it is absent — see detectraptor.py.
 """
 from __future__ import annotations
 
@@ -153,6 +157,18 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
     res = {"lane": "yara", "sources": list(sources), "produced": 0, "skipped": 0,
            "failed": 0, "note": None}
 
+    if fetch and not _rule_files(rules_dir):
+        # Provision the DetectRaptor ruleset — like the shell lane's YARA-Forge
+        # starter, ONLY when the tree has no rules yet: operator rules suppress it,
+        # and DetectRaptor's sets are YARA-Forge extracts, so dropping the merged
+        # file next to a YARA-Forge set would fail the single-index compile on
+        # duplicate identifiers. Offline/failed fetch is a note, not a failure.
+        from . import detectraptor
+        try:
+            detectraptor.fetch(rules_dir)
+        except Exception as exc:  # noqa: BLE001 — network/hash errors surface as a note
+            res["note"] = f"detectraptor fetch failed: {exc}"
+
     rules = _rule_files(rules_dir)
     if not rules:
         res["note"] = f"no rules in {rules_dir}"
@@ -180,9 +196,11 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
         if not force and os.path.exists(out):
             res["skipped"] += 1
         elif not have_fuse():
-            res["note"] = "disk: /dev/fuse unavailable — mount-enable the host or point files at raw"
+            note = "disk: /dev/fuse unavailable — mount-enable the host or point files at raw"
+            res["note"] = f"{res['note']}; {note}" if res["note"] else note
         else:
-            res["note"] = "disk: mounting supported but requires ewfmount/ntfs-3g at runtime"
+            note = "disk: mounting supported but requires ewfmount/ntfs-3g at runtime"
+            res["note"] = f"{res['note']}; {note}" if res["note"] else note
 
     if "memory" in sources:
         out = os.path.join(output_dir, "memory.jsonl")

--- a/python/tests/test_detectraptor.py
+++ b/python/tests/test_detectraptor.py
@@ -1,0 +1,77 @@
+"""Unit tests for the DetectRaptor provisioning module (pure logic, no network)."""
+import os
+
+from get_sybers_dfir.signatures import detectraptor
+
+
+_A = (
+    'import "pe"\n'
+    "rule Alpha : FILE {\n"
+    "    strings:\n        $s = \"x\"\n    condition:\n        $s\n}\n"
+    "private rule Helper {\n    condition:\n        true\n}\n"
+)
+_B = (
+    'import "pe"\nimport "math"\n'
+    "rule Alpha {\n    condition:\n        true\n}\n"     # duplicate id, different body
+    "rule Beta {\n    condition:\n        math.entropy(0, filesize) > 7\n}\n"
+)
+
+
+def test_merge_dedupes_and_hoists_imports():
+    text, stats = detectraptor.merge_rules([("a.yar", _A), ("b.yar", _B)])
+    # imports hoisted once each, before any rule
+    assert text.startswith('import "pe"\nimport "math"\n')
+    assert text.count('import "pe"') == 1
+    # first occurrence of Alpha wins (a.yar's tagged variant), b.yar's is dropped
+    assert text.count("rule Alpha") == 1
+    assert "rule Alpha : FILE" in text
+    assert "private rule Helper" in text and "rule Beta" in text
+    assert stats["a.yar"] == {"kept": 2, "dropped": 0, "incompatible": 0}
+    assert stats["b.yar"] == {"kept": 1, "dropped": 1, "incompatible": 0}
+
+
+def test_merge_drops_incompatible_features():
+    bad = 'rule Telf {\n    condition:\n        elf.telfhash() == "t1"\n}\n'
+    text, stats = detectraptor.merge_rules([("c.yar", bad + "rule Ok { condition: true }\n")])
+    assert "Telf" not in text and "rule Ok" in text
+    assert stats["c.yar"] == {"kept": 1, "dropped": 0, "incompatible": 1}
+
+
+def test_merge_keeps_hex_continuation_lines_in_rule():
+    # full_windows_file.yar spills multi-line hex strings to column 0; those lines
+    # must stay inside their rule, not be treated as rule boundaries.
+    hexy = (
+        "rule Hexy {\n    strings:\n        $h = { AA BB\n"
+        "CC DD }\n    condition:\n        $h\n}\n"
+        "rule Next { condition: true }\n"
+    )
+    text, stats = detectraptor.merge_rules([("d.yar", hexy)])
+    assert stats["d.yar"]["kept"] == 2
+    assert "CC DD }" in text
+
+
+def test_fetch_skips_when_merged_file_exists(tmp_path):
+    out = tmp_path / "detectraptor" / "detectraptor.yar"
+    out.parent.mkdir()
+    out.write_text("// existing\n")
+    res = detectraptor.fetch(str(tmp_path))          # would need network otherwise
+    assert res["skipped"] is True and res["output"] == str(out)
+    assert out.read_text() == "// existing\n"
+
+
+def test_fetch_rejects_unknown_asset(tmp_path):
+    try:
+        detectraptor.fetch(str(tmp_path), assets=["nope"])
+    except ValueError as exc:
+        assert "unknown asset" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_manifest_shape():
+    # every pinned asset: yara/ file name, 64-hex sha256, gz flag matches extension
+    assert detectraptor.ASSETS, "manifest must not be empty"
+    for name, (fname, sha, gz) in detectraptor.ASSETS.items():
+        assert fname.endswith(".yar.gz" if gz else ".yar"), name
+        assert len(sha) == 64 and int(sha, 16) >= 0, name
+    assert len(detectraptor._PIN) == 40 and int(detectraptor._PIN, 16) >= 0


### PR DESCRIPTION
## What DetectRaptor is, and what of it applies here

[mgreen27/DetectRaptor](https://github.com/mgreen27/DetectRaptor) (Matt Green) ships bulk **Velociraptor** detection content in three forms:

| Ships | Format | DX_DFIR lane | Verdict |
|---|---|---|---|
| 23 detection artifacts (`vql/*.yaml`) | Velociraptor VQL | none — no Velociraptor server in this pipeline | **out of scope** |
| Lookup tables (`csv/*.csv`) driving the VQL | CSV | none — coupled to the VQL artifacts | **out of scope** |
| Curated YARA rulesets (`yara/`): webshells + per-OS file/process sets | YARA | **YARA lane** | **integrated** |

It ships **no Sigma, no Suricata rules, no Splunk SPL** (SigmaHQ is only an upstream *source* of its Evtx CSV lookups). Note: the epic named `MHaggis/DetectRaptor`; the repository is actually `mgreen27/DetectRaptor` (404 on MHaggis).

## What this PR does

**Provisioning mechanism, not vendored content** — nothing third-party is committed; only a manifest of pinned URLs + sha256 digests.

- **New `python/get_sybers_dfir/signatures/detectraptor.py`** (stdlib-only): downloads a **commit-pinned, sha256-verified** set of assets and merges them into `data_store/dependencies/yara-rules/detectraptor/detectraptor.yar` (deny-by-default gitignored). The merge is load-bearing: upstream publishes each set for a separate Velociraptor artifact and **every pair of its files repeats rule identifiers** (e.g. webshells × windows_file: 886 dupes), but the lane compiles ONE index — so imports are hoisted, duplicates dropped first-wins, and rules needing module features `blacktop/yara` lacks (`telfhash`) skipped. Per-rule `meta` (author/source_url/license_url) kept byte-for-byte. **~10,700 unique rules** survive. `yara-rules-full.yar` (20 MB) is deliberately not fetched — it *is* the YARA-Forge full package the shell lane's `--fetch` already provisions.
- **`--fetch` now works in the Python YARA lane** (and via `dfir_signatures_fetch=true`): provisions DetectRaptor **only when the rules tree is empty** — operator rules suppress it, mirroring the shell lane's starter semantics and avoiding identifier collisions with a YARA-Forge set. Fetch failure is a note, not a failure. Standalone: `python3 -m get_sybers_dfir.signatures.detectraptor --rules-dir …` (`--print-hashes` = pin-advance workflow).
- **Docs**: operator guide in `docs/Signature-Rules.md` (new *DetectRaptor content* section), pointers in `Scripts-Overview.md` and the `dfir_signatures` role README/argument_specs.
- **`THIRD_PARTY_NOTICES.md`**: DetectRaptor recorded as *fetched, not redistributed* — upstream declares **no repository-level licence**, so the merged file must not be redistributed; each rule's own licence (recorded in its `meta`) governs the rules.

## Validation (evidence)

- `python3 -m get_sybers_dfir.signatures.detectraptor --rules-dir …` → 10,699 rules merged; per-source kept/dropped/incompatible stats reported.
- Single-index compile **clean** under the lane's own container (`blacktop/yara`, yara 4.2.3) — before the telfhash filter it failed (`invalid field name "telfhash"`), which is why the incompatible-feature drop exists.
- End-to-end `yara.run(fetch=True)` with an **empty** rules dir against a synthetic PHP webshell: fetch → merge → scan → **4 detections** in `matches.jsonl` (`SIGNATURE_BASE_Chinachopper_Generic`, `SIGNATURE_BASE_WEBSHELL_PHP_Generic_Eval`, `SIGNATURE_BASE_EXT_WEBSHELL_PHP_Generic`, `SIGNATURE_BASE_APT_Webshell_Tiny_1`), each in the lane's native JSONL shape. Synthetic sample deleted afterwards; nothing under `data_store/` is touched by the commit.
- `--print-hashes` output re-verified equal to the pinned manifest; existing `test_signatures.py` + new `test_detectraptor.py` (merge dedupe / import hoisting / hex-continuation safety / incompatible drop / fetch skip) all pass against dev-tip code.
- No real corpora were present in this environment to scan beyond the synthetic sample — the lane path exercised is identical.

## Explicitly not done

- VQL artifacts + CSV lookups (no Velociraptor engine; a KQL translation of the CSV lookups would be new detection engineering, not integration — noted as a possible follow-up).
- No Sigma→Hayabusa or Suricata wiring — DetectRaptor ships neither.
- Suricata/Hayabusa `--fetch` provisioning remains in the shell lanes (unchanged scope).
