### PR TITLE
feat(detect): detection orchestration — DetectRaptor's runner model over all processed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ is `0`, anything may change without notice.
 
 ## [Unreleased]
 
+### Added
+- **Detection orchestration** (`get_sybers_dfir.detect` + `dfir_detect_adx` role +
+  `dxdfir detect`), modelled on DetectRaptor's StartHunts runner: a registry where
+  each detection declares the processed data it targets (an ADX `db.Table` or a
+  signature-lane JSONL output), a runner that surveys what is actually present and
+  executes only the applicable detections (KQL detections run engine-side via
+  `.set-or-append`; JSONL detections stream their lane files), and a unified
+  `misc.Detections` output — every hit tagged with detection id, severity, ATT&CK
+  techniques, source and a per-sweep `RunId` (`kusto/schema/50-detections.kql`,
+  with `DetectionsLatest()`/`DetectionSummary()` views over the newest sweep).
+  Seeded with 11 detections spanning EvtxECmd, Plaso prefetch, Zeek, Volatility,
+  Velociraptor and the three signature lanes.
+
 ## [0.2.0] - 2026-08-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ That's the idea. Here's where it honestly stands.
 The pipeline is a three-layer design:
 
 - **`dxdfir` CLI** — the front-end (`python/`, Typer): `dxdfir process <source>`,
-  `dxdfir deploy`, `dxdfir ingest`, `dxdfir validate`, `dxdfir list` (`man dxdfir`
-  for the manual).
+  `dxdfir deploy`, `dxdfir ingest`, `dxdfir detect`, `dxdfir validate`,
+  `dxdfir list` (`man dxdfir` for the manual).
 - **`get_sybers.dfir` Ansible collection** — orchestration, one role per source,
   one action per task; the CLI drives it with `ansible-playbook`.
 - **`get_sybers_dfir` Python package** — the per-item processing the roles invoke

--- a/ansible/collections/get_sybers.dfir/README.md
+++ b/ansible/collections/get_sybers.dfir/README.md
@@ -27,6 +27,12 @@ Deploy + load roles: **`dfir_deploy_adx`** (emulator + schema), **`dfir_ingest_a
 into SOF-ELK's watch dir), **`dfir_deploy_sofelk`** (builds the from-source SOF-ELK
 stack — `docker/sof-elk/`). `dxdfir deploy` / `dxdfir ingest` drive the ADX pair.
 
+Analysis role: **`dfir_detect_adx`** — the detection orchestrator
+(`get_sybers_dfir.detect`). It surveys which processed data is actually present
+(ADX tables + signature-lane JSONL outputs), runs only the registered detections
+whose target data is there, and lands every hit — uniformly tagged — in
+`misc.Detections`. `dxdfir detect` drives it.
+
 ## Usage
 The **`dxdfir` CLI** (Python package `get_sybers_dfir`) is the front-end — it drives
 these roles for you:

--- a/ansible/collections/get_sybers.dfir/playbooks/dfir-detect-adx.yml
+++ b/ansible/collections/get_sybers.dfir/playbooks/dfir-detect-adx.yml
@@ -1,0 +1,10 @@
+---
+# The playbook holds the decisions; the role groups, the tasks act.
+- name: "DFIR | run the applicable detections over the processed data"
+  hosts: "{{ dfir_hosts | default('localhost') }}"
+  connection: "{{ dfir_connection | default('local') }}"
+  gather_facts: true
+  tasks:
+    - name: "dfir-detect-adx | run the detect role"
+      ansible.builtin.include_role:
+        name: dfir_detect_adx

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/README.md
@@ -1,0 +1,55 @@
+# dfir_detect_adx
+
+Run the **detection orchestrator** over the pipeline's processed data. The role is
+structure only — it asserts inputs, runs a preflight (the module imports, **and
+that the emulator engine is reachable**), then invokes the `get_sybers_dfir.detect`
+runner as a **single action**.
+
+The runner is DetectRaptor's *StartHunts* model on the Kusto backend: a registry of
+detections, each declaring the processed data it targets; a **survey** of what is
+actually present (which ADX tables exist and are non-empty, which signature-lane
+JSONL outputs are on disk); then execution of **only the applicable detections** —
+KQL detections run engine-side (`.set-or-append`, no rows transit Python),
+signature-lane detections stream their JSONL files. Every hit lands in
+**`misc.Detections`**, tagged with the detection id, severity, ATT&CK techniques,
+source and a per-sweep `RunId`.
+
+## Role variables
+| Variable | Default | Description |
+|---|---|---|
+| `dfir_detect_adx_processed_dir` | `<repo>/data_store/processed` | Tree holding the signature-lane JSONL outputs. |
+| `dfir_detect_adx_only` | `""` (all) | Comma-separated registry detection id(s) to run. |
+| `dfir_detect_adx_dry_run` | `false` | Report targeting decisions; execute nothing (read-only queries). |
+| `dfir_detect_adx_limit` | `1000` | Max hits recorded per detection per sweep. |
+| `dfir_detect_adx_jsonl_out` | `""` (none) | Also export the sweep's hits as JSON Lines here. |
+| `dfir_detect_adx_kusto_host` | `127.0.0.1` | Emulator host. |
+| `dfir_detect_adx_kusto_port` | `8080` | Emulator port. |
+| `dfir_detect_adx_kusto_container` | `kusto-emulator` | Emulator container name (summaries only — pure HTTP, no docker). |
+| `dfir_detect_adx_python_path` | `<repo>/python` | PYTHONPATH to `get_sybers_dfir` (in-repo runs). |
+
+## Sweep semantics
+Sweeps are **append-only**: each run gets a fresh, sortable `RunId` and never
+mutates earlier results. The `DetectionsLatest()` / `DetectionSummary()` views
+(`kusto/schema/50-detections.kql`) read the newest sweep, so re-running never
+double-counts. A detection whose target data is absent or empty is **skipped**
+and reported as such — not run, not failed. `changed` reflects whether the sweep
+recorded any hits.
+
+## Prerequisite
+A deployed, schema-loaded emulator with processed data ingested — `dxdfir deploy`
+then `dxdfir ingest`. The preflight fails clearly if the engine is unreachable.
+
+## Example
+```bash
+dxdfir detect                                  # = this role, full sweep
+dxdfir detect --dry-run                        # targeting report only
+dxdfir detect --only vol-malfind-injection
+ansible-playbook playbooks/dfir-detect-adx.yml -e dfir_detect_adx_only=sig-yara-match
+```
+
+## Testing
+Python unit tests cover the pure logic (registry validation, applicability gating,
+KQL envelope construction, JSONL matching/shaping, timestamp normalisation). The
+**Molecule** scenario needs a running emulator: it stages a signature-lane fixture
+with one promotable record, converges (`--only sig-hayabusa-high`), and verifies
+the tagged hit is queryable in `misc.Detections`.

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/defaults/main.yml
@@ -1,0 +1,22 @@
+# Repo root is five levels up from this role
+# (roles/dfir_detect_adx -> get_sybers.dfir -> collections -> ansible -> repo).
+dfir_detect_adx_repo_root: "{{ role_path }}/../../../../.."
+
+# Where the signature-lane JSONL outputs live (the Kusto tables are found by the
+# orchestrator's own survey — nothing to configure for those).
+dfir_detect_adx_processed_dir: "{{ dfir_detect_adx_repo_root }}/data_store/processed"
+# Which detection(s) to run, comma-separated registry ids; empty = every one.
+dfir_detect_adx_only: ""
+# Report the targeting decisions (which detections would run against the present
+# data) without executing anything. Still queries the emulator, read-only.
+dfir_detect_adx_dry_run: false
+# Max hits recorded per detection per sweep.
+dfir_detect_adx_limit: 1000
+# Also export the sweep's hits as JSON Lines to this path; empty = no export.
+dfir_detect_adx_jsonl_out: ""
+# The ADX (Kusto) emulator endpoint. Everything is HTTP — no docker access needed.
+dfir_detect_adx_kusto_host: "127.0.0.1"
+dfir_detect_adx_kusto_port: 8080
+dfir_detect_adx_kusto_container: "kusto-emulator"
+# In-repo runs use PYTHONPATH; a deployed run installs the package instead.
+dfir_detect_adx_python_path: "{{ dfir_detect_adx_repo_root }}/python"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/meta/argument_specs.yml
@@ -1,0 +1,61 @@
+---
+argument_specs:
+  main:
+    short_description: "Run every applicable registered detection over the processed data."
+    description:
+      - >-
+        The detection-orchestration role (DetectRaptor's StartHunts model on the
+        Kusto backend): the get_sybers_dfir.detect runner surveys which processed
+        data is actually present — which ADX tables exist and are non-empty, which
+        signature-lane JSONL outputs are on disk — then runs only the registered
+        detections whose declared target data is there. Every hit lands in
+        misc.Detections tagged with the detection id, severity, ATT&CK ids, source
+        and a per-sweep RunId; the DetectionsLatest()/DetectionSummary() views read
+        the newest sweep. Sweeps are append-only and never mutate history.
+        Requires a deployed emulator.
+    options:
+      dfir_detect_adx_processed_dir:
+        type: str
+        required: false
+        description: "data_store/processed tree (for the signature-lane JSONL detections)."
+      dfir_detect_adx_only:
+        type: str
+        required: false
+        default: ""
+        description: "Comma-separated registry detection id(s) to run; empty = every one."
+      dfir_detect_adx_dry_run:
+        type: bool
+        required: false
+        default: false
+        description: >-
+          Report which detections would run against the present data; execute
+          nothing. Still queries the emulator (read-only targeting).
+      dfir_detect_adx_limit:
+        type: int
+        required: false
+        default: 1000
+        description: "Max hits recorded per detection per sweep."
+      dfir_detect_adx_jsonl_out:
+        type: str
+        required: false
+        default: ""
+        description: "Also export the sweep's hits as JSON Lines to this path; empty = no export."
+      dfir_detect_adx_kusto_host:
+        type: str
+        required: false
+        default: "127.0.0.1"
+        description: "Emulator host."
+      dfir_detect_adx_kusto_port:
+        type: int
+        required: false
+        default: 8080
+        description: "Emulator port."
+      dfir_detect_adx_kusto_container:
+        type: str
+        required: false
+        default: "kusto-emulator"
+        description: "Emulator container name (recorded in summaries; no docker access needed)."
+      dfir_detect_adx_python_path:
+        type: str
+        required: false
+        description: "PYTHONPATH to the get_sybers_dfir package (in-repo/dev runs)."

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/meta/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: dfir_detect_adx
+  namespace: get_sybers
+  author: Get-Sybers
+  description: >-
+    Run the detection orchestrator over the processed data in the ADX (Kusto)
+    emulator. Invokes the get_sybers_dfir.detect runner, which surveys what data
+    is actually present, executes only the registered detections whose target
+    data is there, and collects every hit — uniformly tagged — in misc.Detections.
+  company: Get-Sybers
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions: [bookworm, trixie]
+  galaxy_tags: [dfir, detection, kusto, adx]
+
+dependencies: []

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/converge.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/converge.yml
@@ -1,0 +1,12 @@
+---
+- name: Converge
+  hosts: localhost
+  gather_facts: true
+  vars:
+    dfir_detect_adx_processed_dir: /tmp/dfir_detect_adx_molecule/processed
+    dfir_detect_adx_only: sig-hayabusa-high
+    dfir_detect_adx_python_path: "{{ (playbook_dir + '/../../../../../../../python') | realpath }}"
+  tasks:
+    - name: "converge | run dfir_detect_adx"
+      ansible.builtin.include_role:
+        name: dfir_detect_adx

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/molecule.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/molecule.yml
@@ -1,0 +1,17 @@
+---
+driver:
+  name: default            # delegated — the role talks to the running emulator
+platforms:
+  - name: localhost
+provisioner:
+  name: ansible
+  inventory:
+    hosts:
+      localhost:
+        ansible_connection: local
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+verifier:
+  name: ansible

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/prepare.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/prepare.yml
@@ -1,0 +1,30 @@
+---
+# Needs a deployed emulator (`dxdfir deploy`) with the schema applied. Stages a
+# tiny signature-lane fixture so the converge has a detection that must fire.
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_processed: /tmp/dfir_detect_adx_molecule/processed
+  tasks:
+    - name: "molecule-prepare | require a reachable emulator"
+      ansible.builtin.command:
+        argv: [python3, -m, get_sybers_dfir.detect, --ping]
+      environment:
+        PYTHONPATH: "{{ (playbook_dir + '/../../../../../../../python') | realpath }}"
+      register: ping
+      changed_when: false
+      failed_when: ping.rc != 0
+
+    - name: "molecule-prepare | signatures/hayabusa fixture dir"
+      ansible.builtin.file:
+        path: "{{ molecule_processed }}/signatures/hayabusa"
+        state: directory
+        mode: "0755"
+
+    - name: "molecule-prepare | one promotable high-severity record"
+      ansible.builtin.copy:
+        dest: "{{ molecule_processed }}/signatures/hayabusa/molecule.jsonl"
+        content: |
+          {"Timestamp":"2020-01-02 03:04:05.000 +00:00","RuleTitle":"DFIR_DETECT_MOLECULE","Level":"high","Computer":"MOLECULE-HOST","Channel":"Sec","EventID":9999,"RuleID":"00000000-0000-0000-0000-000000000000","tool":"hayabusa"}
+        mode: "0644"

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/verify.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/molecule/default/verify.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: "molecule-verify | query the emulator for the promoted fixture hit"
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:8080/v1/rest/query"
+        method: POST
+        body_format: json
+        body:
+          db: misc
+          csl: >-
+            Detections
+            | where DetectionId == "sig-hayabusa-high"
+              and Details.RuleTitle == "DFIR_DETECT_MOLECULE"
+            | count
+        return_content: true
+      register: probe
+
+    - name: "molecule-verify | assert the tagged hit landed"
+      ansible.builtin.assert:
+        that:
+          - (probe.json.Tables[0].Rows[0][0] | int) >= 1
+        fail_msg: "the molecule fixture hit was not found in misc.Detections"
+        quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/tasks/detect.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/tasks/detect.yml
@@ -1,0 +1,17 @@
+---
+- name: "detect-adx | sweep the processed data with the applicable detections"
+  ansible.builtin.command:
+    argv: "{{ ['python3', '-m', 'get_sybers_dfir.detect', '--processed-dir', dfir_detect_adx_processed_dir, '--limit', dfir_detect_adx_limit | string, '--host', dfir_detect_adx_kusto_host, '--port', dfir_detect_adx_kusto_port | string, '--container', dfir_detect_adx_kusto_container] + (['--only', dfir_detect_adx_only] if dfir_detect_adx_only | length > 0 else []) + (['--jsonl-out', dfir_detect_adx_jsonl_out] if dfir_detect_adx_jsonl_out | length > 0 else []) + (['--dry-run'] if dfir_detect_adx_dry_run | bool else []) }}"
+  environment:
+    PYTHONPATH: "{{ dfir_detect_adx_python_path }}"
+  register: dfir_detect_adx_run
+  changed_when: (dfir_detect_adx_run.stdout | from_json).hits_total | int > 0
+
+- name: "detect-adx | assert no detection failed"
+  ansible.builtin.assert:
+    that:
+      - (dfir_detect_adx_run.stdout | from_json).failed | int == 0
+    fail_msg: >-
+      detect reported {{ (dfir_detect_adx_run.stdout | from_json).failed }} failed
+      detection(s): {{ (dfir_detect_adx_run.stdout | from_json).errors }}
+    quiet: true

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/tasks/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# dfir_detect_adx: run every applicable registered detection over the processed
+# data and land the hits in misc.Detections. Applicability (which tables exist
+# and are non-empty, which signature-lane files are present) lives in the Python
+# orchestrator's survey, not in a task's `when:`.
+
+- name: "detect-adx | assert inputs"
+  ansible.builtin.assert:
+    that:
+      - dfir_detect_adx_limit | int > 0
+    fail_msg: "dfir_detect_adx_limit must be a positive hit cap."
+    quiet: true
+  tags: [always]
+
+# Fact-find + preconditions BEFORE any detection runs.
+- name: "detect-adx | preflight"
+  ansible.builtin.include_tasks:
+    file: preflight.yml
+    apply:
+      tags: [always]
+  tags: [always]
+
+- name: "detect-adx | run the applicable detections"
+  ansible.builtin.include_tasks: detect.yml

--- a/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/tasks/preflight.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_detect_adx/tasks/preflight.yml
@@ -1,0 +1,26 @@
+---
+# FIND FACTS -> check module import + engine reachability -> (then DETECT).
+# No docker checks: the orchestrator talks pure HTTP to the emulator.
+
+- name: "detect-adx-preflight | the get_sybers_dfir.detect module imports"
+  ansible.builtin.command: python3 -c "import get_sybers_dfir.detect"
+  environment:
+    PYTHONPATH: "{{ dfir_detect_adx_python_path }}"
+  register: dfir_detect_adx_import
+  changed_when: false
+
+- name: "detect-adx-preflight | the ADX emulator engine is reachable"
+  ansible.builtin.command:
+    argv:
+      - python3
+      - -m
+      - get_sybers_dfir.detect
+      - --ping
+      - --host
+      - "{{ dfir_detect_adx_kusto_host }}"
+      - --port
+      - "{{ dfir_detect_adx_kusto_port }}"
+  environment:
+    PYTHONPATH: "{{ dfir_detect_adx_python_path }}"
+  register: dfir_detect_adx_reachable
+  changed_when: false

--- a/kusto/schema/50-detections.kql
+++ b/kusto/schema/50-detections.kql
@@ -1,0 +1,51 @@
+// Database: misc — unified detection output
+//
+// Written by the detection orchestrator (python/get_sybers_dfir/detect/), which
+// sweeps every processed data type and runs each registered detection against
+// the data it declares — DetectRaptor's StartHunts model on a Kusto backend.
+// Hits land here uniformly, whether the detection was KQL over an ADX table
+// (appended engine-side with .set-or-append) or a predicate over a
+// signature-lane JSONL output (inline-ingested).
+//
+// COLUMN ORDER IS LOAD-BEARING: the jsonl-lane hits arrive as inline CSV, which
+// maps by ordinal. detect/__init__.py carries the same definition (ensured at
+// run time, like the ingest ledger) — change the two together.
+//
+// Sweeps are append-only, tagged with a sortable RunId (UTC time + entropy), so
+// re-running a sweep never mutates history; the views below read the newest
+// sweep. Filter an older one explicitly with `Detections | where RunId == ...`.
+.create-merge table Detections (
+    RunId:       string,     // one sweep of the orchestrator
+    DetectionId: string,     // registry id (kebab-case, stable)
+    Title:       string,
+    Severity:    string,     // info | low | medium | high | critical
+    AttackIds:   string,     // comma-joined MITRE ATT&CK technique ids ('' = none)
+    Source:      string,     // the declared target, e.g. "host.EvtxEcmdJson"
+    Timestamp:   datetime,   // when the detected activity happened (null if unknown)
+    Entity:      string,     // the subject: host, process, IP, key, file, ...
+    Details:     dynamic,    // the packed evidence for this hit
+    DetectedAt:  datetime    // when the sweep recorded it
+)
+
+// The most recent sweep's hits. RunId sorts lexically by construction. toscalar
+// is INLINED, not `let`-bound: the emulator's mgmt endpoint rejects a
+// `let x = ...;` statement inside a .create-or-alter function body with
+// General_BadRequest (verified live; the same body works with the toscalar
+// inlined).
+.create-or-alter function
+with (docstring = "Detection hits from the most recent orchestrator sweep", folder = "Views")
+DetectionsLatest() {
+    Detections
+    | where RunId == toscalar(Detections | summarize max(RunId))
+}
+
+// One row per detection that fired in the latest sweep — the triage entry point.
+.create-or-alter function
+with (docstring = "Latest sweep rolled up per detection (hit counts, entities, span)", folder = "Views")
+DetectionSummary() {
+    DetectionsLatest()
+    | summarize Hits = count(), Entities = dcount(Entity),
+                FirstSeen = min(Timestamp), LastSeen = max(Timestamp)
+              by DetectionId, Title, Severity, AttackIds, Source
+    | order by Hits desc
+}

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -7,14 +7,15 @@ processing the roles invoke.
 
     dxdfir process zeek --pipeline adx   # drive the dfir_zeek role
     dxdfir ingest --only zeek            # load processed output into the ADX emulator
+    dxdfir detect                        # run every applicable registered detection
     dxdfir deploy                        # stand up + schema-load the emulator
     dxdfir validate                      # run the check harness
 
 ``process`` drives the collection with ``ansible-playbook`` (preflight → process →
 verify); the role's single action calls ``python -m get_sybers_dfir.<source>`` for
-the tight loop. ``ingest`` and ``deploy`` drive the ``dfir_ingest_adx`` /
-``dfir_deploy_adx`` roles the same way; ``validate`` runs the repo's check harness
-(``tests/run-checks.sh``).
+the tight loop. ``ingest``, ``detect`` and ``deploy`` drive the ``dfir_ingest_adx``
+/ ``dfir_detect_adx`` / ``dfir_deploy_adx`` roles the same way; ``validate`` runs
+the repo's check harness (``tests/run-checks.sh``).
 """
 from __future__ import annotations
 
@@ -30,7 +31,7 @@ import typer
 from . import __version__
 
 app = typer.Typer(
-    help="DX_DFIR forensic pipeline front-end (process / ingest / deploy / validate).",
+    help="DX_DFIR forensic pipeline front-end (process / ingest / detect / deploy / validate).",
     no_args_is_help=True,
     add_completion=False,
 )
@@ -150,6 +151,43 @@ def ingest(
         cmd += ["-e", kv]
     env = {"ANSIBLE_ROLES_PATH": str(repo / _COLLECTION / "roles")}
     typer.secho("ingesting processed → ADX emulator", fg=typer.colors.GREEN)
+    _run(cmd, cwd=repo, env=env)
+
+
+@app.command()
+def detect(
+    only: str = typer.Option(None, "--only", help="Run only these detection id(s), comma-separated."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Report targeting decisions; execute nothing."),
+    limit: int = typer.Option(None, "--limit", help="Max hits recorded per detection."),
+    jsonl_out: Path = typer.Option(None, "--jsonl-out", help="Also export the sweep's hits as JSON Lines."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+    extra_var: list[str] = typer.Option(None, "--extra-var", "-e", help="Extra Ansible var KEY=VALUE (repeatable)."),
+) -> None:
+    """Sweep the processed data with every applicable registered detection (dfir_detect_adx).
+
+    The detection orchestrator surveys which processed data is actually present
+    (ADX tables + signature-lane JSONL) and runs only the registered detections
+    whose target data is there; hits land uniformly tagged in misc.Detections.
+    """
+    _need("ansible-playbook")
+    repo = _repo_root(repo_root)
+    playbook = repo / _COLLECTION / "playbooks" / "dfir-detect-adx.yml"
+    if not playbook.is_file():
+        typer.secho(f"detect playbook not found: {playbook}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    cmd = ["ansible-playbook", "-i", "localhost,", "-c", "local", str(playbook)]
+    if only:
+        cmd += ["-e", f"dfir_detect_adx_only={only}"]
+    if dry_run:
+        cmd += ["-e", "dfir_detect_adx_dry_run=true"]
+    if limit is not None:
+        cmd += ["-e", f"dfir_detect_adx_limit={limit}"]
+    if jsonl_out is not None:
+        cmd += ["-e", f"dfir_detect_adx_jsonl_out={jsonl_out}"]
+    for kv in extra_var or []:
+        cmd += ["-e", kv]
+    env = {"ANSIBLE_ROLES_PATH": str(repo / _COLLECTION / "roles")}
+    typer.secho("running detections over processed data → misc.Detections", fg=typer.colors.GREEN)
     _run(cmd, cwd=repo, env=env)
 
 

--- a/python/get_sybers_dfir/detect/__init__.py
+++ b/python/get_sybers_dfir/detect/__init__.py
@@ -1,0 +1,354 @@
+"""Detection orchestration — sweep every processed data type, run what applies.
+
+The runner half of DetectRaptor's model, adapted to DX_DFIR's Kusto backend.
+DetectRaptor's ``Server.StartHunts`` iterates a HuntList of detection artifacts,
+filters them (``ArtifactRegex`` / ``TestTargeting``), and schedules each
+applicable one against the data its artifact declares; applicability is settled
+by the artifact's own preconditions. Here the same shape becomes:
+
+    HuntList            -> :mod:`.registry` (each entry declares its target data)
+    precondition         -> the SURVEY: which declared tables actually exist and
+                            are non-empty in the emulator / which signature-lane
+                            JSONL files are actually on disk
+    TestTargeting        -> ``--dry-run`` (report the targeting decisions, run
+                            nothing, write nothing)
+    ArtifactRegex        -> ``--only`` (comma-separated detection ids)
+    hunt() + hunt results-> execute each applicable detection and collect every
+                            hit, uniformly tagged, in ``misc.Detections``
+
+Execution is engine-side where the data is: a ``kusto`` detection becomes one
+``.set-or-append misc.Detections <| <query> | ...tags`` management command, so
+hit rows never transit Python. A ``jsonl`` detection streams its lane files
+locally and lands its hits in the same table via inline ingest. Every hit row
+carries the same envelope::
+
+    RunId, DetectionId, Title, Severity, AttackIds, Source,
+    Timestamp, Entity, Details, DetectedAt
+
+A sweep is additive (append-only) and tagged with a fresh ``RunId``; the
+``DetectionsLatest()`` / ``DetectionSummary()`` views (kusto/schema/
+50-detections.kql) read the newest sweep, so re-running never double-counts.
+``--jsonl-out`` additionally exports the sweep's hits as JSON Lines.
+
+NOTE unlike ingest, ``--dry-run`` still talks to the emulator: targeting *is*
+reading which tables are present and non-empty (read-only queries; DetectRaptor's
+TestTargeting equally needs the server). It writes nothing.
+"""
+from __future__ import annotations
+
+import csv
+import datetime
+import fnmatch
+import io
+import json
+import os
+import uuid
+
+from ..ingest.kusto import KustoClient, error_message, failed
+from .registry import DETECTIONS, validate
+
+DETECTIONS_DB = "misc"
+DETECTIONS_TABLE = "Detections"
+DEFAULT_LIMIT = 1000
+
+# Kept in lockstep with kusto/schema/50-detections.kql (same column order — the
+# inline-CSV ingest below maps by ordinal). Ensured here too, like the ingest
+# ledger, so the runner works against an emulator whose schema predates it.
+_SCHEMA = (
+    f".create-merge table {DETECTIONS_TABLE} ("
+    "RunId:string, DetectionId:string, Title:string, Severity:string, "
+    "AttackIds:string, Source:string, Timestamp:datetime, Entity:string, "
+    "Details:dynamic, DetectedAt:datetime)"
+)
+_COLUMNS = ("RunId", "DetectionId", "Title", "Severity", "AttackIds", "Source",
+            "Timestamp", "Entity", "Details", "DetectedAt")
+
+
+# ---- small pure helpers (unit-tested) --------------------------------------
+def _kql_str(s: str) -> str:
+    """A KQL double-quoted string literal (for registry metadata tags)."""
+    return '"' + str(s).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _utc_now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def new_run_id() -> str:
+    """Sortable per-sweep tag: UTC time + entropy (max(RunId) is the latest run)."""
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{now}-{uuid.uuid4().hex[:8]}"
+
+
+def iso_timestamp(ts) -> str:
+    """Normalise a lane timestamp (ISO variants, Hayabusa's 'Y-m-d H:M:S.f z')
+    to the ISO-8601 UTC form Kusto ingests; '' (null) when unparseable."""
+    if ts is None:
+        return ""
+    s = str(ts).strip()
+    if not s:
+        return ""
+    dt = None
+    try:
+        dt = datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z",
+                    "%Y-%m-%d %H:%M:%S.%f %z", "%Y-%m-%d %H:%M:%S %z"):
+            try:
+                dt = datetime.datetime.strptime(s, fmt)
+                break
+            except ValueError:
+                continue
+    if dt is None:
+        return ""
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def kusto_command(det: dict, run_id: str, limit: int) -> str:
+    """The single engine-side command a kusto detection compiles to: run the
+    query where the data lives, cap it, stamp the envelope, append the hits."""
+    attack = ",".join(det.get("attack", []))
+    return (
+        f".set-or-append {DETECTIONS_TABLE} <|\n"
+        f"{det['query'].strip()}\n"
+        f"| project Timestamp = todatetime(Timestamp), Entity = tostring(Entity), Details\n"
+        f"| take {int(limit)}\n"
+        f"| extend RunId = {_kql_str(run_id)}, DetectionId = {_kql_str(det['id'])},\n"
+        f"         Title = {_kql_str(det['title'])}, Severity = {_kql_str(det['severity'])},\n"
+        f"         AttackIds = {_kql_str(attack)}, Source = {_kql_str(det['target'])},\n"
+        f"         DetectedAt = now()\n"
+        f"| project {', '.join(_COLUMNS)}"
+    )
+
+
+def hits_to_csv(det: dict, hits: list[dict], run_id: str) -> str:
+    """jsonl-lane hits as inline-ingest CSV rows (column order = table order)."""
+    attack = ",".join(det.get("attack", []))
+    now = _utc_now_iso()
+    buf = io.StringIO()
+    w = csv.writer(buf, lineterminator="\n")
+    for h in hits:
+        w.writerow([
+            run_id, det["id"], det["title"], det["severity"], attack, det["target"],
+            iso_timestamp(h.get("Timestamp")), str(h.get("Entity", "") or ""),
+            json.dumps(h.get("Details") or {}, ensure_ascii=False, default=str), now,
+        ])
+    return buf.getvalue().rstrip("\n")
+
+
+def scan_jsonl(paths: list[str], match, limit: int) -> tuple[list[dict], int]:
+    """Stream the lane files through the detection's predicate.
+    Returns (hits capped at limit, count of unparseable lines)."""
+    hits: list[dict] = []
+    bad = 0
+    for path in paths:
+        try:
+            fh = open(path, encoding="utf-8", errors="replace")
+        except OSError:
+            continue                       # pruned mid-run — same stance as ingest
+        with fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    bad += 1
+                    continue
+                hit = match(rec)
+                if hit:
+                    hits.append(hit)
+                    if len(hits) >= limit:
+                        return hits, bad
+    return hits, bad
+
+
+def _find(root: str, glob: str) -> list[str]:
+    out = []
+    for cur, _dirs, files in os.walk(root):
+        for name in files:
+            if fnmatch.fnmatch(name, glob):
+                p = os.path.join(cur, name)
+                try:
+                    if os.path.getsize(p) > 0:
+                        out.append(p)
+                except OSError:
+                    continue
+    return sorted(out)
+
+
+# ---- survey: what data is actually present ---------------------------------
+def _rows(resp: str) -> list[list]:
+    try:
+        d = json.loads(resp)
+        return (d.get("Tables") or [{}])[0].get("Rows") or []
+    except (json.JSONDecodeError, ValueError, IndexError):
+        return []
+
+
+def survey(client: KustoClient, tables: set[str]) -> dict[str, int | None]:
+    """Row counts for every ``db.Table`` a registered detection targets.
+    None = the table (or its database) does not exist; 0 = exists but empty."""
+    counts: dict[str, int | None] = {}
+    by_db: dict[str, set[str]] = {}
+    for t in tables:
+        db, name = t.split(".", 1)
+        by_db.setdefault(db, set()).add(name)
+    for db in sorted(by_db):
+        resp = client.mgmt(db, ".show tables")
+        have = set() if failed(resp) else {r[0] for r in _rows(resp) if r}
+        for name in sorted(by_db[db]):
+            key = f"{db}.{name}"
+            if name not in have:
+                counts[key] = None
+                continue
+            r = client.query(db, f"['{name}'] | count")
+            counts[key] = None if failed(r) else int(_rows(r)[0][0])
+    return counts
+
+
+# ---- per-detection execution -----------------------------------------------
+def _applicable_kusto(det: dict, counts: dict) -> tuple[bool, str]:
+    for req in det["requires"]:
+        n = counts.get(req)
+        if n is None:
+            return False, f"target table {req} does not exist"
+        if n == 0:
+            return False, f"target table {req} is empty"
+    return True, ""
+
+
+def _count_hits(client: KustoClient, run_id: str, det_id: str) -> int:
+    r = client.query(
+        DETECTIONS_DB,
+        f'{DETECTIONS_TABLE} | where RunId == {_kql_str(run_id)} '
+        f'and DetectionId == {_kql_str(det_id)} | count')
+    rows = _rows(r)
+    return int(rows[0][0]) if not failed(r) and rows else 0
+
+
+def _run_kusto(client, det, run_id, limit, entry, summary):
+    resp = client.mgmt(DETECTIONS_DB, kusto_command(det, run_id, limit))
+    if failed(resp):
+        entry.update(status="failed", error=error_message(resp))
+        summary["failed"] += 1
+        summary["errors"].append({"detection": det["id"], "error": entry["error"]})
+        return
+    entry.update(status="ran", hits=_count_hits(client, run_id, det["id"]))
+    summary["ran"] += 1
+    summary["hits_total"] += entry["hits"]
+
+
+def _run_jsonl(client, det, files, run_id, limit, entry, summary):
+    hits, bad = scan_jsonl(files, det["match"], limit)
+    if bad:
+        entry["unparseable_lines"] = bad
+    if hits:
+        csv_rows = hits_to_csv(det, hits, run_id)
+        resp = client.mgmt(
+            DETECTIONS_DB,
+            f".ingest inline into table {DETECTIONS_TABLE} <|\n{csv_rows}")
+        if failed(resp):
+            entry.update(status="failed", error=error_message(resp))
+            summary["failed"] += 1
+            summary["errors"].append({"detection": det["id"], "error": entry["error"]})
+            return
+    entry.update(status="ran", hits=len(hits))
+    summary["ran"] += 1
+    summary["hits_total"] += len(hits)
+
+
+def export_jsonl(client: KustoClient, run_id: str, out_path: str) -> int:
+    """Write this sweep's hits (queried back from misc.Detections) as JSONL."""
+    r = client.query(
+        DETECTIONS_DB,
+        f"{DETECTIONS_TABLE} | where RunId == {_kql_str(run_id)} "
+        f"| order by DetectionId asc, Timestamp asc")
+    if failed(r):
+        raise RuntimeError(f"could not read back hits: {error_message(r)}")
+    d = json.loads(r)
+    table = (d.get("Tables") or [{}])[0]
+    cols = [c.get("ColumnName") for c in table.get("Columns", [])]
+    rows = table.get("Rows") or []
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(dict(zip(cols, row)), ensure_ascii=False,
+                                default=str) + "\n")
+    return len(rows)
+
+
+# ---- the sweep --------------------------------------------------------------
+def process(processed_dir: str | None = None, only: str | None = None,
+            dry_run: bool = False, limit: int = DEFAULT_LIMIT,
+            jsonl_out: str | None = None, host: str = "127.0.0.1",
+            port: int = 8080, container: str = "kusto-emulator") -> dict:
+    """Run every applicable registered detection; return the sweep summary."""
+    validate()
+    client = KustoClient(host=host, port=port, container=container)
+    run_id = new_run_id()
+    summary = {
+        "tool": "detect", "endpoint": client.base, "run_id": run_id,
+        "dry_run": dry_run, "limit": limit,
+        "registered": 0, "ran": 0, "skipped": 0, "failed": 0, "hits_total": 0,
+        "detections": {}, "errors": [],
+    }
+
+    wanted = {s.strip() for s in only.split(",") if s.strip()} if only else None
+    selected = [d for d in DETECTIONS if wanted is None or d["id"] in wanted]
+    if wanted:
+        unknown = wanted - {d["id"] for d in selected}
+        if unknown:
+            summary["error"] = f"unknown detection id(s): {', '.join(sorted(unknown))}"
+            return summary
+    summary["registered"] = len(selected)
+
+    if not client.reachable():
+        summary["error"] = f"nothing answering at {client.base} (deploy first)"
+        return summary
+
+    # Targeting: what does the selected registry need, and what is present?
+    kusto_targets = {req for d in selected if d["kind"] == "kusto" for req in d["requires"]}
+    counts = survey(client, kusto_targets) if kusto_targets else {}
+    summary["present"] = counts
+
+    if not dry_run:
+        resp = client.mgmt(DETECTIONS_DB, _SCHEMA)
+        if failed(resp):
+            summary["error"] = f"could not ensure {DETECTIONS_DB}.{DETECTIONS_TABLE}: {error_message(resp)}"
+            return summary
+
+    for det in selected:
+        entry = {"kind": det["kind"], "target": det["target"], "hits": 0}
+        summary["detections"][det["id"]] = entry
+        if det["kind"] == "kusto":
+            ok, reason = _applicable_kusto(det, counts)
+            if not ok:
+                entry.update(status="skipped", reason=reason)
+                summary["skipped"] += 1
+            elif dry_run:
+                entry["status"] = "would-run"
+            else:
+                _run_kusto(client, det, run_id, limit, entry, summary)
+        else:
+            root = os.path.join(processed_dir or "", det["subdir"])
+            files = _find(root, det["glob"]) if processed_dir and os.path.isdir(root) else []
+            if not files:
+                entry.update(status="skipped",
+                             reason=f"no non-empty {det['glob']} under {det['subdir']}")
+                summary["skipped"] += 1
+            elif dry_run:
+                entry.update(status="would-run", files=len(files))
+            else:
+                _run_jsonl(client, det, files, run_id, limit, entry, summary)
+
+    if jsonl_out and not dry_run:
+        try:
+            summary["jsonl_out"] = {"path": jsonl_out,
+                                    "rows": export_jsonl(client, run_id, jsonl_out)}
+        except (RuntimeError, OSError) as e:
+            summary["errors"].append({"detection": "(export)", "error": str(e)})
+    return summary

--- a/python/get_sybers_dfir/detect/__main__.py
+++ b/python/get_sybers_dfir/detect/__main__.py
@@ -1,0 +1,64 @@
+"""CLI for the detection orchestrator: python -m get_sybers_dfir.detect ..."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from . import DEFAULT_LIMIT, process
+from .registry import DETECTIONS, validate
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="get_sybers_dfir.detect",
+        description="Sweep the processed data in the ADX (Kusto) emulator with "
+                    "every applicable registered detection",
+    )
+    ap.add_argument("--processed-dir",
+                    help="data_store/processed tree (for the signature-lane JSONL detections)")
+    ap.add_argument("--list", action="store_true", dest="list_",
+                    help="list the registered detections and exit")
+    ap.add_argument("--ping", action="store_true",
+                    help="check the emulator is reachable; exit 0/1")
+    ap.add_argument("--only", help="run only these detection id(s), comma-separated")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report which detections would run against the present "
+                         "data (read-only targeting queries); execute nothing")
+    ap.add_argument("--limit", type=int, default=DEFAULT_LIMIT,
+                    help=f"max hits recorded per detection (default {DEFAULT_LIMIT})")
+    ap.add_argument("--jsonl-out", help="also export this sweep's hits as JSON Lines here")
+    ap.add_argument("--host", default="127.0.0.1", help="emulator host (default 127.0.0.1)")
+    ap.add_argument("--port", type=int, default=8080, help="emulator port (default 8080)")
+    ap.add_argument("--container", default="kusto-emulator", help="emulator container name")
+    args = ap.parse_args(argv)
+
+    if args.ping:
+        from ..ingest.kusto import KustoClient
+        up = KustoClient(host=args.host, port=args.port, container=args.container).reachable()
+        sys.stdout.write(("reachable" if up else "unreachable") + f" {args.host}:{args.port}\n")
+        return 0 if up else 1
+
+    if args.list_:
+        validate()
+        for d in DETECTIONS:
+            attack = ",".join(d["attack"]) or "-"
+            sys.stdout.write(f"{d['id']}\t{d['kind']}\t{d['severity']}\t{attack}\t"
+                             f"{d['target']}\t{d['title']}\n")
+        return 0
+
+    summary = process(
+        processed_dir=args.processed_dir, only=args.only, dry_run=args.dry_run,
+        limit=args.limit, jsonl_out=args.jsonl_out,
+        host=args.host, port=args.port, container=args.container,
+    )
+    json.dump(summary, sys.stdout)
+    sys.stdout.write("\n")
+    if summary.get("error"):
+        sys.stderr.write(summary["error"] + "\n")
+        return 2
+    return 1 if summary["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/get_sybers_dfir/detect/registry.py
+++ b/python/get_sybers_dfir/detect/registry.py
@@ -1,0 +1,355 @@
+"""The detection registry — WHAT can run, and WHAT DATA each detection needs.
+
+DetectRaptor keeps its runnable detections in a HuntList table inside
+``DetectRaptor.Server.StartHunts``: one row per detection artifact, each artifact
+naming the data it consumes, the runner filtering and scheduling the applicable
+ones. This module is that HuntList for DX_DFIR: one entry per detection, each
+declaring the processed data it TARGETS, so the runner (:mod:`get_sybers_dfir.
+detect`) can sweep everything that is actually present and skip the rest.
+
+Two kinds of entry, matching the two places processed data lives:
+
+``kind: "kusto"``
+    The detection is a KQL query over the ADX tables. ``requires`` lists the
+    ``db.Table`` sources that must exist AND be non-empty for the detection to be
+    applicable. The query may reference any database (``database("host").X``) —
+    the runner executes it once, engine-side, and appends the hits straight into
+    ``misc.Detections`` (no rows transit Python). CONTRACT: the query's final
+    output must carry exactly three columns —
+
+        Timestamp   datetime (or null) — when the detected activity happened
+        Entity      string — the subject (host, process, IP, key, file, ...)
+        Details     dynamic — the evidence, packed (pack()/Record)
+
+``kind: "jsonl"``
+    The detection is a predicate over a signature-lane JSONL output under
+    ``data_store/processed`` (those files are not in Kusto). ``subdir``/``glob``
+    locate the files; ``match(record)`` returns None for a non-hit, or a dict
+    with the same three keys (Timestamp ISO-ish string or None, Entity str,
+    Details dict). The runner streams the files, applies the predicate, and
+    ingests the hits into the same ``misc.Detections`` table.
+
+Shared metadata: ``id`` (stable, kebab-case), ``title``, ``severity`` (info/low/
+medium/high/critical), ``attack`` (MITRE ATT&CK technique ids), ``target`` (the
+human-readable data source, shown in every hit's ``Source`` column).
+
+Detections are seeded across every processed lane the pipeline lands — Windows
+event logs, the Plaso timeline, Zeek, Volatility memory analysis, Velociraptor,
+and the three signature-lane outputs — several adapted from DetectRaptor's
+detection content where it maps onto DX_DFIR's tables. Adding a detection is
+adding an entry here; the runner needs no change.
+"""
+from __future__ import annotations
+
+SEVERITIES = ("info", "low", "medium", "high", "critical")
+KINDS = ("kusto", "jsonl")
+
+# A JSON-shape EvtxECmd Payload field, extracted inline so the registry does not
+# depend on the mitre database's EvtxPayload() helper being deployed. Used inside
+# a KQL @'...' verbatim string, so the backslashes reach RE2 as written.
+_EVTX_FIELD = r'"@Name":"%s","#text":"((?:[^"\\]|\\.)*)"'
+
+
+# --------------------------------------------------------------------- jsonl matchers
+def match_hayabusa_high(rec: dict):
+    """Hayabusa (Sigma over EVTX) already scored the event — promote the ones it
+    called high/critical into the unified detections output."""
+    if str(rec.get("Level", "")).lower() not in ("high", "crit", "critical"):
+        return None
+    return {
+        "Timestamp": rec.get("Timestamp"),
+        "Entity": str(rec.get("Computer", "") or ""),
+        "Details": {k: rec[k] for k in
+                    ("RuleTitle", "Level", "Channel", "EventID", "RecordID",
+                     "RuleID", "Details") if k in rec},
+    }
+
+
+def match_suricata_alert(rec: dict):
+    """Promote Suricata EVE alerts (the eve.jsonl also carries flow/dns/... context
+    events — only event_type=alert is a detection)."""
+    if rec.get("event_type") != "alert":
+        return None
+    alert = rec.get("alert") or {}
+    return {
+        "Timestamp": rec.get("timestamp"),
+        "Entity": "%s -> %s:%s" % (rec.get("src_ip", "?"), rec.get("dest_ip", "?"),
+                                   rec.get("dest_port", "?")),
+        "Details": {
+            "Signature": alert.get("signature"),
+            "SignatureId": alert.get("signature_id"),
+            "Category": alert.get("category"),
+            "SuricataSeverity": alert.get("severity"),
+            "Proto": rec.get("proto"),
+            "AppProto": rec.get("app_proto"),
+        },
+    }
+
+
+def match_yara(rec: dict):
+    """Every YARA match is a detection by definition — the rule already encodes
+    the judgement. String captures are trimmed to ids/offsets (the matched data
+    can be binary and belongs in the lane output, not the hit row)."""
+    if rec.get("tool") != "yara" or not rec.get("rule"):
+        return None
+    strings = rec.get("strings") or []
+    return {
+        "Timestamp": None,   # a YARA match has no event time
+        "Entity": str(rec.get("target", "") or rec.get("match", "") or ""),
+        "Details": {
+            "Rule": rec.get("rule"),
+            "Source": rec.get("source"),
+            "Match": rec.get("match"),
+            "StringIds": sorted({s.get("id", "?") for s in strings if isinstance(s, dict)}),
+        },
+    }
+
+
+# --------------------------------------------------------------------- the registry
+DETECTIONS: list[dict] = [
+    # ---- host: Windows event logs (EvtxECmd) --------------------------------
+    {
+        "id": "win-eventlog-cleared",
+        "title": "Windows event log cleared",
+        "severity": "high",
+        "attack": ["T1070.001"],
+        "kind": "kusto",
+        "target": "host.EvtxEcmdJson",
+        "requires": ["host.EvtxEcmdJson"],
+        # DetectRaptor Evtx.yaml win_eventlog_clear: 1102 (Security) / 104 (System).
+        # 517 is the pre-Vista Security-cleared id. Channel-scoped: many modern
+        # Operational channels reuse ids 104/1102 for unrelated events.
+        "query": r"""
+database("host").EvtxEcmdJson
+| where (EventId == 1102 and Channel =~ "Security")
+     or (EventId ==  104 and Channel =~ "System")
+     or (EventId ==  517 and Channel =~ "Security")
+| project Timestamp = TimeCreated, Entity = Computer,
+          Details = pack("EventId", EventId, "Channel", Channel,
+                         "UserName", UserName, "MapDescription", MapDescription,
+                         "SourceFile", SourceFile)
+""",
+    },
+    {
+        "id": "win-defender-tamper",
+        "title": "Windows Defender disabled or reconfigured",
+        "severity": "medium",
+        "attack": ["T1562.001"],
+        "kind": "kusto",
+        "target": "host.EvtxEcmdJson",
+        "requires": ["host.EvtxEcmdJson"],
+        # DetectRaptor win_disable_defender (5001/5010/5012) + 5007 (configuration
+        # changed — how exclusions land in the log).
+        "query": r"""
+database("host").EvtxEcmdJson
+| where Channel == "Microsoft-Windows-Windows Defender/Operational"
+    and EventId in (5001, 5007, 5010, 5012)
+| project Timestamp = TimeCreated, Entity = Computer,
+          Details = pack("EventId", EventId, "MapDescription", MapDescription,
+                         "Payload", Payload, "SourceFile", SourceFile)
+""",
+    },
+    {
+        "id": "win-service-suspicious-path",
+        "title": "Service installed from a suspicious path or command",
+        "severity": "high",
+        "attack": ["T1543.003"],
+        "kind": "kusto",
+        "target": "host.EvtxEcmdJson",
+        "requires": ["host.EvtxEcmdJson"],
+        # DetectRaptor win_sus_service: 7045/4697 whose image is a shell one-liner,
+        # a user-writable path, or an admin share.
+        "query": (r"""
+database("host").EvtxEcmdJson
+| where (EventId == 7045 and Channel =~ "System")
+     or (EventId == 4697 and Channel =~ "Security")
+| extend ServicePath = iff(isnotempty(ExecutableInfo), ExecutableInfo,
+                           extract(@'""" + _EVTX_FIELD % "(?:ImagePath|ServiceFileName)" + r"""', 1, Payload))
+| where ServicePath matches regex
+        @'(?i)(\\Users\\|\\Temp\\|\\AppData\\|COMSPEC|powershell|cmd\.exe|\\ADMIN\$|\\C\$|\.bat\b|\.ps1\b)'
+| project Timestamp = TimeCreated, Entity = Computer,
+          Details = pack("EventId", EventId, "ServiceName", PayloadData1,
+                         "ServicePath", ServicePath, "SourceFile", SourceFile)
+"""),
+    },
+    # ---- host: Plaso timeline ----------------------------------------------
+    {
+        "id": "win-prefetch-dualuse-tool",
+        "title": "Prefetch evidence of dual-use / attack tooling execution",
+        "severity": "medium",
+        "attack": ["T1059", "T1053.005"],
+        "kind": "kusto",
+        "target": "host.L2tPrefetch",
+        "requires": ["host.L2tPrefetch"],
+        # DetectRaptor's MFT/Evtx lists of offensive + recon + RMM tooling, cut to
+        # names with prefetch-visible execution semantics.
+        "query": r"""
+database("host").L2tPrefetch
+| extend Executable = tostring(Record.executable)
+| where Executable matches regex
+        @'(?i)^(PSEXEC|PSEXESVC|MIMIKATZ|PROCDUMP|LAZAGNE|SHARPHOUND|ADFIND|DSQUERY|NLTEST|RCLONE|MEGACMD|MEGASYNC|NCAT|NMAP|WCE|SDELETE|SCHTASKS|WHOAMI|WMIC|QUSER|ANYDESK|TEAMVIEWER|ATERA|SPLASHTOP|SCREENCONNECT)\.EXE$'
+| project Timestamp,
+          Entity = strcat(tostring(Record.image_hostname), ": ", Executable),
+          Details = pack("Executable", Executable, "RunCount", Record.run_count,
+                         "Path", tostring(Record.display_name), "Parser", Parser,
+                         "SourceImage", SourceImage)
+""",
+    },
+    # ---- network: Zeek ------------------------------------------------------
+    {
+        "id": "zeek-notice-promoted",
+        "title": "Zeek notice raised",
+        "severity": "low",
+        "attack": [],
+        "kind": "kusto",
+        "target": "network.Zeek (notice)",
+        "requires": ["network.Zeek"],
+        # Zeek's own detection layer — surface notice.log in the unified output.
+        "query": r"""
+database("network").Zeek
+| where LogType == "notice"
+| project Timestamp = Ts,
+          Entity = strcat(tostring(Record.["id.orig_h"]), " -> ",
+                          tostring(Record.["id.resp_h"])),
+          Details = pack("Note", tostring(Record.note), "Msg", tostring(Record.msg),
+                         "Uid", tostring(Record.uid), "SourceFile", SourceFile)
+""",
+    },
+    {
+        "id": "zeek-dns-oversized-query",
+        "title": "Oversized DNS queries (tunnelling / exfiltration indicator)",
+        "severity": "medium",
+        "attack": ["T1071.004", "T1048.003"],
+        "kind": "kusto",
+        "target": "network.Zeek (dns)",
+        "requires": ["network.Zeek"],
+        # One hit per querying host, not per query — 8k raw rows is a lead list,
+        # a per-source summary is a detection.
+        "query": r"""
+database("network").Zeek
+| where LogType == "dns"
+| extend Query = tostring(Record.query)
+| where strlen(Query) >= 60
+    and not(Query endswith ".in-addr.arpa" or Query endswith ".ip6.arpa")
+| summarize QueryCount = count(), SampleQuery = take_any(Query),
+            FirstSeen = min(Ts), LastSeen = max(Ts)
+          by SrcIp = tostring(Record.["id.orig_h"])
+| project Timestamp = FirstSeen, Entity = SrcIp,
+          Details = pack("QueryCount", QueryCount, "SampleQuery", SampleQuery,
+                         "FirstSeen", FirstSeen, "LastSeen", LastSeen)
+""",
+    },
+    # ---- memory: Volatility 3 ----------------------------------------------
+    {
+        "id": "vol-malfind-injection",
+        "title": "Injected / unbacked executable memory (Volatility malfind)",
+        "severity": "high",
+        "attack": ["T1055"],
+        "kind": "kusto",
+        "target": "memory.VolatilityJson (windows.malfind)",
+        "requires": ["memory.VolatilityJson"],
+        # One hit per process per memory image; the raw regions stay in the lane.
+        "query": r"""
+database("memory").VolatilityJson
+| where Plugin == "windows.malfind"
+| extend Proc = tostring(Record.Process), Pid = tolong(Record.PID)
+| summarize Regions = count(),
+            Protections = make_set(tostring(Record.Protection), 10)
+          by SourceFile, Proc, Pid
+| project Timestamp = datetime(null),
+          Entity = strcat(Proc, " (pid ", tostring(Pid), ")"),
+          Details = pack("MemoryImage", SourceFile, "Regions", Regions,
+                         "Protections", Protections)
+""",
+    },
+    # ---- host: Velociraptor offline collections -----------------------------
+    {
+        "id": "velociraptor-run-key",
+        "title": "Autorun (Run/RunOnce) registry persistence",
+        "severity": "medium",
+        "attack": ["T1547.001"],
+        "kind": "kusto",
+        "target": "host.VelociraptorJson",
+        "requires": ["host.VelociraptorJson"],
+        # Registry artefacts collected by the Velociraptor offline collectors
+        # (EZ Tools / RECmd). Skipped, not failed, while that lane has no data.
+        "query": r"""
+database("host").VelociraptorJson
+| where Artefact matches regex @'(?i)(registry|recmd)'
+| extend KeyPath = tostring(coalesce(Record.KeyPath, Record.Key))
+| where KeyPath matches regex @'(?i)\\CurrentVersion\\Run(Once)?(\\|$)'
+| project Timestamp = todatetime(Record.LastWriteTimestamp),
+          Entity = KeyPath, Details = Record
+""",
+    },
+    # ---- signature lanes (JSONL outputs, not in Kusto) ----------------------
+    {
+        "id": "sig-hayabusa-high",
+        "title": "Hayabusa high/critical Sigma detection",
+        "severity": "high",
+        "attack": [],
+        "kind": "jsonl",
+        "target": "signatures/hayabusa",
+        "subdir": "signatures/hayabusa",
+        "glob": "*.jsonl",
+        "match": match_hayabusa_high,
+    },
+    {
+        "id": "sig-suricata-alert",
+        "title": "Suricata IDS alert",
+        "severity": "medium",
+        "attack": [],
+        "kind": "jsonl",
+        "target": "signatures/suricata",
+        "subdir": "signatures/suricata",
+        "glob": "*.jsonl",
+        "match": match_suricata_alert,
+    },
+    {
+        "id": "sig-yara-match",
+        "title": "YARA rule match",
+        "severity": "medium",
+        "attack": [],
+        "kind": "jsonl",
+        "target": "signatures/yara",
+        "subdir": "signatures/yara",
+        "glob": "*.jsonl",
+        "match": match_yara,
+    },
+]
+
+
+def validate(detections: list[dict] | None = None) -> None:
+    """Fail fast on a malformed registry — a bad entry must stop the run before
+    anything executes, not corrupt the output table halfway through a sweep."""
+    detections = DETECTIONS if detections is None else detections
+    seen: set[str] = set()
+    for d in detections:
+        did = d.get("id", "")
+        prefix = f"detection {did!r}: "
+        if not did or not all(c.islower() or c.isdigit() or c == "-" for c in did):
+            raise ValueError(prefix + "id must be non-empty kebab-case")
+        if did in seen:
+            raise ValueError(prefix + "duplicate id")
+        seen.add(did)
+        if d.get("kind") not in KINDS:
+            raise ValueError(prefix + f"kind must be one of {KINDS}")
+        if d.get("severity") not in SEVERITIES:
+            raise ValueError(prefix + f"severity must be one of {SEVERITIES}")
+        for field in ("title", "target"):
+            v = d.get(field, "")
+            if not v or '"' in v or "\\" in v:
+                raise ValueError(prefix + f"{field} must be non-empty, without quotes/backslashes")
+        if not isinstance(d.get("attack"), list):
+            raise ValueError(prefix + "attack must be a list of ATT&CK ids")
+        if d["kind"] == "kusto":
+            reqs = d.get("requires")
+            if not reqs or not all(isinstance(r, str) and r.count(".") == 1 for r in reqs):
+                raise ValueError(prefix + "requires must be a non-empty list of 'db.Table'")
+            if not d.get("query", "").strip():
+                raise ValueError(prefix + "query must be non-empty KQL")
+        else:
+            if not d.get("subdir") or not d.get("glob"):
+                raise ValueError(prefix + "jsonl entries need subdir and glob")
+            if not callable(d.get("match")):
+                raise ValueError(prefix + "jsonl entries need a callable match")

--- a/python/man/dxdfir.1
+++ b/python/man/dxdfir.1
@@ -23,6 +23,15 @@ dxdfir \- DX_DFIR forensic processing pipeline front-end
 .RB [ --force ]
 .RB [ --dry-run ]
 .br
+.B dxdfir detect
+.RB [ --only
+.IR IDS ]
+.RB [ --dry-run ]
+.RB [ --limit
+.IR N ]
+.RB [ --jsonl-out
+.IR PATH ]
+.br
 .B dxdfir deploy
 .RB [ --persist ]
 .RB [ --port
@@ -51,13 +60,9 @@ drives a source's role with
 \(em preflight, then process, then verify \(em and the role's single action calls
 .RB \(lq python \-m get_sybers_dfir. SOURCE \(rq
 for the tight loop.
-.B ingest
-and
-.B deploy
+.BR ingest ", " detect " and " deploy
 likewise drive roles \(em
-.B dfir_ingest_adx
-and
-.B dfir_deploy_adx
+.BR dfir_ingest_adx ", " dfir_detect_adx " and " dfir_deploy_adx
 \(em while
 .B validate
 fronts the repository's check harness
@@ -78,6 +83,17 @@ role. Idempotent: an in-DB ledger records every loaded file, so a re-run loads
 only new files (use
 .B --force
 to re-ingest).
+.TP
+.B detect
+Run the detection orchestrator by driving the
+.B dfir_detect_adx
+role: survey which processed data is actually present (ADX tables and
+signature-lane JSONL outputs), run only the registered detections whose target
+data is there, and collect every hit \(em uniformly tagged \(em in
+.IR misc.Detections .
+Sweeps are append-only under a per-sweep RunId; the
+.IR DetectionsLatest ()/ DetectionSummary ()
+views read the newest sweep.
 .TP
 .B deploy
 Deploy the ADX (Kusto) emulator and apply the schema by driving the
@@ -150,6 +166,29 @@ List what would be loaded; contact nothing.
 As for
 .B process
 above.
+.SS detect
+.TP
+.BI --only " IDS"
+Run only these registry detection id(s), comma-separated (see
+.RB \(lq python\ -m\ get_sybers_dfir.detect\ --list \(rq).
+.TP
+.B --dry-run
+Report which detections would run against the present data; execute nothing.
+Unlike
+.BR "ingest --dry-run" ,
+targeting requires reading which tables are present, so the emulator is still
+queried (read-only).
+.TP
+.BI --limit " N"
+Max hits recorded per detection per sweep (default 1000).
+.TP
+.BI --jsonl-out " PATH"
+Also export the sweep's hits as JSON Lines.
+.TP
+.BR --repo-root " " \fIPATH\fR ", " --extra-var ", " -e " " \fIKEY=VALUE\fR
+As for
+.B process
+above.
 .SH ENVIRONMENT
 .TP
 .B DFIR_REPO_ROOT
@@ -160,7 +199,7 @@ directory, then from the installed package's location.
 .TP
 .B ANSIBLE_ROLES_PATH
 Set by
-.BR process ", " ingest " and " deploy
+.BR process ", " ingest ", " detect " and " deploy
 to the collection's roles directory so the roles resolve without installing the
 collection.
 .SH EXIT STATUS
@@ -188,6 +227,9 @@ Run only the YARA signature lane:
 .TP
 Stand up the emulator, then load Zeek output:
 .B dxdfir deploy && dxdfir ingest --only zeek
+.TP
+Sweep everything present with the applicable detections:
+.B dxdfir detect --jsonl-out /tmp/detections.jsonl
 .SH FILES
 .TP
 .I ansible/collections/get_sybers.dfir/

--- a/python/tests/test_detect.py
+++ b/python/tests/test_detect.py
@@ -1,0 +1,159 @@
+"""Unit tests for the detection orchestrator's pure logic (no emulator needed)."""
+import csv
+import io
+import json
+
+import pytest
+
+from get_sybers_dfir import detect
+from get_sybers_dfir.detect import registry
+
+
+# ---- registry hygiene ------------------------------------------------------
+def test_seeded_registry_validates():
+    registry.validate()
+
+
+def test_registry_ids_unique_and_kebab():
+    ids = [d["id"] for d in registry.DETECTIONS]
+    assert len(ids) == len(set(ids))
+    assert all(i == i.lower() and " " not in i for i in ids)
+
+
+def test_validate_rejects_bad_entries():
+    base = {"id": "x-1", "title": "t", "severity": "low", "attack": [],
+            "kind": "kusto", "target": "db.T", "requires": ["db.T"], "query": "T"}
+    for patch in (
+        {"id": "Bad_Case"},
+        {"severity": "urgent"},
+        {"kind": "sql"},
+        {"title": 'has "quotes"'},
+        {"requires": ["notdotted"]},
+        {"query": "   "},
+        {"attack": "T1055"},
+    ):
+        with pytest.raises(ValueError):
+            registry.validate([{**base, **patch}])
+    with pytest.raises(ValueError):        # duplicate id
+        registry.validate([base, dict(base)])
+    with pytest.raises(ValueError):        # jsonl needs a callable match
+        registry.validate([{**base, "kind": "jsonl", "subdir": "s", "glob": "*",
+                            "match": "not-callable"}])
+
+
+# ---- kusto command construction -------------------------------------------
+def test_kusto_command_wraps_query_with_envelope():
+    det = {"id": "x-1", "title": "Ti", "severity": "high", "attack": ["T1", "T2"],
+           "target": "host.T", "kind": "kusto", "requires": ["host.T"],
+           "query": "database(\"host\").T | project Timestamp, Entity, Details"}
+    cmd = detect.kusto_command(det, "RUN1", 50)
+    assert cmd.startswith(".set-or-append Detections <|")
+    assert "| take 50" in cmd
+    assert '"RUN1"' in cmd and '"x-1"' in cmd and '"T1,T2"' in cmd
+    # ends with the full envelope projection, in table column order
+    assert cmd.splitlines()[-1] == "| project " + ", ".join(detect._COLUMNS)
+
+
+def test_kql_str_escapes():
+    assert detect._kql_str('a"b\\c') == '"a\\"b\\\\c"'
+
+
+# ---- timestamp normalisation ----------------------------------------------
+def test_iso_timestamp_variants():
+    # hayabusa: "2018-03-27 12:11:53.899 +00:00"
+    assert detect.iso_timestamp("2018-03-27 12:11:53.899 +00:00") == \
+        "2018-03-27T12:11:53.899000Z"
+    # suricata: legacy +0000 offset without a colon
+    assert detect.iso_timestamp("2011-06-18T18:17:15.107810+0000") == \
+        "2011-06-18T18:17:15.107810Z"
+    # already-UTC Z form and naive form survive
+    assert detect.iso_timestamp("2020-01-02T03:04:05Z") == "2020-01-02T03:04:05.000000Z"
+    assert detect.iso_timestamp("2020-01-02T03:04:05") == "2020-01-02T03:04:05.000000Z"
+    # non-UTC offsets are converted
+    assert detect.iso_timestamp("2020-01-02T03:04:05+02:00") == "2020-01-02T01:04:05.000000Z"
+    # unparseable / missing stays a Kusto null
+    assert detect.iso_timestamp(None) == ""
+    assert detect.iso_timestamp("not a time") == ""
+
+
+# ---- jsonl scanning + CSV shaping ------------------------------------------
+def test_scan_jsonl_applies_predicate_and_cap(tmp_path):
+    f = tmp_path / "lane.jsonl"
+    f.write_text("\n".join(json.dumps({"n": i}) for i in range(10)) + "\nnot json\n")
+    hits, bad = detect.scan_jsonl(
+        [str(f)], lambda r: {"Entity": str(r["n"]), "Details": r} if r["n"] % 2 == 0 else None,
+        limit=3)
+    assert [h["Entity"] for h in hits] == ["0", "2", "4"]   # capped at 3
+    # the cap stopped the scan before the bad line; without it the line counts
+    hits, bad = detect.scan_jsonl([str(f)], lambda r: None, limit=10)
+    assert hits == [] and bad == 1
+
+
+def test_hits_to_csv_column_order_and_dynamic_json():
+    det = {"id": "sig-x", "title": "T", "severity": "low", "attack": ["T9"],
+           "target": "signatures/x"}
+    out = detect.hits_to_csv(det, [{
+        "Timestamp": "2020-01-02T03:04:05Z", "Entity": 'host,with"comma',
+        "Details": {"k": "v", "path": "C:\\x"},
+    }], "RUNZ")
+    row = next(csv.reader(io.StringIO(out)))
+    assert row[:6] == ["RUNZ", "sig-x", "T", "low", "T9", "signatures/x"]
+    assert row[6] == "2020-01-02T03:04:05.000000Z"
+    assert row[7] == 'host,with"comma'
+    assert json.loads(row[8]) == {"k": "v", "path": "C:\\x"}   # dynamic column
+    assert len(row) == len(detect._COLUMNS)
+
+
+# ---- applicability gating --------------------------------------------------
+def test_applicable_kusto_gates_on_presence_and_rows():
+    det = {"requires": ["host.A", "network.B"]}
+    ok, _ = detect._applicable_kusto(det, {"host.A": 5, "network.B": 1})
+    assert ok
+    ok, reason = detect._applicable_kusto(det, {"host.A": 5, "network.B": 0})
+    assert not ok and "empty" in reason
+    ok, reason = detect._applicable_kusto(det, {"host.A": 5})
+    assert not ok and "does not exist" in reason
+
+
+def test_run_id_sortable():
+    a, b = detect.new_run_id(), detect.new_run_id()
+    assert len(a.split("-")) == 2 and a[:8].isdigit()
+    assert max(a, b)[:16] >= min(a, b)[:16]
+
+
+# ---- seeded jsonl matchers --------------------------------------------------
+def test_match_hayabusa_promotes_only_high():
+    high = {"Level": "high", "Computer": "PC1", "RuleTitle": "R", "EventID": 1}
+    assert registry.match_hayabusa_high(high)["Entity"] == "PC1"
+    assert registry.match_hayabusa_high({"Level": "info"}) is None
+    assert registry.match_hayabusa_high({}) is None
+
+
+def test_match_suricata_only_alerts():
+    assert registry.match_suricata_alert({"event_type": "flow"}) is None
+    hit = registry.match_suricata_alert({
+        "event_type": "alert", "src_ip": "1.1.1.1", "dest_ip": "2.2.2.2",
+        "dest_port": 80, "alert": {"signature": "SIG", "severity": 1}})
+    assert hit["Entity"] == "1.1.1.1 -> 2.2.2.2:80"
+    assert hit["Details"]["Signature"] == "SIG"
+
+
+def test_match_yara_trims_string_data():
+    hit = registry.match_yara({
+        "tool": "yara", "rule": "R", "target": "t.bin", "source": "file",
+        "strings": [{"id": "$a", "offset": 0, "data": "\x00binary"}]})
+    assert hit["Details"]["StringIds"] == ["$a"]
+    assert "data" not in json.dumps(hit["Details"])
+    assert registry.match_yara({"tool": "other", "rule": "R"}) is None
+
+
+# ---- process() error paths (no emulator contact needed) ---------------------
+def test_process_unknown_only_id_errors():
+    summary = detect.process(only="no-such-detection", dry_run=True)
+    assert "unknown detection id" in summary["error"]
+
+
+def test_process_unreachable_reports(monkeypatch):
+    monkeypatch.setattr(detect.KustoClient, "reachable", lambda self: False)
+    summary = detect.process(dry_run=True)
+    assert "nothing answering" in summary["error"]


### PR DESCRIPTION
Adapts **DetectRaptor's detection-runner / orchestration model** (not its rule content — that half already landed via the yara `--fetch` provisioning in #78 and is untouched here) to DX_DFIR, so a single sweep runs every registered detection against **all processed data that is actually present**, and only that.

## DetectRaptor's pattern, as adapted

DetectRaptor's `Server.StartHunts` holds a **HuntList** (one row per detection artifact), filters it (`ArtifactRegex`, `TestTargeting`), and schedules each applicable artifact against the data source it declares; applicability is settled per artifact. On DX_DFIR's Kusto backend that becomes:

| DetectRaptor | DX_DFIR |
|---|---|
| HuntList CSV in StartHunts | `python/get_sybers_dfir/detect/registry.py` — each detection declares the `db.Table` (or signature-lane JSONL output) it targets |
| artifact preconditions | the runner's **survey**: which declared tables exist AND are non-empty, which lane files are on disk |
| `TestTargeting` | `--dry-run` (targeting report; executes nothing — still read-only-queries the emulator, since targeting *is* reading what's present) |
| `ArtifactRegex` | `--only id[,id...]` |
| `hunt()` + hunt results | engine-side `.set-or-append` per KQL detection / local JSONL streaming per lane detection → unified `misc.Detections` |

## What's in the box

- **Registry** (`detect/registry.py`): two entry kinds. `kusto` entries carry KQL over the ADX tables (cross-database, like the CAR functions) with a fixed output contract (`Timestamp`, `Entity`, `Details`); `jsonl` entries carry a predicate over a signature-lane output. Validation fails fast on malformed entries.
- **Runner** (`detect/__init__.py`): surveys presence → skips non-applicable detections (reported as *skipped*, with the reason — not run, not failed) → executes the rest. KQL hits are appended **engine-side** (no rows transit Python); JSONL hits are inline-ingested. Every hit carries `RunId, DetectionId, Title, Severity, AttackIds, Source, Timestamp, Entity, Details, DetectedAt`. Sweeps are append-only under a sortable per-sweep `RunId`; optional `--jsonl-out` exports the sweep.
- **Schema** (`kusto/schema/50-detections.kql`): `misc.Detections` + `DetectionsLatest()` / `DetectionSummary()` views over the newest sweep. (Emulator gotcha found live: a `let` statement inside a `.create-or-alter function` body is rejected with `General_BadRequest` — the view inlines its `toscalar`, and the file documents it.)
- **Collection/CLI fit**: `dfir_detect_adx` role (one action per task: assert → preflight → detect; pure HTTP, no docker), `dfir-detect-adx.yml` playbook, `dxdfir detect` verb, man page + READMEs + CHANGELOG, and a Molecule scenario (stages a promotable Hayabusa fixture, converges `--only sig-hayabusa-high`, verifies the tagged hit in `misc.Detections`).
- **15 unit tests** (`python/tests/test_detect.py`) — full suite now 124 passed; `tests/run-checks.sh`: 130 passed / 0 failed.

## Seeded detections (11, spanning every processed lane)

| id | targets | fired live |
|---|---|---|
| `win-eventlog-cleared` (T1070.001) | host.EvtxEcmdJson | ran, 0 hits (honest zero) |
| `win-defender-tamper` (T1562.001) | host.EvtxEcmdJson | **10** |
| `win-service-suspicious-path` (T1543.003) | host.EvtxEcmdJson | **2** — real find: service from `C:\Users\jcloudy\AppData\Local\Temp\ad_driver.sys` |
| `win-prefetch-dualuse-tool` (T1059/T1053.005) | host.L2tPrefetch | **16** |
| `zeek-notice-promoted` | network.Zeek (notice) | **672** |
| `zeek-dns-oversized-query` (T1071.004/T1048.003) | network.Zeek (dns) | **55** (per-source summaries) |
| `vol-malfind-injection` (T1055) | memory.VolatilityJson | **1000** (capped at `--limit`) |
| `velociraptor-run-key` (T1547.001) | host.VelociraptorJson | **skipped** — "target table host.VelociraptorJson is empty" (the applicability gate, demonstrated) |
| `sig-hayabusa-high` | signatures/hayabusa JSONL | **9** |
| `sig-suricata-alert` | signatures/suricata JSONL | ran, 0 hits (this eve.jsonl holds only flow events) |
| `sig-yara-match` | signatures/yara JSONL | **109** |

Several are adapted from DetectRaptor detection content where it maps onto these tables (eventlog-clear, defender, suspicious service, dual-use tooling); the value is the engine — adding a detection is one registry entry, no runner change.

## Live validation (kustainer emulator, real ingested data)

Two full sweeps, identical results (append-only reproducibility):

```
run_id 20260826T144435Z-65bcaebf | ran 10 | skipped 1 | failed 0 | hits 1873
present: host.EvtxEcmdJson=64765  host.L2tPrefetch=1708  host.VelociraptorJson=0
         memory.VolatilityJson=2423660  network.Zeek=2834520
DetectionsLatest() | count  ->  1873   (only the newest sweep, though the table holds both)
```

The `dfir_detect_adx` role ran green end-to-end via `ansible-playbook` against the live emulator; the schema file applied cleanly through `apply-kusto-schema.sh`.

**Not validated here**: `velociraptor-run-key` never executed (its target lane has no data on this box — that's the skip path working as designed, but the query itself has only been schema-checked); Molecule itself wasn't run (molecule not installed in this environment — the scenario mirrors `dfir_ingest_adx`'s delegated pattern).

No `data_store/raw` or `data_store/processed` content is touched by this PR (verified: the push list is code/docs only).
