### PR TITLE
dxdfir build-car — first-class CAR store builder (epic #86)

### DIFF
--- a/docs/CAR-Pipeline.md
+++ b/docs/CAR-Pipeline.md
@@ -45,9 +45,16 @@ aggregate — never part of the per-source product (see §9, still to build).
 Run it:
 
 ```
-python -m get_sybers_dfir.mitrecar --in <file-or-dir> --out <dir> [--host NAME] [--artefacts k1,k2]
-# → <dir>/car.db  +  <dir>/car_<object>.jsonl   (one JSONL per populated object)
+dxdfir car                                  # batch: build every source under data_store/processed/
+dxdfir car --force                          # rebuild existing stores too (after a map/coverage change)
+dxdfir car --in <file-or-dir> --out <dir> [--host NAME] [--artefacts k1,k2]   # one source
+# → <dir>/car.db + <dir>/superset.db + <dir>/car_<object>.jsonl (one JSONL per populated object)
 ```
+
+Batch mode is **idempotent** — a source whose `car.db` already exists is skipped;
+`--force` rebuilds it, which is required after new maps land or the existing
+(stale) stores would keep skipping the newly-covered events. (`dxdfir car` fronts
+the same engine as `python -m get_sybers_dfir.mitrecar`.)
 
 ## 3. Components (the vendored `third_party/piiat-mitrecar` submodule)
 

--- a/docs/CAR-Pipeline.md
+++ b/docs/CAR-Pipeline.md
@@ -45,16 +45,16 @@ aggregate — never part of the per-source product (see §9, still to build).
 Run it:
 
 ```
-dxdfir car                                  # batch: build every source under data_store/processed/
-dxdfir car --force                          # rebuild existing stores too (after a map/coverage change)
-dxdfir car --in <file-or-dir> --out <dir> [--host NAME] [--artefacts k1,k2]   # one source
+dxdfir build-car                              # batch: build every source under data_store/processed/
+dxdfir build-car --rebuild                    # re-derive existing stores too (after a map/coverage change)
+dxdfir build-car --in <file-or-dir> --out <dir> [--host NAME] [--artefacts k1,k2]   # one source
 # → <dir>/car.db + <dir>/superset.db + <dir>/car_<object>.jsonl (one JSONL per populated object)
 ```
 
-Batch mode is **idempotent** — a source whose `car.db` already exists is skipped;
-`--force` rebuilds it, which is required after new maps land or the existing
-(stale) stores would keep skipping the newly-covered events. (`dxdfir car` fronts
-the same engine as `python -m get_sybers_dfir.mitrecar`.)
+A source whose `car.db` already exists is left as-is; `--rebuild` re-derives it,
+which is required after new maps land or the existing (stale) stores would keep
+skipping the newly-covered events. (`dxdfir build-car` fronts the same engine as
+`python -m get_sybers_dfir.mitrecar`.)
 
 ## 3. Components (the vendored `third_party/piiat-mitrecar` submodule)
 

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -272,6 +272,46 @@ def verify_car(
     raise typer.Exit(carcheck.main(["--host", host, "--port", str(port)]))
 
 
+@app.command(name="car")
+def car(
+    processed_dir: str = typer.Argument(
+        None, help="Processed tree to batch (default: <repo>/data_store/processed). Ignored with --in."),
+    in_path: str = typer.Option(None, "--in", help="Single-source: one processed file/dir → one car.db."),
+    out: str = typer.Option(None, "--out", help="Output dir (single-source: this source's car dir; batch: the car/ root)."),
+    host: str = typer.Option(None, "--host", help="Single-source: fallback source_host where the map derives none."),
+    artefacts: str = typer.Option(None, "--artefacts", help="Single-source: comma-separated artefact map keys (default: route by filename)."),
+    force: bool = typer.Option(False, "--force", help="Batch: rebuild sources whose car.db already exists."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Normalize processed evidence into per-source CAR stores (car.db + superset.db).
+
+    Batch mode (default): discover every source under the processed tree and build
+    each one's car.db + superset.db + car_<object>.jsonl. Single-source mode (--in):
+    one file/dir → one car.db.
+
+    Batch is idempotent — a source whose car.db already exists is skipped. Pass
+    --force to rebuild after a coverage/map change, otherwise the existing (stale)
+    stores are kept and newly-mapped events are never ingested.
+    """
+    from . import mitrecar
+    if in_path:
+        argv = ["--in", in_path]
+        for flag, val in (("--out", out), ("--host", host), ("--artefacts", artefacts)):
+            if val:
+                argv += [flag, val]
+    else:
+        batch = processed_dir or str(_repo_root(repo_root) / "data_store" / "processed")
+        argv = ["--batch", batch]
+        if out:
+            argv += ["--out", out]
+        if force:
+            argv.append("--force")
+    proc = mitrecar.run(argv)
+    sys.stdout.write(proc.stdout)
+    sys.stderr.write(proc.stderr)
+    raise typer.Exit(proc.returncode)
+
+
 @app.command(name="car-timeline")
 def car_timeline(
     car_dir: str = typer.Argument(..., help="A source's car directory, or a tree to aggregate."),

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -272,26 +272,26 @@ def verify_car(
     raise typer.Exit(carcheck.main(["--host", host, "--port", str(port)]))
 
 
-@app.command(name="car")
-def car(
+@app.command(name="build-car")
+def build_car(
     processed_dir: str = typer.Argument(
-        None, help="Processed tree to batch (default: <repo>/data_store/processed). Ignored with --in."),
+        None, help="Processed tree to build from (default: <repo>/data_store/processed). Ignored with --in."),
     in_path: str = typer.Option(None, "--in", help="Single-source: one processed file/dir → one car.db."),
     out: str = typer.Option(None, "--out", help="Output dir (single-source: this source's car dir; batch: the car/ root)."),
     host: str = typer.Option(None, "--host", help="Single-source: fallback source_host where the map derives none."),
     artefacts: str = typer.Option(None, "--artefacts", help="Single-source: comma-separated artefact map keys (default: route by filename)."),
-    force: bool = typer.Option(False, "--force", help="Batch: rebuild sources whose car.db already exists."),
+    rebuild: bool = typer.Option(False, "--rebuild", help="Rebuild CAR stores that already exist (e.g. after a map/coverage change)."),
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
 ) -> None:
-    """Normalize processed evidence into per-source CAR stores (car.db + superset.db).
+    """Build the per-source CAR stores (car.db + superset.db) from processed evidence.
 
-    Batch mode (default): discover every source under the processed tree and build
-    each one's car.db + superset.db + car_<object>.jsonl. Single-source mode (--in):
-    one file/dir → one car.db.
+    Default (batch): discover every source under the processed tree and build each
+    one's car.db + superset.db + car_<object>.jsonl. Single-source (--in): one
+    file/dir → one car.db.
 
-    Batch is idempotent — a source whose car.db already exists is skipped. Pass
-    --force to rebuild after a coverage/map change, otherwise the existing (stale)
-    stores are kept and newly-mapped events are never ingested.
+    A source whose car.db already exists is left as-is; pass --rebuild to re-derive
+    it from the current maps — required after a coverage/map change, otherwise the
+    existing (stale) stores keep skipping the newly-mapped events.
     """
     from . import mitrecar
     if in_path:
@@ -304,7 +304,7 @@ def car(
         argv = ["--batch", batch]
         if out:
             argv += ["--out", out]
-        if force:
+        if rebuild:                      # the engine's own flag for "rebuild existing"
             argv.append("--force")
     proc = mitrecar.run(argv)
     sys.stdout.write(proc.stdout)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Unit tests for the dfir CLI (Typer CliRunner; subprocess mocked)."""
 import os
+import subprocess
 from pathlib import Path
 from unittest import mock
 
@@ -103,3 +104,27 @@ def test_failing_command_propagates_exit_code(tmp_path):
             mock.patch.object(cli, "_ansible_playbook", return_value="ansible-playbook"):
         r = runner.invoke(cli.app, ["ingest", "--repo-root", str(repo)])
     assert r.exit_code == 3
+
+
+def test_car_batch_defaults_to_processed_tree_with_force(tmp_path):
+    from get_sybers_dfir import mitrecar
+    repo = _fake_repo(tmp_path)
+    fake = subprocess.CompletedProcess([], 0, stdout="[]\n", stderr="")
+    with mock.patch.object(mitrecar, "run", return_value=fake) as m:
+        r = runner.invoke(cli.app, ["car", "--force", "--repo-root", str(repo)])
+    assert r.exit_code == 0, r.stdout
+    argv = m.call_args.args[0]
+    assert "--batch" in argv and "--force" in argv
+    assert argv[argv.index("--batch") + 1] == str(repo / "data_store" / "processed")
+
+
+def test_car_single_source_passes_in_out_host(tmp_path):
+    from get_sybers_dfir import mitrecar
+    fake = subprocess.CompletedProcess([], 0, stdout="{}\n", stderr="")
+    with mock.patch.object(mitrecar, "run", return_value=fake) as m:
+        r = runner.invoke(cli.app, ["car", "--in", "/x/a.jsonl", "--out", "/y", "--host", "H"])
+    assert r.exit_code == 0, r.stdout
+    argv = m.call_args.args[0]
+    assert argv[:2] == ["--in", "/x/a.jsonl"]
+    assert "--batch" not in argv
+    assert "--out" in argv and "/y" in argv and "H" in argv

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -106,23 +106,24 @@ def test_failing_command_propagates_exit_code(tmp_path):
     assert r.exit_code == 3
 
 
-def test_car_batch_defaults_to_processed_tree_with_force(tmp_path):
+def test_build_car_batch_defaults_to_processed_tree_and_rebuild(tmp_path):
     from get_sybers_dfir import mitrecar
     repo = _fake_repo(tmp_path)
     fake = subprocess.CompletedProcess([], 0, stdout="[]\n", stderr="")
     with mock.patch.object(mitrecar, "run", return_value=fake) as m:
-        r = runner.invoke(cli.app, ["car", "--force", "--repo-root", str(repo)])
+        r = runner.invoke(cli.app, ["build-car", "--rebuild", "--repo-root", str(repo)])
     assert r.exit_code == 0, r.stdout
     argv = m.call_args.args[0]
+    # user-facing --rebuild maps to the engine's own --force
     assert "--batch" in argv and "--force" in argv
     assert argv[argv.index("--batch") + 1] == str(repo / "data_store" / "processed")
 
 
-def test_car_single_source_passes_in_out_host(tmp_path):
+def test_build_car_single_source_passes_in_out_host(tmp_path):
     from get_sybers_dfir import mitrecar
     fake = subprocess.CompletedProcess([], 0, stdout="{}\n", stderr="")
     with mock.patch.object(mitrecar, "run", return_value=fake) as m:
-        r = runner.invoke(cli.app, ["car", "--in", "/x/a.jsonl", "--out", "/y", "--host", "H"])
+        r = runner.invoke(cli.app, ["build-car", "--in", "/x/a.jsonl", "--out", "/y", "--host", "H"])
     assert r.exit_code == 0, r.stdout
     argv = m.call_args.args[0]
     assert argv[:2] == ["--in", "/x/a.jsonl"]


### PR DESCRIPTION
Adds the missing **producer** verb for the CAR stores. Building them was only reachable via `python -m get_sybers_dfir.mitrecar --batch` or the Ansible role, even though the consumer (`dxdfir car-timeline`) was already a CLI verb.

- **`dxdfir build-car`** — build the per-source CAR stores (`car.db` + `superset.db` + `car_<object>.jsonl`) from processed evidence. Batch over `data_store/processed` by default; `--in/--out/--host/--artefacts` for one source.
- **`--rebuild`** — re-derive stores that already exist (batch is otherwise idempotent and skips them). This is what re-ingests events newly covered by a map/coverage change; it maps to the engine's own `--force` internally, so the user-facing flag says what it does.
- Named verb-object to match the CLI's existing standard (`verify-car`, `verify-images`); `car-timeline` and `verify-car` unchanged.

CAR surface now reads as a pipeline: `build-car` → `car-timeline` → `verify-car`.

Tests added (batch default + `--rebuild`, single-source argv); 207 pass. Doc updated.