### PR TITLE
release: 0.6.0 — materialized MITRE CAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ is `0`, anything may change without notice.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-30
+
 ### Added
 - Materialized MITRE CAR: the engine (PIIAT-MitreCar) normalises each source to `car_<object>.jsonl`, ingested as the 13 `mitre.car_*` tables + `car_relationships`, with `Car()`/`CarObjects()` views.
 - `dxdfir build-car` (build the per-source CAR stores) and `dxdfir car-timeline` (one property-rich, time-ordered timeline from car.db + superset.db).

--- a/ansible/collections/get_sybers.dfir/galaxy.yml
+++ b/ansible/collections/get_sybers.dfir/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: get_sybers
 name: dfir
-version: 0.5.0
+version: 0.6.0
 readme: README.md
 repository: https://github.com/Get-Sybers/DX_DFIR
 issues: https://github.com/Get-Sybers/DX_DFIR/issues

--- a/python/get_sybers_dfir/__init__.py
+++ b/python/get_sybers_dfir/__init__.py
@@ -6,4 +6,4 @@ actions; the playbook holds the decisions. See docs/CAR-Extraction-Rules.md and
 epic #46.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "get-sybers-dfir"
-version = "0.5.0"
+version = "0.6.0"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [


### PR DESCRIPTION
Version bump to **0.6.0** across pyproject / `__version__` / galaxy.yml, and the CHANGELOG `[0.6.0]` section.

Covers the materialized-CAR line already on main: the `mitre.car_*` tables + `car_relationships` + `Car()`/`CarObjects()`, `build-car`/`car-timeline`/`ingest --only car`, the Zimmerman lane — and the removal of the query-time `Car*()` functions and the Velociraptor lane. Minor bump per SemVer-in-0.x (feature line that also drops the old query-time CAR API).

After merge, tag/publish the GitHub Release `v0.6.0` on main so the README badge picks it up.