### PR TITLE
docs: link PIIAT-Mem / PIIAT-MitreCar references to their repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ is `0`, anything may change without notice.
 ## [0.6.0] - 2026-08-30
 
 ### Added
-- Materialized MITRE CAR: the engine (PIIAT-MitreCar) normalises each source to `car_<object>.jsonl`, ingested as the 13 `mitre.car_*` tables + `car_relationships`, with `Car()`/`CarObjects()` views.
+- Materialized MITRE CAR: the engine ([PIIAT-MitreCar](https://github.com/Get-Sybers/PIIAT-MitreCar)) normalises each source to `car_<object>.jsonl`, ingested as the 13 `mitre.car_*` tables + `car_relationships`, with `Car()`/`CarObjects()` views.
 - `dxdfir build-car` (build the per-source CAR stores) and `dxdfir car-timeline` (one property-rich, time-ordered timeline from car.db + superset.db).
 - `dxdfir ingest --only car` loads the CAR stores into `mitre.car_*`.
 - Zimmerman (EZ-Tools) lane: hardened `dfir/*` containers (RECmd, SRUM via Plaso, MFT, …) → CAR.
 
 ### Changed
-- CAR extraction moved into the PIIAT-MitreCar engine (pinned submodule); memory/Volatility driven via the PIIAT-Mem CLI. `40-mitre.kql` is now the materialized tables, schema generated from the engine model.
+- CAR extraction moved into the PIIAT-MitreCar engine (pinned submodule); memory/Volatility driven via the [PIIAT-Mem](https://github.com/Get-Sybers/PIIAT-Mem) CLI. `40-mitre.kql` is now the materialized tables, schema generated from the engine model.
 - `dxdfir verify-car` rewritten against the `mitre.car_*` tables; `car_action` validated against the engine model's vocabulary.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ matching `dfir_<source>` role); processors are also runnable as
 | Disk images / VM exports (Plaso) | `process plaso` | per-parser `host.L2t<Parser>` tables |
 | PCAP (Zeek) | `process zeek` | `network.ZeekConn` (typed) + generic `network.Zeek` |
 | Windows event logs + Sysmon (EvtxECmd) | `process evtx` | `host.EvtxEcmdJson` |
-| Memory (Volatility 3 / PIIAT-Mem) | `process volatility` | `memory.VolatilityJson` |
+| Memory (Volatility 3 / [PIIAT-Mem](https://github.com/Get-Sybers/PIIAT-Mem)) | `process volatility` | `memory.VolatilityJson` |
 | EZ-Tools artefacts — SRUM, registry, … | `process zimmerman` | processed output → CAR (`mitre.car_*`, via `build-car`) |
 | YARA / Suricata / Hayabusa | `process signatures` | JSONL under `processed/signatures/` |
 

--- a/ansible/collections/get_sybers.dfir/roles/dfir_images/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_images/README.md
@@ -3,7 +3,7 @@
 Build **every runtime tool container from source, in-repo, hardened** — and
 verify it. No third-party tool image is pulled at runtime: yara, suricata,
 zeek, volatility, plaso and evtxecmd are all built from `docker/<name>/Dockerfile`
-(volatility from the PIIAT-Mem submodule's context). The **Eric Zimmerman tool
+(volatility from the [PIIAT-Mem](https://github.com/Get-Sybers/PIIAT-Mem) submodule's context). The **Eric Zimmerman tool
 family** — recmd, mftecmd, amcacheparser, appcompatcacheparser,
 lecmd, jlecmd, sbecmd, sqlecmd, rbcmd, wxtcmd — builds from the ONE parameterized
 `docker/eztool/Dockerfile` (the same recipe as evtxecmd; the tool is selected

--- a/ansible/collections/get_sybers.dfir/roles/dfir_volatility/README.md
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_volatility/README.md
@@ -2,7 +2,7 @@
 
 Process **memory images** with **Volatility 3** into per-plugin JSON Lines for the
 ADX or SOF-ELK pipeline. The role is structure only — it asserts inputs, runs a
-preflight (docker reachable, memory dir present, the PIIAT-Mem tool runnable), then
+preflight (docker reachable, memory dir present, the [PIIAT-Mem](https://github.com/Get-Sybers/PIIAT-Mem) tool runnable), then
 invokes the `get_sybers_dfir.volatility` processor as a **single action**. One
 `<plugin>.jsonl` per plugin per image.
 

--- a/docs/CAR-Extraction-Rules.md
+++ b/docs/CAR-Extraction-Rules.md
@@ -2,7 +2,7 @@
 
 The MITRE CAR data model is DX_DFIR's extraction target. The CAR objects, their
 fields and their canonical actions are reconstructed from the pinned `car`
-submodule (the forked MITRE model we own), and the engine (PIIAT-MitreCar)
+submodule (the forked MITRE model we own), and the engine ([PIIAT-MitreCar](https://github.com/Get-Sybers/PIIAT-MitreCar))
 normalises every artefact into finished CAR events against it. These four
 principles govern how each CAR object is built.
 

--- a/docs/CAR-Pipeline.md
+++ b/docs/CAR-Pipeline.md
@@ -22,7 +22,7 @@ input source ──▶ artefact map(s) ──▶ normalize ──▶ its own car
                                                    car_<object>.jsonl → ADX
 ```
 
-It is the pipeline-wide application of what shipped in **PIIAT-Mem v1.0.0** for
+It is the pipeline-wide application of what shipped in **[PIIAT-Mem](https://github.com/Get-Sybers/PIIAT-Mem) v1.0.0** for
 memory: the mapping/inference logic lives in the processor we own, the store is
 finished CAR, and the query layer just reads the model instead of re-deriving it.
 
@@ -58,7 +58,7 @@ skipping the newly-covered events. (`dxdfir build-car` fronts the same engine as
 
 ## 3. Components (the vendored `third_party/piiat-mitrecar` submodule)
 
-The engine is the standalone public **PIIAT-MitreCar** tool (Get-Sybers/PIIAT-MitreCar),
+The engine is the standalone public **[PIIAT-MitreCar](https://github.com/Get-Sybers/PIIAT-MitreCar)** tool,
 vendored as a submodule and driven via its CLI by the thin
 `get_sybers_dfir/mitrecar.py` lane — exactly the PIIAT-Mem pattern.
 

--- a/docs/CAR-Relations.md
+++ b/docs/CAR-Relations.md
@@ -1,6 +1,6 @@
 # CAR relations — identity, joins, inheritance, limits
 
-The relational discipline of PIIAT-Mem's `car-store.md` §3, applied to the CAR
+The relational discipline of [PIIAT-Mem](https://github.com/Get-Sybers/PIIAT-Mem)'s `car-store.md` §3, applied to the CAR
 objects the **memory artefact cannot supply** — determined from MITRE's own doc
 pages (car.mitre.org, field semantics read verbatim) and ratified against real
 evidence. The ten memory-fed objects are governed by

--- a/docs/Kusto-Port.md
+++ b/docs/Kusto-Port.md
@@ -60,7 +60,7 @@ mapping.
 ## MITRE CAR is materialized
 
 The `mitre` database is the CAR model as **ingested tables**, not query-time
-views. The engine (PIIAT-MitreCar) normalises each evidence source into finished
+views. The engine ([PIIAT-MitreCar](https://github.com/Get-Sybers/PIIAT-MitreCar)) normalises each evidence source into finished
 CAR events and the pipeline ingests one `car_<object>.jsonl` per object as the
 13 `mitre.car_<object>` tables, plus `car_relationships` (the superset
 relationship edges). `Car()` unions the objects into one timestamp-ordered

--- a/project-progress.md
+++ b/project-progress.md
@@ -55,7 +55,7 @@ Processing = the evidence-side scripts. Ingest / CAR = the Kusto backend.
 | [Hayabusa](https://github.com/Yamato-Security/hayabusa) (EVTX → Sigma) | ✅ `get_sybers_dfir.signatures` (hayabusa lane; also in the evtx lane) — validated 792 detections | json (Sigma) | ⏳ `processed/signatures/hayabusa` | ⏳ |
 | [Syslog](https://syslog-ng.github.io)                         | ✅ (via Plaso) |                 |              |               |
 
-**CAR is materialized.** The engine (PIIAT-MitreCar) normalises each evidence
+**CAR is materialized.** The engine ([PIIAT-MitreCar](https://github.com/Get-Sybers/PIIAT-MitreCar)) normalises each evidence
 source into finished CAR events; the pipeline ingests one `car_<object>.jsonl`
 per object as the 13 `mitre.car_<object>` tables plus `car_relationships` (the
 superset relationship edges). `Car()` unions the objects into one timeline;


### PR DESCRIPTION
Wherever the docs name the sibling projects in prose, the first mention now links to the repo — README, task board, CHANGELOG, the CAR docs (Pipeline/Kusto-Port/Relations/Extraction-Rules), and the dfir_volatility / dfir_images role READMEs. Code identifiers (`piiat_mitrecar`, `python -m piiat_mem`) left as-is. Docs only; run-checks 69/0.