### PR TITLE
detect: propagate ATT&CK technique IDs from Hayabusa/Suricata/YARA into Detections

### DIFF
--- a/python/get_sybers_dfir/detect/__init__.py
+++ b/python/get_sybers_dfir/detect/__init__.py
@@ -124,12 +124,18 @@ def kusto_command(det: dict, run_id: str, limit: int) -> str:
 
 
 def hits_to_csv(det: dict, hits: list[dict], run_id: str) -> str:
-    """jsonl-lane hits as inline-ingest CSV rows (column order = table order)."""
-    attack = ",".join(det.get("attack", []))
+    """jsonl-lane hits as inline-ingest CSV rows (column order = table order).
+
+    AttackIds is per-hit: a hit that parsed its own ATT&CK technique ids (from
+    Hayabusa MitreTags, a Suricata alert's ``mitre_technique_id``, or a YARA
+    rule's meta) carries them; a hit without falls back to the detection's static
+    ``attack`` list — '' for the signature lanes, which declare none."""
+    default_attack = det.get("attack", [])
     now = _utc_now_iso()
     buf = io.StringIO()
     w = csv.writer(buf, lineterminator="\n")
     for h in hits:
+        attack = ",".join(h.get("AttackIds") or default_attack)
         w.writerow([
             run_id, det["id"], det["title"], det["severity"], attack, det["target"],
             iso_timestamp(h.get("Timestamp")), str(h.get("Entity", "") or ""),

--- a/python/get_sybers_dfir/detect/registry.py
+++ b/python/get_sybers_dfir/detect/registry.py
@@ -26,8 +26,12 @@ Two kinds of entry, matching the two places processed data lives:
     ``data_store/processed`` (those files are not in Kusto). ``subdir``/``glob``
     locate the files; ``match(record)`` returns None for a non-hit, or a dict
     with the same three keys (Timestamp ISO-ish string or None, Entity str,
-    Details dict). The runner streams the files, applies the predicate, and
-    ingests the hits into the same ``misc.Detections`` table.
+    Details dict) and an OPTIONAL ``AttackIds`` (list of ATT&CK technique ids
+    parsed from the record's own tags — Hayabusa MitreTags, Suricata
+    ``mitre_technique_id``, a YARA rule's meta); when present it fills the hit's
+    ``AttackIds`` column, otherwise the detection's static ``attack`` list does.
+    The runner streams the files, applies the predicate, and ingests the hits
+    into the same ``misc.Detections`` table.
 
 Shared metadata: ``id`` (stable, kebab-case), ``title``, ``severity`` (info/low/
 medium/high/critical), ``attack`` (MITRE ATT&CK technique ids), ``target`` (the
@@ -41,8 +45,56 @@ adding an entry here; the runner needs no change.
 """
 from __future__ import annotations
 
+import re
+
 SEVERITIES = ("info", "low", "medium", "high", "critical")
 KINDS = ("kusto", "jsonl")
+
+# A MITRE ATT&CK technique id: T#### with an optional .### sub-technique. The
+# lanes render tags in different shapes (Hayabusa joins several tags in one
+# string, Suricata metadata is a list, ET Open sometimes writes t1059_003), so
+# every per-hit tag source is run through _technique_ids() below, which pulls the
+# technique ids out of whatever it is given and drops everything else (tactic
+# names/ids, software/group ids, CAR ids).
+_TECHNIQUE_RE = re.compile(r"T\d{4}(?:[._]\d{3})?", re.IGNORECASE)
+# Meta keys that name an ATT&CK reference (attack / att&ck / att_ck / mitre_attack
+# / mitre / technique). Matches "attack" but not "pattern"/"attribute".
+_MITRE_META_KEY_RE = re.compile(r"att.?ck|mitre|technique", re.IGNORECASE)
+
+
+def _technique_ids(value) -> list[str]:
+    """ATT&CK technique ids found in ``value`` (a string, or a list/tuple/dict of
+    them), normalised to canonical upper-case dotted form (``T1059.003``) and
+    de-duplicated in first-seen order. Non-technique tags are ignored; ``''`` /
+    ``None`` / no match yields ``[]``. Pure."""
+    if not value:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        text = " ".join(str(v) for v in value)
+    elif isinstance(value, dict):
+        text = " ".join(str(v) for v in value.values())
+    else:
+        text = str(value)
+    out: list[str] = []
+    seen: set[str] = set()
+    for tok in _TECHNIQUE_RE.findall(text):
+        tid = tok.upper().replace("_", ".")
+        if tid not in seen:
+            seen.add(tid)
+            out.append(tid)
+    return out
+
+
+def _yara_meta_attack(meta) -> list[str]:
+    """Technique ids declared in a YARA rule's ``meta``. Prefers values under an
+    ATT&CK-named key (``attack``, ``mitre_technique``, ...); with no such key,
+    falls back to scanning every value (the technique-id pattern is distinctive).
+    Pure."""
+    if not isinstance(meta, dict):
+        return _technique_ids(meta)
+    keyed = [v for k, v in meta.items() if _MITRE_META_KEY_RE.search(str(k))]
+    return _technique_ids(keyed) or _technique_ids(list(meta.values()))
+
 
 # A JSON-shape EvtxECmd Payload field, extracted inline so the registry does not
 # depend on the mitre database's EvtxPayload() helper being deployed. Used inside
@@ -53,16 +105,25 @@ _EVTX_FIELD = r'"@Name":"%s","#text":"((?:[^"\\]|\\.)*)"'
 # --------------------------------------------------------------------- jsonl matchers
 def match_hayabusa_high(rec: dict):
     """Hayabusa (Sigma over EVTX) already scored the event — promote the ones it
-    called high/critical into the unified detections output."""
+    called high/critical into the unified detections output.
+
+    The Sigma rule's ATT&CK technique ids ride along in the ``MitreTags`` column
+    (emitted by the lane's ``--profile verbose``); they are parsed out and
+    attached as ``AttackIds`` so the hit carries its real techniques instead of
+    the detection's empty static list."""
     if str(rec.get("Level", "")).lower() not in ("high", "crit", "critical"):
         return None
-    return {
+    hit = {
         "Timestamp": rec.get("Timestamp"),
         "Entity": str(rec.get("Computer", "") or ""),
         "Details": {k: rec[k] for k in
                     ("RuleTitle", "Level", "Channel", "EventID", "RecordID",
                      "RuleID", "Details") if k in rec},
     }
+    attack = _technique_ids([rec.get("MitreTags"), rec.get("MitreTactics")])
+    if attack:
+        hit["AttackIds"] = attack
+    return hit
 
 
 def match_suricata_alert(rec: dict):
@@ -71,7 +132,7 @@ def match_suricata_alert(rec: dict):
     if rec.get("event_type") != "alert":
         return None
     alert = rec.get("alert") or {}
-    return {
+    hit = {
         "Timestamp": rec.get("timestamp"),
         "Entity": "%s -> %s:%s" % (rec.get("src_ip", "?"), rec.get("dest_ip", "?"),
                                    rec.get("dest_port", "?")),
@@ -84,6 +145,14 @@ def match_suricata_alert(rec: dict):
             "AppProto": rec.get("app_proto"),
         },
     }
+    # ET Open populates rule metadata with mitre_technique_id (a list) for many
+    # rules; carry the techniques through as the hit's AttackIds when present.
+    metadata = alert.get("metadata")
+    if isinstance(metadata, dict):
+        attack = _technique_ids(metadata.get("mitre_technique_id"))
+        if attack:
+            hit["AttackIds"] = attack
+    return hit
 
 
 def match_yara(rec: dict):
@@ -93,7 +162,7 @@ def match_yara(rec: dict):
     if rec.get("tool") != "yara" or not rec.get("rule"):
         return None
     strings = rec.get("strings") or []
-    return {
+    hit = {
         "Timestamp": None,   # a YARA match has no event time
         "Entity": str(rec.get("target", "") or rec.get("match", "") or ""),
         "Details": {
@@ -103,6 +172,11 @@ def match_yara(rec: dict):
             "StringIds": sorted({s.get("id", "?") for s in strings if isinstance(s, dict)}),
         },
     }
+    # When the rule's meta carries ATT&CK technique ids, surface them as AttackIds.
+    attack = _yara_meta_attack(rec.get("meta"))
+    if attack:
+        hit["AttackIds"] = attack
+    return hit
 
 
 # --------------------------------------------------------------------- the registry

--- a/python/get_sybers_dfir/detect/registry.py
+++ b/python/get_sybers_dfir/detect/registry.py
@@ -63,13 +63,18 @@ _MITRE_META_KEY_RE = re.compile(r"att.?ck|mitre|technique", re.IGNORECASE)
 
 
 def _technique_ids(value) -> list[str]:
-    """ATT&CK technique ids found in ``value`` (a string, or a list/tuple/dict of
-    them), normalised to canonical upper-case dotted form (``T1059.003``) and
-    de-duplicated in first-seen order. Non-technique tags are ignored; ``''`` /
-    ``None`` / no match yields ``[]``. Pure."""
+    """ATT&CK technique ids found in ``value`` (a string, or a list/tuple/set/dict
+    of them), normalised to canonical upper-case dotted form (``T1059.003``) and
+    de-duplicated in first-seen order (a ``set`` input is sorted first, as it has
+    no first-seen order). Non-technique tags are ignored; ``''`` / ``None`` / no
+    match yields ``[]``. Pure."""
     if not value:
         return []
-    if isinstance(value, (list, tuple, set)):
+    if isinstance(value, (set, frozenset)):
+        # A set has no meaningful "first-seen" order, and string hashing is
+        # randomised per process, so sort it to keep the output deterministic.
+        text = " ".join(str(v) for v in sorted(value, key=str))
+    elif isinstance(value, (list, tuple)):
         text = " ".join(str(v) for v in value)
     elif isinstance(value, dict):
         text = " ".join(str(v) for v in value.values())

--- a/python/get_sybers_dfir/signatures/hayabusa.py
+++ b/python/get_sybers_dfir/signatures/hayabusa.py
@@ -75,9 +75,19 @@ def scan_directory(hb_bin, scan_dir, rules_dir) -> str:
     # TOCTOU-prone tempfile.mktemp(); the dir (and file) are cleaned up on exit.
     with tempfile.TemporaryDirectory() as tmpd:
         tmp_out = os.path.join(tmpd, "timeline.jsonl")
+        # `--profile verbose` so each JSONL detection carries its MITRE ATT&CK
+        # columns (%MitreTactics% / %MitreTags%) — the default (standard) profile
+        # omits them, which is what made the detect lane emit empty AttackIds. The
+        # detect registry's match_hayabusa_high parses MitreTags into technique ids
+        # (get_sybers_dfir.detect.registry). A leaner custom profile (minimal +
+        # the two Mitre columns) would need authoring into the operator-supplied
+        # config/profiles.yaml, which isn't present to write to/verify here, so
+        # the built-in verbose profile — guaranteed to emit both — is used; the
+        # matcher keeps only the columns it needs, so the extra fields are inert.
         argv = [
             hb_bin, "json-timeline", "--directory", scan_dir, "--output", tmp_out,
-            "--JSONL-output", "--no-wizard", "--UTC", "--quiet",
+            "--JSONL-output", "--profile", "verbose",
+            "--no-wizard", "--UTC", "--quiet",
         ]
         if rules_dir:
             argv += ["--rules", rules_dir]

--- a/python/tests/test_detect.py
+++ b/python/tests/test_detect.py
@@ -182,6 +182,8 @@ def test_technique_ids_normalises_and_dedupes():
         ["T1112"]
     assert registry._technique_ids(None) == [] and registry._technique_ids("") == []
     assert registry._technique_ids("no ids here") == []
+    # a set has no first-seen order, so it is sorted first for a deterministic result
+    assert registry._technique_ids({"T1204", "t1059.003"}) == ["T1204", "T1059.003"]
 
 
 def test_match_hayabusa_extracts_mitre_tags():

--- a/python/tests/test_detect.py
+++ b/python/tests/test_detect.py
@@ -104,6 +104,30 @@ def test_hits_to_csv_column_order_and_dynamic_json():
     assert len(row) == len(detect._COLUMNS)
 
 
+def test_hits_to_csv_attack_ids_are_per_hit():
+    # The signature lanes declare no static attack ids, so AttackIds must come
+    # from each hit: a hit that parsed its own techniques carries them, a tagless
+    # hit stays ''.
+    det = {"id": "sig-x", "title": "T", "severity": "low", "attack": [],
+           "target": "signatures/x"}
+    out = detect.hits_to_csv(det, [
+        {"Entity": "a", "Details": {}, "AttackIds": ["T1059.003", "T1204.002"]},
+        {"Entity": "b", "Details": {}},                       # no tags -> ''
+    ], "RUNZ")
+    rows = list(csv.reader(io.StringIO(out)))
+    assert rows[0][4] == "T1059.003,T1204.002"                # AttackIds column
+    assert rows[1][4] == ""
+
+
+def test_hits_to_csv_static_attack_is_the_fallback():
+    # A hit without its own AttackIds still inherits a detection's static list
+    # (kusto detections keep theirs; this keeps jsonl behaviour uniform).
+    det = {"id": "x", "title": "T", "severity": "low", "attack": ["T9"],
+           "target": "t"}
+    out = detect.hits_to_csv(det, [{"Entity": "a", "Details": {}}], "R")
+    assert next(csv.reader(io.StringIO(out)))[4] == "T9"
+
+
 # ---- applicability gating --------------------------------------------------
 def test_applicable_kusto_gates_on_presence_and_rows():
     det = {"requires": ["host.A", "network.B"]}
@@ -145,6 +169,51 @@ def test_match_yara_trims_string_data():
     assert hit["Details"]["StringIds"] == ["$a"]
     assert "data" not in json.dumps(hit["Details"])
     assert registry.match_yara({"tool": "other", "rule": "R"}) is None
+
+
+# ---- ATT&CK technique-id propagation (the tag-leak fix) ---------------------
+def test_technique_ids_normalises_and_dedupes():
+    # canonical dotted upper-case, first-seen order; ET Open underscore form and
+    # a plain string both parse; non-technique tags (tactics, software/CAR ids)
+    # are dropped; empties yield [].
+    assert registry._technique_ids(["t1059.003", "T1204", "t1059_003"]) == \
+        ["T1059.003", "T1204"]
+    assert registry._technique_ids("attack.t1112, attack.ta0005, S0002, TA0002") == \
+        ["T1112"]
+    assert registry._technique_ids(None) == [] and registry._technique_ids("") == []
+    assert registry._technique_ids("no ids here") == []
+
+
+def test_match_hayabusa_extracts_mitre_tags():
+    hit = registry.match_hayabusa_high({
+        "Level": "high", "Computer": "PC1", "RuleTitle": "R",
+        "MitreTactics": "Execution", "MitreTags": "T1059.001 ¦ T1204.002"})
+    assert hit["AttackIds"] == ["T1059.001", "T1204.002"]
+    # a high hit with no MITRE columns simply carries no per-hit tags
+    assert "AttackIds" not in registry.match_hayabusa_high(
+        {"Level": "high", "Computer": "PC1"})
+
+
+def test_match_suricata_reads_mitre_technique_id():
+    hit = registry.match_suricata_alert({
+        "event_type": "alert", "src_ip": "1.1.1.1", "dest_ip": "2.2.2.2",
+        "dest_port": 80,
+        "alert": {"signature": "SIG", "metadata": {
+            "mitre_technique_id": ["t1204"], "mitre_tactic_id": ["TA0002"]}}})
+    assert hit["AttackIds"] == ["T1204"]
+    # an alert without ATT&CK metadata carries no per-hit tags
+    assert "AttackIds" not in registry.match_suricata_alert({
+        "event_type": "alert", "alert": {"signature": "SIG"}})
+
+
+def test_match_yara_reads_meta_attack():
+    hit = registry.match_yara({
+        "tool": "yara", "rule": "R", "target": "t.bin",
+        "meta": {"description": "x", "attack": "T1027"}})
+    assert hit["AttackIds"] == ["T1027"]
+    # no meta -> no per-hit tags (the lane does not always emit meta)
+    assert "AttackIds" not in registry.match_yara(
+        {"tool": "yara", "rule": "R", "target": "t.bin"})
 
 
 # ---- process() error paths (no emulator contact needed) ---------------------


### PR DESCRIPTION
## Why

The detect pipeline already runs three signature engines that compute ATT&CK technique IDs — Hayabusa (Sigma over EVTX), Suricata (ET Open rules), and YARA — but the pipeline was **dropping** them. The three signature-lane promotions in the registry declared `attack: []`, and Hayabusa was invoked with a profile that omits MITRE tags, so every promoted hit landed in `misc.Detections` with an empty `AttackIds` column. This is the missing half of surfacing ATT&CK on detections: the tags are computed and then leaked away. This PR carries each hit's *own* techniques through to the output.

Scoped strictly to ATT&CK-tag propagation — no guid/confidence columns, no Elastic-side changes, and the load-bearing `AttackIds` column order/ordinal CSV mapping is untouched.

## What changed

- **Hayabusa lane** (`signatures/hayabusa.py`): `scan_directory` now invokes `json-timeline` with `--profile verbose`, so the JSONL carries the `MitreTactics` / `MitreTags` columns the default (standard) profile omits. (A leaner custom `minimal`+Mitre profile would have to be authored into the operator-supplied `config/profiles.yaml`, which is not present in-tree to write to or verify against; `verbose` is the built-in guaranteed to emit both, and the matcher keeps only the columns it needs so the extra fields are inert.)
- **Registry matchers** (`detect/registry.py`): a pure `_technique_ids()` helper extracts `T####` / `T####.###` technique IDs from whatever shape a lane produces (string, list, dict), normalises to canonical upper-case dotted form, de-dupes, and drops non-technique tags (tactics, software/group/CAR IDs). Wired in per lane:
  - `match_hayabusa_high` parses `MitreTags` (and `MitreTactics`).
  - `match_suricata_alert` reads `alert.metadata.mitre_technique_id`.
  - `match_yara` reads the rule `meta` (ATT&CK-named keys, with a distinctive-pattern fallback) — attached only when present.
  - Each attaches the result as an optional per-hit `AttackIds` list.
- **CSV shaping** (`detect/__init__.py`): `hits_to_csv` now takes `AttackIds` per hit, falling back to the detection's static `attack` list when a hit has none — so the signature lanes emit real technique IDs and a genuinely tagless hit still yields `''`.

### Before / after for `AttackIds`
- **Before:** every `sig-hayabusa-high` / `sig-suricata-alert` / `sig-yara-match` hit → `AttackIds = ''` (static `attack: []`).
- **After:** each hit carries its parsed technique IDs, e.g. a Hayabusa hit whose rule tags `T1059.001`/`T1204.002` → `AttackIds = "T1059.001,T1204.002"`; a hit with no tags still → `''`.

## Tests

Extended `python/tests/test_detect.py`:
- `_technique_ids` normalisation/dedupe (dotted, underscore→dot, lowercase, non-technique tags dropped, empties → `[]`).
- Hayabusa hit with `MitreTags`, Suricata alert with `mitre_technique_id`, and YARA hit with a technique in `meta` each populate `AttackIds`; the tagless variant of each carries none.
- `hits_to_csv` uses per-hit `AttackIds` (tagless hit → `''`) and still falls back to a detection's static list.

Run: `PYTHONPATH=python python -m pytest python/tests/test_detect.py python/tests/test_signatures.py` → **74 passed**. Repo static suite `./tests/run-checks.sh` → **59 passed, 0 failed, 2 skipped** (shellcheck/ansible-lint not installed locally). The one failure in the full suite (`test_carcheck.py::test_union_equals_sum_detects_fabrication`) is pre-existing on `dev` and unrelated to these files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu)_