### PR TITLE
docker: add Byakugan's Elastic-native stack (security ON) under docker/elastic

### DIFF
--- a/docker/elastic/.env.example
+++ b/docker/elastic/.env.example
@@ -1,0 +1,34 @@
+# Byakugan Elastic stack — copy to .env next to docker-compose.yml and replace
+# every placeholder. .env is gitignored: NEVER commit real secrets.
+#   passwords: >= 6 chars (no quotes/backslashes); keys: openssl rand -hex 32
+
+# Elastic stack version (Elasticsearch, Kibana, elastic-agent, Filebeat).
+ELASTIC_VERSION=9.4.3
+
+# `elastic` superuser — bootstrap password for Elasticsearch; also used by the
+# fleet-server container to run Fleet setup and by Filebeat to write evidence.
+ELASTIC_PASSWORD=change-me-elastic
+
+# `kibana_system` — set by config/setup.sh, used by Kibana to reach Elasticsearch.
+KIBANA_SYSTEM_PASSWORD=change-me-kibana-system
+
+# Kibana encryption keys (>= 32 chars each; Fleet needs the saved-objects key).
+KIBANA_ENCRYPTED_SAVED_OBJECTS_KEY=change-me-to-a-random-32-plus-character-key
+KIBANA_SECURITY_ENCRYPTION_KEY=change-me-to-a-random-32-plus-character-key
+KIBANA_REPORTING_ENCRYPTION_KEY=change-me-to-a-random-32-plus-character-key
+
+# Optional: a Fleet service token (Kibana -> Fleet -> Settings, or
+# POST /api/fleet/service_tokens). Empty = the fleet-server container requests one
+# from Kibana with the elastic credentials on first boot.
+FLEET_SERVER_SERVICE_TOKEN=
+
+# Host directory holding the delivered evidence tree (<type>/**/*.json[l]) —
+# point it at the same path dfir_ingest_sofelk delivers to. Mounted read-only.
+ELASTIC_INGEST_DIR=./ingest
+
+# Data stream namespace: evidence lands in logs-dfir.<type>-<DFIR_NAMESPACE>
+# (e.g. one namespace per case).
+DFIR_NAMESPACE=default
+
+# Elasticsearch JVM heap.
+ES_JAVA_OPTS=-Xms1g -Xmx1g

--- a/docker/elastic/.gitignore
+++ b/docker/elastic/.gitignore
@@ -1,0 +1,3 @@
+# Local secrets + runtime ingest staging — never commit either.
+.env
+ingest/

--- a/docker/elastic/README.md
+++ b/docker/elastic/README.md
@@ -1,0 +1,105 @@
+# Byakugan Elastic stack (security ON)
+
+Byakugan's **own Elastic-native stack** — the foundation for the Elastic-native
+DFIR detection engine. It **replaces SOF-ELK + Logstash** (`docker/sof-elk/`,
+retiring): the same Elasticsearch + Kibana pair, but built by us, with security
+**on**, Fleet, and Filebeat as the shipper instead of Logstash. Everything stays
+inside the Elastic ecosystem on a **Basic licence**.
+
+| Service | Image | Role |
+|---|---|---|
+| `setup` | `elasticsearch` (one-shot) | generates the CA + node certs, sets the `kibana_system` password, exits |
+| `elasticsearch` | `elasticsearch` | single node, security on, TLS on HTTP + transport, Basic licence |
+| `kibana` | `kibana` | UI + Fleet; talks to Elasticsearch over TLS as `kibana_system` |
+| `fleet-server` | `elastic-agent` | Fleet Server, self-enrols into the preconfigured `fleet-server-policy` |
+| `filebeat` | `filebeat` | the Elastic-native shipper — delivered evidence -> `logs-dfir.<type>-<ns>` data streams |
+
+Pinned to Elastic **9.4.3** — override with `ELASTIC_VERSION` (compose
+variable-with-default, same convention as the other `docker/*` builds). All
+published ports bind to **127.0.0.1**; data lives in named volumes (`certs`,
+`esdata`, `kibanadata`, `fleetdata`, `filebeatdata`).
+
+## Bring it up
+
+```bash
+cd docker/elastic
+cp .env.example .env            # then replace EVERY placeholder (see the file)
+sudo sysctl -w vm.max_map_count=262144
+docker compose up -d
+docker compose ps               # setup exits 0; the rest go (healthy)
+```
+
+- Elasticsearch -> https://127.0.0.1:9200 (`elastic` / `ELASTIC_PASSWORD`, CA in the `certs` volume)
+- Kibana -> http://127.0.0.1:5601 (log in as `elastic`)
+- Fleet Server -> https://127.0.0.1:8220
+
+`config/setup.sh` refuses to run while `ELASTIC_PASSWORD` / `KIBANA_SYSTEM_PASSWORD`
+still hold the `.env.example` placeholders. `.env` and `ingest/` are gitignored —
+**never commit real secrets**. To fetch the CA for host-side clients:
+`docker compose cp elasticsearch:/usr/share/elasticsearch/config/certs/ca/ca.crt .`
+
+## Security posture
+
+| | retired `docker/sof-elk` | `docker/elastic` |
+|---|---|---|
+| licence | Basic | Basic (`xpack.license.self_generated.type: basic`) |
+| `xpack.security` | **off** (dead-box posture) | **on** — authentication + RBAC |
+| Elasticsearch TLS | none | HTTP + transport, own CA (`config/setup.sh`) |
+| Kibana -> ES | anonymous, plain HTTP | `kibana_system` over TLS with CA verification |
+| shipper | Logstash (+ Filebeat -> Logstash) | Filebeat -> Elasticsearch directly |
+| Fleet | n/a | Fleet Server with TLS, preconfigured policy + output |
+| ports | 127.0.0.1 | 127.0.0.1 |
+
+Credentials are only ever read from the environment (`.env`): `ELASTIC_PASSWORD`,
+`KIBANA_SYSTEM_PASSWORD`, the three Kibana encryption keys, and an optional
+`FLEET_SERVER_SERVICE_TOKEN`. Kibana itself is served over plain HTTP on the
+loopback interface; the Elasticsearch API, transport and Fleet Server are TLS.
+
+## Fleet enrolment
+
+`fleet-server` bootstraps itself: with `KIBANA_FLEET_SETUP=1` it runs Fleet setup
+through Kibana (as `elastic`), obtains a service token unless
+`FLEET_SERVER_SERVICE_TOKEN` is set, and enrols into `fleet-server-policy` — the
+policy, the Fleet Server host (`https://fleet-server:8220`) and the default
+Elasticsearch output (`https://elasticsearch:9200`, CA `/certs/ca/ca.crt` on the
+agent side) are preconfigured in `config/kibana.yml`. Its state is persisted in
+`fleetdata`, so restarts keep the enrolment.
+
+To enrol another agent, create an enrolment token in Kibana (Fleet -> Enrollment
+tokens, or `POST /api/fleet/enrollment_api_keys`) and run an `elastic-agent`
+container on the `byakugan_default` network with the `certs` volume mounted at
+`/certs`:
+
+```bash
+docker run --rm --network byakugan_default -v byakugan_certs:/certs:ro \
+  -e FLEET_ENROLL=1 -e FLEET_URL=https://fleet-server:8220 -e FLEET_CA=/certs/ca/ca.crt \
+  -e FLEET_ENROLLMENT_TOKEN=<token> \
+  docker.elastic.co/elastic-agent/elastic-agent:9.4.3
+```
+
+Agents outside the compose network need a Fleet Server host they can resolve —
+add one under Fleet -> Settings. The `fleet_server` package is bundled with
+Kibana; other integrations are fetched from the Elastic Package Registry
+(`xpack.fleet.registryUrl` for a self-hosted mirror when air-gapped).
+
+## Shipping evidence
+
+`ELASTIC_INGEST_DIR` is mounted read-only at `/ingest`. Filebeat
+(`config/filebeat.yml`) tails `<type>/**/*.json` and `*.jsonl` — the tree
+`dfir_ingest_sofelk` already delivers (`zeek/`, `plaso/`, ...; keep type dirs
+lowercase) — stamps `labels.type` from the directory, and writes each line into
+the data stream `logs-dfir.<type>-<DFIR_NAMESPACE>` (one namespace per case works
+well). Data streams are created by Elasticsearch's built-in `logs-*-*` template;
+native -> ECS normalisation is Elastic-native too (ingest pipelines on those
+streams) and lands in a later phase, together with the CAR-driven detection
+rules that tag these evidence lines.
+
+## Notes
+
+- Elasticsearch needs `vm.max_map_count=262144` on the host.
+- Filebeat writes as `elastic` for now; a least-privilege writer role is a follow-up.
+- An **Ansible deploy role is intentionally deferred** to a follow-up; when it is
+  added it must conform to the bits-n-bobs Ansible standard (like the existing
+  `get_sybers.dfir` roles). Until then this compose file is the deployment.
+- `docker/sof-elk/` (and its `dfir_deploy_sofelk` role) is retiring in favour of
+  this stack; nothing here depends on it.

--- a/docker/elastic/config/elasticsearch.yml
+++ b/docker/elastic/config/elasticsearch.yml
@@ -1,0 +1,25 @@
+# Byakugan Elasticsearch — single node, security ON, Basic licence.
+# Mounted read-only over the image's elasticsearch.yml (so network.host is set
+# here explicitly). Certificates are generated into config/certs by the compose
+# `setup` service (config/setup.sh).
+cluster.name: byakugan
+node.name: es01
+network.host: 0.0.0.0
+discovery.type: single-node
+bootstrap.memory_lock: true
+
+# Self-generated Basic licence — no trial features assumed anywhere in Byakugan.
+xpack.license.self_generated.type: basic
+
+# Security ON: authentication + RBAC, TLS on both the HTTP and transport layers.
+# (The retired SOF-ELK stack ran with xpack.security.enabled=false.)
+xpack.security.enabled: true
+xpack.security.http.ssl.enabled: true
+xpack.security.http.ssl.key: certs/es01/es01.key
+xpack.security.http.ssl.certificate: certs/es01/es01.crt
+xpack.security.http.ssl.certificate_authorities: certs/ca/ca.crt
+xpack.security.transport.ssl.enabled: true
+xpack.security.transport.ssl.key: certs/es01/es01.key
+xpack.security.transport.ssl.certificate: certs/es01/es01.crt
+xpack.security.transport.ssl.certificate_authorities: certs/ca/ca.crt
+xpack.security.transport.ssl.verification_mode: certificate

--- a/docker/elastic/config/filebeat.yml
+++ b/docker/elastic/config/filebeat.yml
@@ -1,0 +1,42 @@
+# Byakugan shipper — Filebeat replaces SOF-ELK's Logstash.
+#
+# Tails the delivered evidence tree mounted at /ingest (<type>/**/*.json[l], the
+# layout dfir_ingest_sofelk already produces) and writes each line straight into
+# an Elastic data stream, logs-dfir.<type>-<namespace>, over the secured
+# Elasticsearch API. No Logstash filters: native -> ECS normalisation is
+# Elastic-native too (ingest pipelines on the data streams — a later phase).
+
+filebeat.inputs:
+  - type: filestream
+    id: byakugan-evidence
+    enabled: true
+    paths:
+      - /ingest/*/**/*.json
+      - /ingest/*/**/*.jsonl
+    parsers:
+      - ndjson:
+          target: ""
+          add_error_key: true
+          overwrite_keys: true
+          expand_keys: true
+    processors:
+      # The first directory under /ingest is the evidence type (zeek, plaso, ...);
+      # it becomes labels.type (as SOF-ELK stamped it) and routes the data stream.
+      - dissect:
+          tokenizer: "/ingest/%{labels.type}/%{?rest}"
+          field: log.file.path
+          target_prefix: ""
+
+# Data streams are created by Elasticsearch's built-in logs-*-* template; Filebeat
+# manages neither templates nor ILM here (a custom index needs both off).
+setup.template.enabled: false
+setup.ilm.enabled: false
+
+output.elasticsearch:
+  hosts: ["${ELASTICSEARCH_HOSTS:https://elasticsearch:9200}"]
+  username: "${ELASTICSEARCH_USERNAME:elastic}"
+  password: "${ELASTICSEARCH_PASSWORD}"
+  ssl.certificate_authorities: ["/certs/ca/ca.crt"]
+  index: "logs-dfir.%{[labels.type]:misc}-${DFIR_NAMESPACE:default}"
+
+logging.level: info

--- a/docker/elastic/config/kibana.yml
+++ b/docker/elastic/config/kibana.yml
@@ -1,0 +1,40 @@
+# Byakugan Kibana — talks to Elasticsearch over TLS as kibana_system and hosts
+# Fleet. ${VAR} references are resolved from the container environment (set in
+# docker-compose.yml from .env).
+server.name: byakugan-kibana
+server.host: "0.0.0.0"
+server.publicBaseUrl: "http://127.0.0.1:5601"
+telemetry.optIn: false
+
+elasticsearch.hosts: ["https://elasticsearch:9200"]
+elasticsearch.username: kibana_system
+elasticsearch.password: "${KIBANA_SYSTEM_PASSWORD}"
+elasticsearch.ssl.certificateAuthorities: ["/usr/share/kibana/config/certs/ca/ca.crt"]
+
+# Each key >= 32 chars (openssl rand -hex 32). Fleet refuses to start without the
+# encryptedSavedObjects key; the security key keeps sessions valid across restarts.
+xpack.encryptedSavedObjects.encryptionKey: "${KIBANA_ENCRYPTED_SAVED_OBJECTS_KEY}"
+xpack.security.encryptionKey: "${KIBANA_SECURITY_ENCRYPTION_KEY}"
+xpack.reporting.encryptionKey: "${KIBANA_REPORTING_ENCRYPTION_KEY}"
+
+# Fleet — preconfigured so the fleet-server container can enrol itself on first
+# boot. Agents reach Fleet Server and Elasticsearch by their compose service
+# names; the CA path is on the AGENT's filesystem (the shared certs volume).
+xpack.fleet.agents.fleet_server.hosts: ["https://fleet-server:8220"]
+xpack.fleet.outputs:
+  - id: byakugan-elasticsearch
+    name: Byakugan Elasticsearch
+    type: elasticsearch
+    hosts: ["https://elasticsearch:9200"]
+    is_default: true
+    is_default_monitoring: true
+    config:
+      ssl.certificate_authorities: ["/certs/ca/ca.crt"]
+xpack.fleet.agentPolicies:
+  - name: Fleet Server policy
+    id: fleet-server-policy
+    namespace: default
+    package_policies:
+      - name: fleet_server-1
+        package:
+          name: fleet_server

--- a/docker/elastic/config/setup.sh
+++ b/docker/elastic/config/setup.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Byakugan Elastic bootstrap — runs once per `docker compose up` from the
+# Elasticsearch image as root (the compose `setup` service).
+#   1. generate the CA + node certificates into the shared certs volume (once);
+#   2. wait for Elasticsearch to answer over TLS with security on;
+#   3. set the kibana_system password (idempotent).
+# Elasticsearch waits for step 1 (healthcheck), Kibana/Filebeat for the script
+# to complete successfully.
+set -euo pipefail
+
+CERTS=/usr/share/elasticsearch/config/certs
+ES_URL=https://elasticsearch:9200
+
+: "${ELASTIC_PASSWORD:?ELASTIC_PASSWORD must be set (docker/elastic/.env)}"
+: "${KIBANA_SYSTEM_PASSWORD:?KIBANA_SYSTEM_PASSWORD must be set (docker/elastic/.env)}"
+for v in ELASTIC_PASSWORD KIBANA_SYSTEM_PASSWORD; do
+  case "${!v}" in
+    *change-me*)
+      echo "setup | ${v} still holds the .env.example placeholder — set a real value in docker/elastic/.env" >&2
+      exit 1 ;;
+  esac
+done
+
+if [ ! -f "${CERTS}/ca/ca.crt" ]; then
+  echo "setup | generating the CA"
+  /usr/share/elasticsearch/bin/elasticsearch-certutil ca --silent --pem --out "${CERTS}/ca.zip"
+  unzip -q "${CERTS}/ca.zip" -d "${CERTS}"
+fi
+
+if [ ! -f "${CERTS}/es01/es01.crt" ]; then
+  echo "setup | generating node certificates"
+  cat > "${CERTS}/instances.yml" <<'EOF'
+instances:
+  - name: es01
+    dns: [elasticsearch, es01, localhost]
+    ip: [127.0.0.1]
+  - name: fleet-server
+    dns: [fleet-server, localhost]
+    ip: [127.0.0.1]
+EOF
+  /usr/share/elasticsearch/bin/elasticsearch-certutil cert --silent --pem \
+    --in "${CERTS}/instances.yml" \
+    --ca-cert "${CERTS}/ca/ca.crt" --ca-key "${CERTS}/ca/ca.key" \
+    --out "${CERTS}/certs.zip"
+  unzip -q "${CERTS}/certs.zip" -d "${CERTS}"
+fi
+
+# Readable by the stack's service users (uid 1000, group 0), nobody else.
+chown -R root:0 "${CERTS}"
+find "${CERTS}" -type d -exec chmod 750 {} \;
+find "${CERTS}" -type f -exec chmod 640 {} \;
+
+echo "setup | waiting for Elasticsearch at ${ES_URL}"
+until curl -s --cacert "${CERTS}/ca/ca.crt" "${ES_URL}" | grep -q "missing authentication credentials"; do
+  sleep 5
+done
+
+echo "setup | setting the kibana_system password"
+until curl -s -X POST --cacert "${CERTS}/ca/ca.crt" \
+      -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" \
+      "${ES_URL}/_security/user/kibana_system/_password" \
+      -d "{\"password\":\"${KIBANA_SYSTEM_PASSWORD}\"}" | grep -q "^{}"; do
+  sleep 5
+done
+
+echo "setup | done"

--- a/docker/elastic/config/setup.sh
+++ b/docker/elastic/config/setup.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 
 CERTS=/usr/share/elasticsearch/config/certs
 ES_URL=https://elasticsearch:9200
+# The Elasticsearch image bundles a JDK but not necessarily `unzip`, so ZIP
+# output from elasticsearch-certutil is extracted with the JDK `jar` tool
+# (a .jar is a .zip) — no dependency on unzip being present in the image.
+JAR=/usr/share/elasticsearch/jdk/bin/jar
 
 : "${ELASTIC_PASSWORD:?ELASTIC_PASSWORD must be set (docker/elastic/.env)}"
 : "${KIBANA_SYSTEM_PASSWORD:?KIBANA_SYSTEM_PASSWORD must be set (docker/elastic/.env)}"
@@ -24,7 +28,7 @@ done
 if [ ! -f "${CERTS}/ca/ca.crt" ]; then
   echo "setup | generating the CA"
   /usr/share/elasticsearch/bin/elasticsearch-certutil ca --silent --pem --out "${CERTS}/ca.zip"
-  unzip -q "${CERTS}/ca.zip" -d "${CERTS}"
+  ( cd "${CERTS}" && "${JAR}" xf ca.zip )
 fi
 
 if [ ! -f "${CERTS}/es01/es01.crt" ]; then
@@ -42,13 +46,16 @@ EOF
     --in "${CERTS}/instances.yml" \
     --ca-cert "${CERTS}/ca/ca.crt" --ca-key "${CERTS}/ca/ca.key" \
     --out "${CERTS}/certs.zip"
-  unzip -q "${CERTS}/certs.zip" -d "${CERTS}"
+  ( cd "${CERTS}" && "${JAR}" xf certs.zip )
 fi
 
 # Readable by the stack's service users (uid 1000, group 0), nobody else.
 chown -R root:0 "${CERTS}"
 find "${CERTS}" -type d -exec chmod 750 {} \;
 find "${CERTS}" -type f -exec chmod 640 {} \;
+# The CA private key is only needed during bootstrap (cert generation); keep it
+# root-only so a group-0 service container cannot read it afterwards.
+[ -f "${CERTS}/ca/ca.key" ] && chmod 600 "${CERTS}/ca/ca.key"
 
 echo "setup | waiting for Elasticsearch at ${ES_URL}"
 until curl -s --cacert "${CERTS}/ca/ca.crt" "${ES_URL}" | grep -q "missing authentication credentials"; do

--- a/docker/elastic/docker-compose.yml
+++ b/docker/elastic/docker-compose.yml
@@ -1,0 +1,153 @@
+name: byakugan
+
+# Byakugan's own Elastic-native stack — replaces SOF-ELK + Logstash (docker/sof-elk,
+# retiring). Elasticsearch single-node with security ON (Basic licence, TLS on the
+# HTTP + transport layers), Kibana with Fleet, a Fleet Server (elastic-agent) and
+# Filebeat as the Elastic-native shipper. Every published port is bound to
+# 127.0.0.1. Credentials come from .env (copy .env.example; NEVER commit .env).
+# Pin the stack with ELASTIC_VERSION (default 9.4.3).
+#
+# Bring-up order: setup (certs) -> elasticsearch -> setup completes (kibana_system
+# password) -> kibana -> fleet-server. filebeat starts once elasticsearch is healthy.
+
+services:
+  # One-shot bootstrap (config/setup.sh): CA + node certificates into the shared
+  # `certs` volume, then the kibana_system password once Elasticsearch answers.
+  # Healthy = certificates exist; completed = kibana_system password is set.
+  setup:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-9.4.3}"
+    user: "0"
+    command: ["bash", "/usr/local/bin/byakugan-setup"]
+    environment:
+      ELASTIC_PASSWORD: "${ELASTIC_PASSWORD:?set it in docker/elastic/.env (see .env.example)}"
+      KIBANA_SYSTEM_PASSWORD: "${KIBANA_SYSTEM_PASSWORD:?set it in docker/elastic/.env (see .env.example)}"
+    volumes:
+      - ./config/setup.sh:/usr/local/bin/byakugan-setup:ro
+      - certs:/usr/share/elasticsearch/config/certs
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f /usr/share/elasticsearch/config/certs/es01/es01.crt ]"]
+      interval: 2s
+      timeout: 5s
+      retries: 60
+
+  elasticsearch:
+    image: "docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-9.4.3}"
+    depends_on:
+      setup:
+        condition: service_healthy
+    environment:
+      ELASTIC_PASSWORD: "${ELASTIC_PASSWORD:?set it in docker/elastic/.env (see .env.example)}"
+      ES_JAVA_OPTS: "${ES_JAVA_OPTS:--Xms1g -Xmx1g}"
+    ulimits:
+      memlock: {soft: -1, hard: -1}
+    volumes:
+      - ./config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+      - certs:/usr/share/elasticsearch/config/certs:ro
+      - esdata:/usr/share/elasticsearch/data
+    ports:
+      - "127.0.0.1:9200:9200"
+    healthcheck:
+      # TLS answers AND security rejects the unauthenticated call: the posture check.
+      test: ["CMD-SHELL", "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'"]
+      interval: 15s
+      timeout: 10s
+      retries: 30
+
+  kibana:
+    image: "docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-9.4.3}"
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      # Consumed by config/kibana.yml via ${VAR} substitution.
+      KIBANA_SYSTEM_PASSWORD: "${KIBANA_SYSTEM_PASSWORD:?set it in docker/elastic/.env (see .env.example)}"
+      KIBANA_ENCRYPTED_SAVED_OBJECTS_KEY: "${KIBANA_ENCRYPTED_SAVED_OBJECTS_KEY:?set it in docker/elastic/.env (see .env.example)}"
+      KIBANA_SECURITY_ENCRYPTION_KEY: "${KIBANA_SECURITY_ENCRYPTION_KEY:?set it in docker/elastic/.env (see .env.example)}"
+      KIBANA_REPORTING_ENCRYPTION_KEY: "${KIBANA_REPORTING_ENCRYPTION_KEY:?set it in docker/elastic/.env (see .env.example)}"
+    volumes:
+      - ./config/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
+      - certs:/usr/share/kibana/config/certs:ro
+      - kibanadata:/usr/share/kibana/data
+    ports:
+      - "127.0.0.1:5601:5601"
+    healthcheck:
+      # Ready once the login redirect is served (503 "not ready yet" until then).
+      test: ["CMD-SHELL", "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302'"]
+      interval: 15s
+      timeout: 10s
+      retries: 40
+
+  # Fleet Server = an elastic-agent. Bootstraps itself through Kibana's Fleet API
+  # (KIBANA_FLEET_SETUP) into the preconfigured fleet-server-policy from
+  # config/kibana.yml; give it a pre-created service token via
+  # FLEET_SERVER_SERVICE_TOKEN to skip the Kibana-brokered token request.
+  fleet-server:
+    image: "docker.elastic.co/elastic-agent/elastic-agent:${ELASTIC_VERSION:-9.4.3}"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    environment:
+      FLEET_SERVER_ENABLE: "1"
+      FLEET_SERVER_POLICY_ID: fleet-server-policy
+      FLEET_SERVER_ELASTICSEARCH_HOST: https://elasticsearch:9200
+      FLEET_SERVER_ELASTICSEARCH_CA: /certs/ca/ca.crt
+      FLEET_SERVER_SERVICE_TOKEN: "${FLEET_SERVER_SERVICE_TOKEN:-}"
+      FLEET_SERVER_CERT: /certs/fleet-server/fleet-server.crt
+      FLEET_SERVER_CERT_KEY: /certs/fleet-server/fleet-server.key
+      FLEET_URL: https://fleet-server:8220
+      FLEET_CA: /certs/ca/ca.crt
+      KIBANA_FLEET_SETUP: "1"
+      KIBANA_FLEET_HOST: http://kibana:5601
+      KIBANA_FLEET_USERNAME: elastic
+      KIBANA_FLEET_PASSWORD: "${ELASTIC_PASSWORD:?set it in docker/elastic/.env (see .env.example)}"
+    volumes:
+      - certs:/certs:ro
+      - fleetdata:/usr/share/elastic-agent/state
+    ports:
+      - "127.0.0.1:8220:8220"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s --cacert /certs/ca/ca.crt https://localhost:8220/api/status | grep -q HEALTHY"]
+      interval: 15s
+      timeout: 10s
+      retries: 40
+
+  # The shipper that replaces Logstash: tails the delivered evidence tree
+  # (<type>/**/*.json[l], the same layout dfir_ingest_sofelk produces) and writes
+  # it straight into logs-dfir.<type>-<namespace> data streams over the secured
+  # Elasticsearch API. Runs as root only to read operator-delivered files; the
+  # ingest mount is read-only.
+  filebeat:
+    image: "docker.elastic.co/beats/filebeat:${ELASTIC_VERSION:-9.4.3}"
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+      elasticsearch:
+        condition: service_healthy
+    user: root
+    command: ["-e", "--strict.perms=false", "-environment", "container"]
+    environment:
+      ELASTICSEARCH_HOSTS: https://elasticsearch:9200
+      ELASTICSEARCH_USERNAME: elastic
+      ELASTICSEARCH_PASSWORD: "${ELASTIC_PASSWORD:?set it in docker/elastic/.env (see .env.example)}"
+      DFIR_NAMESPACE: "${DFIR_NAMESPACE:-default}"
+    volumes:
+      - ./config/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - certs:/certs:ro
+      - "${ELASTIC_INGEST_DIR:-./ingest}:/ingest:ro"
+      - filebeatdata:/usr/share/filebeat/data
+    healthcheck:
+      test: ["CMD", "filebeat", "test", "output", "--strict.perms=false"]
+      interval: 60s
+      timeout: 30s
+      retries: 5
+
+volumes:
+  certs:
+  esdata:
+  kibanadata:
+  fleetdata:
+  filebeatdata:

--- a/docker/sof-elk/README.md
+++ b/docker/sof-elk/README.md
@@ -1,5 +1,10 @@
 # SOF-ELK container (from source)
 
+> **Retiring.** Byakugan's own Elastic-native stack — security ON, Fleet, Filebeat
+> instead of Logstash — lives in [`docker/elastic/`](../elastic/README.md) and
+> replaces this one. This directory stays only until `dfir_deploy_sofelk` (which
+> builds from it) is retired with it.
+
 SOF-ELK® ([philhagen/sof-elk](https://github.com/philhagen/sof-elk)) ships as a VM,
 so there is no canonical public image. This builds one **from the upstream repo** so
 the `dfir_deploy_sofelk` role has a real stack to run.

--- a/docs/Containers.md
+++ b/docs/Containers.md
@@ -111,7 +111,9 @@ loaded inventory is confirmed to be the expected hardened set. Nothing reaches
 the network.
 
 The SOF-ELK stack (`docker/sof-elk/`, from-source build) is handled separately
-by `dfir_deploy_sofelk`.
+by `dfir_deploy_sofelk`. It is retiring in favour of Byakugan's own Elastic-native
+stack (`docker/elastic/` — security on, Fleet, Filebeat instead of Logstash; see
+its README).
 
 **Not containers:** **Hayabusa** ships as a self-contained Rust binary (no
 official image) — operator-supplied: download the pinned release into

--- a/docs/Dir-Structure.md
+++ b/docs/Dir-Structure.md
@@ -18,7 +18,7 @@ The pipeline is a three-layer design: the **`dxdfir` CLI** (the verbs) drives th
     └── scripts/                                      # Deploy/apply/ingest + signature lanes (bash)
     │   └── lib/                                      # Shared bash libraries: docker lifecycle, Kusto REST API
     │
-    └── docker/                                       # Container builds — the from-source SOF-ELK stack (sof-elk/)
+    └── docker/                                       # Container builds — Byakugan's Elastic-native stack (elastic/), the retiring SOF-ELK stack (sof-elk/)
     │
     └── dev-scripts/                                  # Experimental/one-off helpers, unsupported (e.g. the Plaso output module)
     │


### PR DESCRIPTION
## What

Byakugan's own **Elastic-native container foundation** (**P0**), replacing SOF-ELK + Logstash, staying inside the Elastic ecosystem on a Basic licence:

- **`docker/elastic/docker-compose.yml`** — Elasticsearch 9.4.3 single-node with **`xpack.security` ENABLED** (Basic licence, TLS on HTTP + transport from an own CA); **Kibana** wired to it over the secured connection as `kibana_system`; a **Fleet Server** (elastic-agent) that self-enrols into a preconfigured policy; and **Filebeat** as the Elastic-native shipper in Logstash's place (tails the delivered `<type>/**/*.json[l]` evidence tree → `logs-dfir.<type>-*` data streams).
- `ELASTIC_VERSION` defaults to 9.4.3 (compose variable-with-default); every published port binds to `127.0.0.1`; all services have healthchecks; state in named volumes; every credential from `.env` (`:?`-guarded). **`.env.example` ships placeholders only and `config/setup.sh` refuses to run with them — no secrets committed.**
- `config/` — `elasticsearch.yml`, `kibana.yml`, `filebeat.yml`, `setup.sh` (certs + `kibana_system` bootstrap). `README.md` covers bring-up, the security posture (ON + Basic, contrasted with the security-off SOF-ELK), Fleet enrolment, and that the Ansible deploy role is deferred (must follow the bits-n-bobs Ansible standard).

## SOF-ELK not deleted here (deliberate)
`docker/sof-elk/` is **kept** in this PR: the `dfir_deploy_sofelk` ansible role hard-references it (defaults `compose_dir`, preflight stat/assert, molecule paths), and `ansible/**` is outside this change's scope. The `git rm -r docker/sof-elk` belongs in the **same** change that retires that role — a deferred, ansible-owned follow-up. Interim: its README carries a retiring banner; `docs/Containers.md` + `docs/Dir-Structure.md` point at the new stack.

## Checks
```
docker compose --env-file .env.example config -q   -> EXIT 0 (no warnings)
config YAML parses; bash -n config/setup.sh OK; no committed secrets
```
CI (`checks` run #433) is green. Scope limited to `docker/**` + trivial `docs/**`.

**Residual (reviewer's manual step):** not runtime-tested end-to-end — a full `docker compose up` needs privileged `vm.max_map_count` + multi-GB image pulls. Verify Filebeat's writes land in the `logs-dfir.*` data streams and Fleet self-bootstrap on first bring-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu)_