### PR TITLE
detect: scaffold Elastic detection rules-as-code (Byakugan P2 enabler, additive)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,6 +8,11 @@ exclude_paths:
   - .claude/
   - data_store/
   - ansible/collections/get_sybers.dfir/.ansible/
+  # Elastic detection rules-as-code: these are rule DATA (ES|QL/EQL definitions
+  # with long query lines), not ansible. ansible-lint auto-discovers the YAML
+  # but has no business linting it — the rules have their own gate
+  # (detect/rules_loader.py validation + tests/test_rules.py).
+  - python/get_sybers_dfir/detect/rules/
 
 # The collection's task names use the Get-Sybers house prefix
 # "<role>-<stage> | lowercase description"; the leading-uppercase idiom is

--- a/python/get_sybers_dfir/detect/rules/README.md
+++ b/python/get_sybers_dfir/detect/rules/README.md
@@ -1,0 +1,164 @@
+# Elastic detection rules-as-code (Byakugan)
+
+The detections of [`../registry.py`](../registry.py), re-expressed for **Elastic's
+own Detection Engine** as data: one YAML file per rule, ES|QL or EQL, each
+carrying the contract for the **tagged evidence line** it produces. Loaded and
+validated by [`../rules_loader.py`](../rules_loader.py), pinned by
+`python/tests/test_rules.py`.
+
+> **Additive.** Nothing in the Kusto path changes: `registry.py`, the runner in
+> `detect/__init__.py`, the emulator and `kusto/schema/50-detections.kql` stay as
+> they are until Kusto/ADX retires at the **end of phase 2 (decision D1)**. This
+> directory is the phase-2 enabler that lets that retirement happen. The loader
+> does not import the registry, so the rule set outlives it; the ids are shared,
+> and the tests pin the two id sets equal (a detection can neither be dropped
+> silently nor exist twice under different names).
+
+```bash
+cd python && PYTHONPATH=. python -m get_sybers_dfir.detect.rules_loader   # JSON summary, exit 1 on a bad rule
+cd python && PYTHONPATH=. python -m pytest tests/test_rules.py
+```
+
+## The rule file
+
+| key | required | meaning |
+|---|---|---|
+| `id` | yes | the registry id — kebab-case, equal to the file stem (`<id>.yml`) |
+| `name` | yes | rule title (no quotes / backslashes) |
+| `status` | yes | `ported` (query is real) or `stub` (query is `null`, intent lives in `todo`) |
+| `severity` | yes | `low` / `medium` / `high` / `critical` — Elastic's set; the registry's `info` maps to `low` |
+| `risk_score` | no | 0..100; defaults to Elastic's canonical value per severity (21 / 47 / 73 / 99) |
+| `attack` | yes | ATT&CK technique ids (`T1234`, `T1234.001`); may be empty |
+| `tactics` | no | ATT&CK tactic ids (`TA0005`) |
+| `language` | yes | `esql` or `eql` |
+| `index` | yes | the data streams read (`logs-<dataset>-*`); an ES|QL `FROM` must read exactly these |
+| `query` | ported | the ES|QL / EQL |
+| `evidence` | yes | the tagged-evidence-line contract: `shape` (`line` / `aggregate`), `stamped_by` (`query` / `engine`), `fields` (what the line carries beyond the source document) |
+| `car_join` | yes | how a hit reaches the car-detections lookup index: `key` (`event.id` / `process.entity_id`) and `via` (`direct` / `provenance` + the provenance fields) |
+| `fields` | no | the ECS fields the query reads and the native lane field each comes from — the contract the ingest pipeline must satisfy |
+| `source` | yes | provenance: `registry` id, `kind` (`kusto` / `jsonl`), the verbatim `kql` or the jsonl `match` function name |
+| `todo` | stub | `query` (the intended ES|QL/EQL) and `blockers` (why it is still a stub) |
+
+`rules_loader.validate()` mirrors `registry.validate()`: first problem raises
+`ValueError` prefixed with the rule id. Beyond field validation it runs a
+**structural** query check (`check_query()`, not a parser): an ES|QL query must
+start with `FROM` over exactly the declared streams, chain only known commands,
+request `METADATA _id, _index, _version` unless it aggregates with `STATS`, agree
+with the declared evidence shape, and actually stamp (`EVAL x = ...` / `STATS ...
+BY x`) every field its evidence contract promises; an EQL query must be a
+`<category> where` / `sequence` / `sample` query and let the engine stamp;
+both must balance brackets outside string literals and carry no KQL left-overs
+(`| project`, `pack(`, `=~`, `tostring(` ...).
+
+## Tagged evidence lines (Hayabusa-style)
+
+There is no separate abstract alert envelope. **The alert is the matched
+evidence document**, enriched inline:
+
+- **ES|QL, `shape: line`** — the query reads with `METADATA _id, _index,
+  _version`, which makes the Detection Engine raise **one alert per matched
+  source document**, carrying every source field plus the columns the query
+  `EVAL`s. The rule stamps `rule.id`, `rule.name`, `event.risk_score`,
+  `threat.framework`, `threat.tactic.{id,name}`, `threat.technique.{id,name}`
+  itself (`stamped_by: query`); several techniques ride as a multi-value
+  `threat.technique.id` (`MV_APPEND`). Nothing from the source line is dropped
+  (no `KEEP`).
+- **ES|QL, `shape: aggregate`** — a `STATS ... BY` query has no single source
+  document; the alert is the group row (key + aggregates), stamped the same way.
+  Used where one hit per subject is the detection (`zeek-dns-oversized-query`:
+  per querying host, not per query).
+- **EQL** — EQL cannot `EVAL`; the alert is the source event (every field
+  copied) and the engine stamps the rule's identity and ATT&CK mapping under
+  `kibana.alert.*` (`stamped_by: engine`; `evidence.fields` lists those).
+
+The Detection Engine additionally copies every rule's `threat` block to
+`kibana.alert.rule.threat` in both cases; the inline `threat.*` fields are what
+make the line self-describing outside Kibana (exports, the CAR join, OpenCTI
+exchange).
+
+## Data streams and ECS fields
+
+Rules read the Byakugan data streams: **`logs-dfir.<type>-<namespace>`** for
+delivered native evidence (`<type>` = the processed lane: `evtx`, `plaso`,
+`zeek`, `volatility`, `hayabusa`, `suricata`, `yara` — the directory name the
+shipper stamps into `labels.type`) and **`logs-car.<object>-<namespace>`** for
+CAR (`logs-car.*-*` reads every object). Rules are written in **ECS** terms
+(`event.code`, `winlog.channel`, `dns.question.name`, ...): each rule's `fields`
+block records which native lane field each ECS field comes from, which is the
+contract the ECS-normalisation ingest pipelines (a later phase) must satisfy.
+Until those pipelines exist the streams hold native field names and the ported
+rules match nothing — the rules are the specification, not the pipelines.
+
+## The `car-detections` lookup index and `LOOKUP JOIN`
+
+[`car-detections/`](car-detections/) is the contract as data:
+
+- [`car-detections.index-template.json`](car-detections/car-detections.index-template.json)
+  — an Elasticsearch index template (`PUT _index_template/car-detections`) with
+  **`index.mode: lookup`** (single shard, what makes an index joinable), strict
+  mappings for the join keys, the stamped `rule.*` / `threat.*` fields and the
+  `detection.*` provenance. `_id` is `<detection.id>:<event.id>`.
+- [`join-keys.yml`](car-detections/join-keys.yml) — which CAR/ECS field joins to
+  which lookup-index key, what the join stamps, who writes the index, and the
+  reference query.
+
+**Model.** The CAR `guid` travels into Elastic as ECS **`event.id`** on every CAR
+object and as **`process.entity_id`** on process (names owned by the
+PIIAT-MitreCar CAR->ECS projection; this contract only depends on them).
+`LOOKUP JOIN` needs the same field name on both sides, so the lookup index maps
+the keys under those ECS names. Any ES|QL over the CAR streams then flags the
+CAR rows a detection matched, inline:
+
+```esql
+FROM logs-car.*-* METADATA _id, _index, _version
+| LOOKUP JOIN car-detections ON event.id
+| WHERE detection.id IS NOT NULL
+```
+
+Joining `ON process.entity_id` instead cascades a process-level detection onto
+the rows that process owns (module, thread, file, socket ...), since they carry
+the owning process guid under the same name. `LOOKUP JOIN` emits one row per
+matching lookup row, so a guid hit by two detections yields two stamped lines;
+`STATS ... BY event.id` collapses them when one row per CAR event is wanted.
+
+**Writer.** A sweep step (the phase-2 runner) reads the Detection Engine's
+alerts (`.alerts-security.alerts-*`) and upserts one document per
+(detection, guid). A rule that ran over `logs-car.*` has `event.id` on its
+evidence line already (`car_join.via: direct`); a rule over native evidence
+(`logs-dfir.*`) resolves the guid through its declared `car_join.provenance`
+fields against the CAR row's flattened native bag (`via: provenance`) — e.g.
+`log.file.path` + `winlog.record_id` for an EVTX-sourced rule. Requires
+Elasticsearch 9.x (`LOOKUP JOIN` GA; technical preview in 8.18); Basic licence.
+
+## Coverage: KQL -> ES|QL / EQL
+
+Every registry detection, ported or stub (the tests fail if one goes missing):
+
+| registry id | Kusto source | Elastic | reads | status | note |
+|---|---|---|---|---|---|
+| `win-eventlog-cleared` | `host.EvtxEcmdJson` | EQL | `logs-dfir.evtx-*` | **ported** | `any where` over `event.code` / `winlog.channel` (`:` = the KQL `=~`); engine-stamped |
+| `win-defender-tamper` | `host.EvtxEcmdJson` | ES\|QL line | `logs-dfir.evtx-*` | **ported** | `WHERE ... IN`, inline `threat.*` via `EVAL` |
+| `win-service-suspicious-path` | `host.EvtxEcmdJson` | ES\|QL line | `logs-dfir.evtx-*` | **ported** | `COALESCE(winlog.event_data.ImagePath, ServiceFileName)`; KQL `(?i)` regex -> `TO_LOWER` + Lucene `RLIKE` (no `\b`: end-or-non-alnum instead) |
+| `win-prefetch-dualuse-tool` | `host.L2tPrefetch` | ES\|QL line | `logs-dfir.plaso-*` | **ported** | anchored regex -> `TO_UPPER(process.name) IN (...)`; two techniques as multi-value |
+| `zeek-notice-promoted` | `network.Zeek (notice)` | ES\|QL line | `logs-dfir.zeek-*` | **ported** | `event.dataset == "zeek.notice"`; no ATT&CK, identity stamp only |
+| `zeek-dns-oversized-query` | `network.Zeek (dns)` | ES\|QL aggregate | `logs-dfir.zeek-*` | **ported** | `summarize by` -> `STATS ... BY source.ip`; `take_any()` -> `MAX()` |
+| `vol-malfind-injection` | `memory.VolatilityJson` | ES\|QL aggregate | `logs-dfir.volatility-*` | stub | `make_set()` -> `VALUES()` (technical preview); `volatility.*` projection not yet defined |
+| `sig-hayabusa-high` | `signatures/hayabusa` (jsonl) | ES\|QL line | `logs-dfir.hayabusa-*` | stub | promotion of `hayabusa.level`; per-hit `MitreTags` -> `threat.technique.id` belongs in the ingest pipeline |
+| `sig-suricata-alert` | `signatures/suricata` (jsonl) | ES\|QL line | `logs-dfir.suricata-*` | stub | `suricata.eve.event_type == "alert"`; `mitre_technique_id` lift belongs in the ingest pipeline |
+| `sig-yara-match` | `signatures/yara` (jsonl) | ES\|QL line | `logs-dfir.yara-*` | stub | `yara.*` projection and `strings[].data` trimming not yet defined |
+
+6 ported (5 ES|QL, 1 EQL), 4 stubs. A stub keeps the intended query in
+`todo.query`, says why in `todo.blockers`, and keeps the source KQL / matcher
+name in `source`, so nothing is silently dropped.
+
+## What is deliberately not here yet
+
+- **Pushing rules into Kibana.** The YAML is one `to_kibana()` away from the
+  Detection Engine's NDJSON (`rule_id`, `type`/`language`, `query`, `index`,
+  `threat`, `severity`, `risk_score`); that exporter and the deploy step land
+  with the runner in phase 2.
+- **Ingest pipelines** (native -> ECS) for the `logs-dfir.*` streams — the
+  `fields` blocks are their specification.
+- **Sigma compiled to Elastic at build time** — a later phase; it will add rule
+  files here in the same shape.
+- **Retiring the Kusto path** — end of phase 2 (D1), not now.

--- a/python/get_sybers_dfir/detect/rules/car-detections/car-detections.index-template.json
+++ b/python/get_sybers_dfir/detect/rules/car-detections/car-detections.index-template.json
@@ -1,0 +1,68 @@
+{
+  "index_patterns": ["car-detections", "car-detections-*"],
+  "priority": 500,
+  "_meta": {
+    "description": "Byakugan car-detections lookup index: one row per (detection, CAR event guid). ES|QL `LOOKUP JOIN car-detections ON event.id` stamps these rows onto logs-car.* evidence lines. index.mode=lookup is what makes the index joinable (single shard, enforced by Elasticsearch). See join-keys.yml and ../README.md.",
+    "owner": "DX_DFIR python/get_sybers_dfir/detect/rules",
+    "join_keys": ["event.id", "process.entity_id"],
+    "document_id": "<detection.id>:<event.id>"
+  },
+  "template": {
+    "settings": {
+      "index.mode": "lookup",
+      "index.number_of_replicas": 0
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "@timestamp": {"type": "date"},
+        "event": {
+          "properties": {
+            "id": {"type": "keyword"},
+            "risk_score": {"type": "float"}
+          }
+        },
+        "process": {
+          "properties": {
+            "entity_id": {"type": "keyword"}
+          }
+        },
+        "detection": {
+          "properties": {
+            "id": {"type": "keyword"},
+            "status": {"type": "keyword"},
+            "severity": {"type": "keyword"},
+            "run_id": {"type": "keyword"},
+            "detected_at": {"type": "date"},
+            "source_index": {"type": "keyword"},
+            "source_id": {"type": "keyword"},
+            "join_via": {"type": "keyword"}
+          }
+        },
+        "rule": {
+          "properties": {
+            "id": {"type": "keyword"},
+            "name": {"type": "keyword"}
+          }
+        },
+        "threat": {
+          "properties": {
+            "framework": {"type": "keyword"},
+            "tactic": {
+              "properties": {
+                "id": {"type": "keyword"},
+                "name": {"type": "keyword"}
+              }
+            },
+            "technique": {
+              "properties": {
+                "id": {"type": "keyword"},
+                "name": {"type": "keyword"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/python/get_sybers_dfir/detect/rules/car-detections/join-keys.yml
+++ b/python/get_sybers_dfir/detect/rules/car-detections/join-keys.yml
@@ -1,0 +1,88 @@
+# The car-detections lookup index — join-key contract (data, not prose).
+#
+# WHAT: a small LOOKUP-mode index (car-detections.index-template.json) holding
+# one row per (detection, CAR event guid). Any ES|QL over logs-car.* can
+# `LOOKUP JOIN car-detections ON <key>` and every CAR evidence line that a
+# detection matched comes back stamped with rule.* / threat.* / detection.*
+# inline — the tagged-evidence-line model, applied to the CAR data streams.
+#
+# KEYS: the CAR `guid` travels into Elastic as ECS `event.id` on every CAR
+# object, and as `process.entity_id` on process (the PIIAT-MitreCar-owned
+# CAR->ECS projection decides those names; this file only depends on them).
+# LOOKUP JOIN needs the SAME field name on both sides, so the lookup index maps
+# the keys under their ECS names.
+#
+# The loader (rules_loader.CAR_JOIN_KEYS) and tests/test_rules.py pin the join
+# set below; change the two together.
+
+lookup_index: car-detections
+
+join:
+  - car_field: guid
+    ecs_field: event.id
+    lookup_field: event.id
+    objects: all
+    primary: true
+    note: >-
+      Every CAR object row carries its guid as event.id. This is the default
+      join: FROM logs-car.*-* | LOOKUP JOIN car-detections ON event.id.
+  - car_field: guid
+    ecs_field: process.entity_id
+    lookup_field: process.entity_id
+    objects: [process]
+    primary: false
+    note: >-
+      A process row also carries its guid as process.entity_id, and rows owned
+      by that process (module, thread, file, socket ... via owning_guid) carry
+      it under the same name, so joining ON process.entity_id cascades a
+      process-level detection onto the process's children in one pass.
+
+# Fields the join stamps onto a matched logs-car.* line (all mapped in the
+# template). A lookup field with the same name as a source field overrides it.
+stamped_fields:
+  - detection.id
+  - detection.status
+  - detection.severity
+  - detection.run_id
+  - detection.detected_at
+  - detection.source_index
+  - detection.source_id
+  - detection.join_via
+  - rule.id
+  - rule.name
+  - event.risk_score
+  - threat.framework
+  - threat.tactic.id
+  - threat.tactic.name
+  - threat.technique.id
+  - threat.technique.name
+
+# WHO WRITES: a sweep step (the phase-2 runner) reads the Detection Engine's
+# alerts (.alerts-security.alerts-*) and upserts one document per
+# (detection, guid), _id "<detection.id>:<event.id>". A rule whose evidence
+# line already carries event.id (it ran over logs-car.*) resolves the key
+# DIRECTLY; a rule over native evidence (logs-dfir.*) resolves it via the
+# rule's car_join.provenance fields against the CAR row's flattened native bag
+# — each rule file declares which (car_join.via: direct | provenance).
+writers:
+  - name: sweep
+    reads: [".alerts-security.alerts-*"]
+    resolves_key_via: [direct, provenance]
+    document_id: "<detection.id>:<event.id>"
+
+# Fan-out semantics: LOOKUP JOIN emits one output row per matching lookup row,
+# so a guid hit by two detections yields two stamped lines (multi-valued
+# threat.* per line stay multi-valued). Collapse with STATS ... BY event.id when
+# one row per CAR event is wanted.
+example_query: |
+  FROM logs-car.*-* METADATA _id, _index, _version
+  | LOOKUP JOIN car-detections ON event.id
+  | WHERE detection.id IS NOT NULL
+  | KEEP @timestamp, event.id, event.action, host.name, detection.id, detection.severity,
+         rule.id, rule.name, threat.tactic.id, threat.technique.id, _id, _index
+  | SORT @timestamp ASC
+  | LIMIT 1000
+
+requires:
+  elasticsearch: ">=9.0 (LOOKUP JOIN GA; technical preview in 8.18)"
+  licence: basic

--- a/python/get_sybers_dfir/detect/rules/sig-hayabusa-high.yml
+++ b/python/get_sybers_dfir/detect/rules/sig-hayabusa-high.yml
@@ -1,0 +1,51 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: sig-hayabusa-high
+name: Hayabusa high/critical Sigma detection
+status: stub
+severity: high
+attack: []
+tactics: []
+language: esql
+index: [logs-dfir.hayabusa-*]
+query: null
+# Hayabusa (Sigma over EVTX) already scored the event and is the model for the
+# whole tagged-evidence-line idea: its output line IS the evidence with the
+# rule and ATT&CK tags inline. The rule only promotes high/critical lines.
+todo:
+  query: |
+    FROM logs-dfir.hayabusa-* METADATA _id, _index, _version
+    | WHERE TO_LOWER(hayabusa.level) IN ("high", "critical", "crit")
+    | EVAL rule.id = "sig-hayabusa-high",
+           rule.name = "Hayabusa high/critical Sigma detection",
+           event.risk_score = 73.0
+    | LIMIT 1000
+  blockers:
+    - "Per-hit ATT&CK ids: the jsonl matcher parses MitreTags ('T1059.001 ¦ T1204.002') at run time; in Elastic that belongs in the ingest pipeline (split on the ¦ separator into threat.technique.id) so the evidence line already carries its techniques and the rule only promotes — the ECS-normalisation phase"
+    - "Hayabusa's own RuleID/RuleTitle must land under hayabusa.rule_id / hayabusa.rule_title, not rule.id / rule.name, or the promotion stamp overwrites them"
+    - "Once Sigma compiles to Elastic at build time (later phase) this promotion may be redundant with the compiled rules; decide then whether it stays"
+evidence:
+  shape: line
+  stamped_by: query
+  fields:
+    - rule.id
+    - rule.name
+    - event.risk_score
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [host.name, winlog.channel, winlog.record_id]
+fields:
+  - {ecs: "@timestamp", native: Timestamp}
+  - {ecs: host.name, native: Computer}
+  - {ecs: winlog.channel, native: Channel}
+  - {ecs: event.code, native: EventID}
+  - {ecs: winlog.record_id, native: RecordID}
+  - {ecs: hayabusa.level, native: Level}
+  - {ecs: hayabusa.rule_id, native: RuleID}
+  - {ecs: hayabusa.rule_title, native: RuleTitle}
+  - {ecs: threat.technique.id, native: "MitreTags (split on ¦)"}
+  - {ecs: threat.tactic.name, native: "MitreTactics (split on ¦)"}
+source:
+  registry: sig-hayabusa-high
+  kind: jsonl
+  match: match_hayabusa_high

--- a/python/get_sybers_dfir/detect/rules/sig-suricata-alert.yml
+++ b/python/get_sybers_dfir/detect/rules/sig-suricata-alert.yml
@@ -1,0 +1,52 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: sig-suricata-alert
+name: Suricata IDS alert
+status: stub
+severity: medium
+attack: []
+tactics: []
+language: esql
+index: [logs-dfir.suricata-*]
+query: null
+# The eve.jsonl also carries flow/dns/... context events — only
+# event_type=alert is a detection. Field names follow Elastic's own Suricata
+# integration (suricata.eve.*), the reference projection for the lane.
+todo:
+  query: |
+    FROM logs-dfir.suricata-* METADATA _id, _index, _version
+    | WHERE suricata.eve.event_type == "alert"
+    | EVAL rule.id = "sig-suricata-alert",
+           rule.name = "Suricata IDS alert",
+           event.risk_score = 47.0
+    | LIMIT 1000
+  blockers:
+    - "Per-hit ATT&CK ids: ET Open puts mitre_technique_id (a list) in alert.metadata; the ingest pipeline must lift it to threat.technique.id so the alert line carries its techniques — the ECS-normalisation phase"
+    - "The lane's eve.jsonl needs the suricata.eve.* projection (event_type, alert.signature, alert.signature_id, alert.category, alert.severity) plus source.ip / destination.ip / destination.port / network.transport"
+evidence:
+  shape: line
+  stamped_by: query
+  fields:
+    - rule.id
+    - rule.name
+    - event.risk_score
+car_join:
+  key: event.id
+  via: provenance
+  provenance: ["@timestamp", source.ip, destination.ip, destination.port]
+fields:
+  - {ecs: "@timestamp", native: timestamp}
+  - {ecs: suricata.eve.event_type, native: event_type}
+  - {ecs: source.ip, native: src_ip}
+  - {ecs: destination.ip, native: dest_ip}
+  - {ecs: destination.port, native: dest_port}
+  - {ecs: network.transport, native: proto}
+  - {ecs: network.protocol, native: app_proto}
+  - {ecs: suricata.eve.alert.signature, native: alert.signature}
+  - {ecs: suricata.eve.alert.signature_id, native: alert.signature_id}
+  - {ecs: suricata.eve.alert.category, native: alert.category}
+  - {ecs: suricata.eve.alert.severity, native: alert.severity}
+  - {ecs: threat.technique.id, native: alert.metadata.mitre_technique_id}
+source:
+  registry: sig-suricata-alert
+  kind: jsonl
+  match: match_suricata_alert

--- a/python/get_sybers_dfir/detect/rules/sig-yara-match.yml
+++ b/python/get_sybers_dfir/detect/rules/sig-yara-match.yml
@@ -1,0 +1,48 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: sig-yara-match
+name: YARA rule match
+status: stub
+severity: medium
+attack: []
+tactics: []
+language: esql
+index: [logs-dfir.yara-*]
+query: null
+# Every YARA match is a detection by definition — the rule already encodes the
+# judgement. The jsonl matcher trims string captures to ids/offsets because the
+# matched data can be binary; in Elastic that trimming moves to the ingest
+# pipeline so the evidence line never carries binary blobs.
+todo:
+  query: |
+    FROM logs-dfir.yara-* METADATA _id, _index, _version
+    | WHERE yara.tool == "yara" AND yara.rule IS NOT NULL
+    | EVAL rule.id = "sig-yara-match",
+           rule.name = "YARA rule match",
+           event.risk_score = 47.0
+    | LIMIT 1000
+  blockers:
+    - "No Elastic integration for the lane's JSONL: the yara.* projection (tool, rule, source, target, match, strings[].id) and the trimming of strings[].data are an ingest-pipeline contract still to be written"
+    - "Per-hit ATT&CK ids come from the rule's meta (attack / mitre_technique keys, with a scan-every-value fallback in the registry) — the pipeline must reproduce that into threat.technique.id"
+evidence:
+  shape: line
+  stamped_by: query
+  fields:
+    - rule.id
+    - rule.name
+    - event.risk_score
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [yara.source, yara.target]
+fields:
+  - {ecs: yara.tool, native: tool}
+  - {ecs: yara.rule, native: rule}
+  - {ecs: yara.source, native: source}
+  - {ecs: yara.target, native: target}
+  - {ecs: yara.match, native: match}
+  - {ecs: yara.string_ids, native: "strings[].id (data trimmed)"}
+  - {ecs: threat.technique.id, native: "meta.attack / meta.mitre_* (fallback: any meta value)"}
+source:
+  registry: sig-yara-match
+  kind: jsonl
+  match: match_yara

--- a/python/get_sybers_dfir/detect/rules/vol-malfind-injection.yml
+++ b/python/get_sybers_dfir/detect/rules/vol-malfind-injection.yml
@@ -1,0 +1,73 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: vol-malfind-injection
+name: Injected / unbacked executable memory (Volatility malfind)
+status: stub
+severity: high
+attack: [T1055]
+tactics: [TA0005, TA0004]
+language: esql
+index: [logs-dfir.volatility-*]
+query: null
+# One hit per process per memory image; the raw regions stay in the lane. The
+# aggregate shape of the KQL (summarize by SourceFile, Proc, Pid) carries over
+# as STATS BY; make_set() is VALUES().
+todo:
+  query: |
+    FROM logs-dfir.volatility-*
+    | WHERE volatility.plugin == "windows.malfind"
+    | STATS regions = COUNT(*),
+            protections = VALUES(volatility.protection)
+          BY file.path, process.name, process.pid
+    | EVAL rule.id = "vol-malfind-injection",
+           rule.name = "Injected / unbacked executable memory (Volatility malfind)",
+           event.risk_score = 73.0,
+           threat.framework = "MITRE ATT&CK",
+           threat.tactic.id = MV_APPEND("TA0005", "TA0004"),
+           threat.tactic.name = MV_APPEND("Defense Evasion", "Privilege Escalation"),
+           threat.technique.id = "T1055",
+           threat.technique.name = "Process Injection"
+    | LIMIT 1000
+  blockers:
+    - "VALUES() (the make_set() port) is technical preview in ES|QL — pin the stack version before promoting, or drop the protections column"
+    - "Volatility has no Elastic integration: the volatility.plugin / volatility.protection / process.* / file.path (memory image) projection of the lane's {Plugin, SourceFile, Record} rows is an ingest-pipeline contract still to be written"
+evidence:
+  shape: aggregate
+  stamped_by: query
+  fields:
+    - file.path
+    - process.name
+    - process.pid
+    - regions
+    - protections
+    - rule.id
+    - rule.name
+    - event.risk_score
+    - threat.framework
+    - threat.tactic.id
+    - threat.tactic.name
+    - threat.technique.id
+    - threat.technique.name
+car_join:
+  key: process.entity_id
+  via: provenance
+  provenance: [file.path, process.pid]
+fields:
+  - {ecs: volatility.plugin, native: Plugin}
+  - {ecs: file.path, native: SourceFile (the memory image)}
+  - {ecs: process.name, native: Record.Process}
+  - {ecs: process.pid, native: Record.PID}
+  - {ecs: volatility.protection, native: Record.Protection}
+source:
+  registry: vol-malfind-injection
+  kind: kusto
+  kql: |
+    database("memory").VolatilityJson
+    | where Plugin == "windows.malfind"
+    | extend Proc = tostring(Record.Process), Pid = tolong(Record.PID)
+    | summarize Regions = count(),
+                Protections = make_set(tostring(Record.Protection), 10)
+              by SourceFile, Proc, Pid
+    | project Timestamp = datetime(null),
+              Entity = strcat(Proc, " (pid ", tostring(Pid), ")"),
+              Details = pack("MemoryImage", SourceFile, "Regions", Regions,
+                             "Protections", Protections)

--- a/python/get_sybers_dfir/detect/rules/win-defender-tamper.yml
+++ b/python/get_sybers_dfir/detect/rules/win-defender-tamper.yml
@@ -1,0 +1,61 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: win-defender-tamper
+name: Windows Defender disabled or reconfigured
+status: ported
+severity: medium
+attack: [T1562.001]
+tactics: [TA0005]
+language: esql
+index: [logs-dfir.evtx-*]
+# DetectRaptor win_disable_defender (5001/5010/5012) + 5007 (configuration
+# changed — how exclusions land in the log). METADATA _id/_index/_version makes
+# the Detection Engine raise one alert per matched document, carrying every
+# source field plus the EVAL'd threat.* / rule.* — the tagged evidence line.
+query: |
+  FROM logs-dfir.evtx-* METADATA _id, _index, _version
+  | WHERE winlog.channel == "Microsoft-Windows-Windows Defender/Operational"
+      AND event.code IN ("5001", "5007", "5010", "5012")
+  | EVAL rule.id = "win-defender-tamper",
+         rule.name = "Windows Defender disabled or reconfigured",
+         event.risk_score = 47.0,
+         threat.framework = "MITRE ATT&CK",
+         threat.tactic.id = "TA0005",
+         threat.tactic.name = "Defense Evasion",
+         threat.technique.id = "T1562.001",
+         threat.technique.name = "Impair Defenses: Disable or Modify Tools"
+  | LIMIT 1000
+evidence:
+  shape: line
+  stamped_by: query
+  fields:
+    - rule.id
+    - rule.name
+    - event.risk_score
+    - threat.framework
+    - threat.tactic.id
+    - threat.tactic.name
+    - threat.technique.id
+    - threat.technique.name
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [log.file.path, winlog.record_id]
+fields:
+  - {ecs: "@timestamp", native: TimeCreated}
+  - {ecs: event.code, native: EventId}
+  - {ecs: winlog.channel, native: Channel}
+  - {ecs: winlog.record_id, native: EventRecordId}
+  - {ecs: host.name, native: Computer}
+  - {ecs: message, native: MapDescription}
+  - {ecs: winlog.event_data, native: "Payload (EventData XML, parsed by the ingest pipeline)"}
+  - {ecs: log.file.path, native: SourceFile}
+source:
+  registry: win-defender-tamper
+  kind: kusto
+  kql: |
+    database("host").EvtxEcmdJson
+    | where Channel == "Microsoft-Windows-Windows Defender/Operational"
+        and EventId in (5001, 5007, 5010, 5012)
+    | project Timestamp = TimeCreated, Entity = Computer,
+              Details = pack("EventId", EventId, "MapDescription", MapDescription,
+                             "Payload", Payload, "SourceFile", SourceFile)

--- a/python/get_sybers_dfir/detect/rules/win-eventlog-cleared.yml
+++ b/python/get_sybers_dfir/detect/rules/win-eventlog-cleared.yml
@@ -1,0 +1,55 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: win-eventlog-cleared
+name: Windows event log cleared
+status: ported
+severity: high
+attack: [T1070.001]
+tactics: [TA0005]
+language: eql
+index: [logs-dfir.evtx-*]
+# DetectRaptor Evtx.yaml win_eventlog_clear: 1102 (Security) / 104 (System); 517
+# is the pre-Vista Security-cleared id. Channel-scoped, exactly as the KQL: many
+# modern Operational channels reuse 104/1102 for unrelated events. EQL `:` is the
+# case-insensitive string match (the KQL `=~`).
+query: |
+  any where
+    (event.code == "1102" and winlog.channel : "Security") or
+    (event.code == "104"  and winlog.channel : "System") or
+    (event.code == "517"  and winlog.channel : "Security")
+# EQL cannot EVAL: the alert IS the matched event document (every source field
+# copied) and the Detection Engine stamps the rule's ATT&CK mapping and identity
+# onto it under kibana.alert.*.
+evidence:
+  shape: line
+  stamped_by: engine
+  fields:
+    - kibana.alert.rule.rule_id
+    - kibana.alert.rule.name
+    - kibana.alert.severity
+    - kibana.alert.risk_score
+    - kibana.alert.rule.threat
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [log.file.path, winlog.record_id]
+fields:
+  - {ecs: "@timestamp", native: TimeCreated}
+  - {ecs: event.code, native: EventId}
+  - {ecs: winlog.channel, native: Channel}
+  - {ecs: winlog.record_id, native: EventRecordId}
+  - {ecs: host.name, native: Computer}
+  - {ecs: user.name, native: UserName}
+  - {ecs: message, native: MapDescription}
+  - {ecs: log.file.path, native: SourceFile}
+source:
+  registry: win-eventlog-cleared
+  kind: kusto
+  kql: |
+    database("host").EvtxEcmdJson
+    | where (EventId == 1102 and Channel =~ "Security")
+         or (EventId ==  104 and Channel =~ "System")
+         or (EventId ==  517 and Channel =~ "Security")
+    | project Timestamp = TimeCreated, Entity = Computer,
+              Details = pack("EventId", EventId, "Channel", Channel,
+                             "UserName", UserName, "MapDescription", MapDescription,
+                             "SourceFile", SourceFile)

--- a/python/get_sybers_dfir/detect/rules/win-prefetch-dualuse-tool.yml
+++ b/python/get_sybers_dfir/detect/rules/win-prefetch-dualuse-tool.yml
@@ -1,0 +1,69 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: win-prefetch-dualuse-tool
+name: Prefetch evidence of dual-use / attack tooling execution
+status: ported
+severity: medium
+attack: [T1059, T1053.005]
+tactics: [TA0002]
+language: esql
+index: [logs-dfir.plaso-*]
+# DetectRaptor's MFT/Evtx lists of offensive + recon + RMM tooling, cut to names
+# with prefetch-visible execution semantics. The anchored, case-insensitive KQL
+# regex is an exact-name IN list over the upper-cased executable. Two techniques
+# ride on one line as a multi-value threat.technique.id (MV_APPEND).
+query: |
+  FROM logs-dfir.plaso-* METADATA _id, _index, _version
+  | WHERE event.dataset == "plaso.prefetch"
+      AND TO_UPPER(process.name) IN (
+            "PSEXEC.EXE", "PSEXESVC.EXE", "MIMIKATZ.EXE", "PROCDUMP.EXE", "LAZAGNE.EXE",
+            "SHARPHOUND.EXE", "ADFIND.EXE", "DSQUERY.EXE", "NLTEST.EXE", "RCLONE.EXE",
+            "MEGACMD.EXE", "MEGASYNC.EXE", "NCAT.EXE", "NMAP.EXE", "WCE.EXE", "SDELETE.EXE",
+            "SCHTASKS.EXE", "WHOAMI.EXE", "WMIC.EXE", "QUSER.EXE", "ANYDESK.EXE",
+            "TEAMVIEWER.EXE", "ATERA.EXE", "SPLASHTOP.EXE", "SCREENCONNECT.EXE")
+  | EVAL rule.id = "win-prefetch-dualuse-tool",
+         rule.name = "Prefetch evidence of dual-use / attack tooling execution",
+         event.risk_score = 47.0,
+         threat.framework = "MITRE ATT&CK",
+         threat.tactic.id = "TA0002",
+         threat.tactic.name = "Execution",
+         threat.technique.id = MV_APPEND("T1059", "T1053.005"),
+         threat.technique.name = MV_APPEND("Command and Scripting Interpreter",
+                                           "Scheduled Task/Job: Scheduled Task")
+  | LIMIT 1000
+evidence:
+  shape: line
+  stamped_by: query
+  fields:
+    - rule.id
+    - rule.name
+    - event.risk_score
+    - threat.framework
+    - threat.tactic.id
+    - threat.tactic.name
+    - threat.technique.id
+    - threat.technique.name
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [event.dataset, host.name, file.path, "@timestamp"]
+fields:
+  - {ecs: "@timestamp", native: timestamp (microseconds since epoch)}
+  - {ecs: event.dataset, native: "parser (prefetch -> plaso.prefetch)"}
+  - {ecs: process.name, native: executable}
+  - {ecs: host.name, native: image_hostname}
+  - {ecs: file.path, native: display_name}
+  - {ecs: plaso.run_count, native: run_count}
+  - {ecs: plaso.source_image, native: SourceImage}
+source:
+  registry: win-prefetch-dualuse-tool
+  kind: kusto
+  kql: |
+    database("host").L2tPrefetch
+    | extend Executable = tostring(Record.executable)
+    | where Executable matches regex
+            @'(?i)^(PSEXEC|PSEXESVC|MIMIKATZ|PROCDUMP|LAZAGNE|SHARPHOUND|ADFIND|DSQUERY|NLTEST|RCLONE|MEGACMD|MEGASYNC|NCAT|NMAP|WCE|SDELETE|SCHTASKS|WHOAMI|WMIC|QUSER|ANYDESK|TEAMVIEWER|ATERA|SPLASHTOP|SCREENCONNECT)\.EXE$'
+    | project Timestamp,
+              Entity = strcat(tostring(Record.image_hostname), ": ", Executable),
+              Details = pack("Executable", Executable, "RunCount", Record.run_count,
+                             "Path", tostring(Record.display_name), "Parser", Parser,
+                             "SourceImage", SourceImage)

--- a/python/get_sybers_dfir/detect/rules/win-service-suspicious-path.yml
+++ b/python/get_sybers_dfir/detect/rules/win-service-suspicious-path.yml
@@ -1,0 +1,72 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: win-service-suspicious-path
+name: Service installed from a suspicious path or command
+status: ported
+severity: high
+attack: [T1543.003]
+tactics: [TA0003, TA0004]
+language: esql
+index: [logs-dfir.evtx-*]
+# DetectRaptor win_sus_service: 7045 (System) / 4697 (Security) whose image is a
+# shell one-liner, a user-writable path, or an admin share. The image path is
+# ImagePath on 7045 and ServiceFileName on 4697 (winlog.event_data.* is the ECS
+# home of EventData). RLIKE is a Lucene regex: whole-string, no (?i) and no \b —
+# so the input is lowercased first, the pattern is wrapped in .*...*, and the
+# KQL's `\.bat\b|\.ps1\b` becomes "followed by end-of-string or a non-alnum".
+# The triple-quoted literal keeps the backslashes verbatim.
+query: |
+  FROM logs-dfir.evtx-* METADATA _id, _index, _version
+  | WHERE (event.code == "7045" AND TO_LOWER(winlog.channel) == "system")
+       OR (event.code == "4697" AND TO_LOWER(winlog.channel) == "security")
+  | EVAL service.executable = COALESCE(winlog.event_data.ImagePath, winlog.event_data.ServiceFileName)
+  | WHERE TO_LOWER(service.executable) RLIKE """.*(\\users\\|\\temp\\|\\appdata\\|comspec|powershell|cmd\.exe|\\admin[$]|\\c[$]).*|.*\.(bat|ps1)([^a-z0-9].*)?"""
+  | EVAL rule.id = "win-service-suspicious-path",
+         rule.name = "Service installed from a suspicious path or command",
+         event.risk_score = 73.0,
+         threat.framework = "MITRE ATT&CK",
+         threat.tactic.id = MV_APPEND("TA0003", "TA0004"),
+         threat.tactic.name = MV_APPEND("Persistence", "Privilege Escalation"),
+         threat.technique.id = "T1543.003",
+         threat.technique.name = "Create or Modify System Process: Windows Service"
+  | LIMIT 1000
+evidence:
+  shape: line
+  stamped_by: query
+  fields:
+    - service.executable
+    - rule.id
+    - rule.name
+    - event.risk_score
+    - threat.framework
+    - threat.tactic.id
+    - threat.tactic.name
+    - threat.technique.id
+    - threat.technique.name
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [log.file.path, winlog.record_id]
+fields:
+  - {ecs: "@timestamp", native: TimeCreated}
+  - {ecs: event.code, native: EventId}
+  - {ecs: winlog.channel, native: Channel}
+  - {ecs: winlog.record_id, native: EventRecordId}
+  - {ecs: host.name, native: Computer}
+  - {ecs: winlog.event_data.ServiceName, native: PayloadData1}
+  - {ecs: winlog.event_data.ImagePath, native: "Payload @Name=ImagePath (7045) / ExecutableInfo"}
+  - {ecs: winlog.event_data.ServiceFileName, native: "Payload @Name=ServiceFileName (4697)"}
+  - {ecs: log.file.path, native: SourceFile}
+source:
+  registry: win-service-suspicious-path
+  kind: kusto
+  kql: |
+    database("host").EvtxEcmdJson
+    | where (EventId == 7045 and Channel =~ "System")
+         or (EventId == 4697 and Channel =~ "Security")
+    | extend ServicePath = iff(isnotempty(ExecutableInfo), ExecutableInfo,
+                               extract(@'"@Name":"(?:ImagePath|ServiceFileName)","#text":"((?:[^"\\]|\\.)*)"', 1, Payload))
+    | where ServicePath matches regex
+            @'(?i)(\\Users\\|\\Temp\\|\\AppData\\|COMSPEC|powershell|cmd\.exe|\\ADMIN\$|\\C\$|\.bat\b|\.ps1\b)'
+    | project Timestamp = TimeCreated, Entity = Computer,
+              Details = pack("EventId", EventId, "ServiceName", PayloadData1,
+                             "ServicePath", ServicePath, "SourceFile", SourceFile)

--- a/python/get_sybers_dfir/detect/rules/zeek-dns-oversized-query.yml
+++ b/python/get_sybers_dfir/detect/rules/zeek-dns-oversized-query.yml
@@ -1,0 +1,77 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: zeek-dns-oversized-query
+name: Oversized DNS queries (tunnelling / exfiltration indicator)
+status: ported
+severity: medium
+attack: [T1071.004, T1048.003]
+tactics: [TA0011, TA0010]
+language: esql
+index: [logs-dfir.zeek-*]
+# One hit per querying host, not per query — 8k raw rows is a lead list, a
+# per-source summary is a detection. This is the AGGREGATE evidence shape: the
+# alert is the STATS row (no single source document), so the line is built
+# from the group key and aggregates and then stamped like any other. take_any()
+# becomes MAX() (deterministic; VALUES() is still technical preview).
+query: |
+  FROM logs-dfir.zeek-*
+  | WHERE event.dataset == "zeek.dns"
+      AND LENGTH(dns.question.name) >= 60
+      AND NOT ENDS_WITH(dns.question.name, ".in-addr.arpa")
+      AND NOT ENDS_WITH(dns.question.name, ".ip6.arpa")
+  | STATS query_count = COUNT(*),
+          sample_query = MAX(dns.question.name),
+          first_seen = MIN(@timestamp),
+          last_seen = MAX(@timestamp)
+        BY source.ip
+  | EVAL rule.id = "zeek-dns-oversized-query",
+         rule.name = "Oversized DNS queries (tunnelling / exfiltration indicator)",
+         event.risk_score = 47.0,
+         threat.framework = "MITRE ATT&CK",
+         threat.tactic.id = MV_APPEND("TA0011", "TA0010"),
+         threat.tactic.name = MV_APPEND("Command and Control", "Exfiltration"),
+         threat.technique.id = MV_APPEND("T1071.004", "T1048.003"),
+         threat.technique.name = MV_APPEND("Application Layer Protocol: DNS",
+                                           "Exfiltration Over Alternative Protocol: Exfiltration Over Unencrypted Non-C2 Protocol")
+  | SORT query_count DESC
+  | LIMIT 1000
+evidence:
+  shape: aggregate
+  stamped_by: query
+  fields:
+    - source.ip
+    - query_count
+    - sample_query
+    - first_seen
+    - last_seen
+    - rule.id
+    - rule.name
+    - event.risk_score
+    - threat.framework
+    - threat.tactic.id
+    - threat.tactic.name
+    - threat.technique.id
+    - threat.technique.name
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [event.dataset, source.ip]
+fields:
+  - {ecs: "@timestamp", native: ts}
+  - {ecs: event.dataset, native: "LogType (dns -> zeek.dns)"}
+  - {ecs: source.ip, native: id.orig_h}
+  - {ecs: dns.question.name, native: query}
+source:
+  registry: zeek-dns-oversized-query
+  kind: kusto
+  kql: |
+    database("network").Zeek
+    | where LogType == "dns"
+    | extend Query = tostring(Record.query)
+    | where strlen(Query) >= 60
+        and not(Query endswith ".in-addr.arpa" or Query endswith ".ip6.arpa")
+    | summarize QueryCount = count(), SampleQuery = take_any(Query),
+                FirstSeen = min(Ts), LastSeen = max(Ts)
+              by SrcIp = tostring(Record.["id.orig_h"])
+    | project Timestamp = FirstSeen, Entity = SrcIp,
+              Details = pack("QueryCount", QueryCount, "SampleQuery", SampleQuery,
+                             "FirstSeen", FirstSeen, "LastSeen", LastSeen)

--- a/python/get_sybers_dfir/detect/rules/zeek-notice-promoted.yml
+++ b/python/get_sybers_dfir/detect/rules/zeek-notice-promoted.yml
@@ -1,0 +1,51 @@
+# Byakugan Elastic detection rule (rules-as-code). Model: ./README.md
+id: zeek-notice-promoted
+name: Zeek notice raised
+status: ported
+severity: low
+attack: []
+tactics: []
+language: esql
+index: [logs-dfir.zeek-*]
+# Zeek's own detection layer — surface notice.log in the unified output. No
+# static ATT&CK mapping (a notice's meaning is in zeek.notice.note), so the line
+# is stamped with rule identity only; threat.* stays whatever the notice itself
+# carried.
+query: |
+  FROM logs-dfir.zeek-* METADATA _id, _index, _version
+  | WHERE event.dataset == "zeek.notice"
+  | EVAL rule.id = "zeek-notice-promoted",
+         rule.name = "Zeek notice raised",
+         event.risk_score = 21.0
+  | LIMIT 1000
+evidence:
+  shape: line
+  stamped_by: query
+  fields:
+    - rule.id
+    - rule.name
+    - event.risk_score
+car_join:
+  key: event.id
+  via: provenance
+  provenance: [event.dataset, zeek.session_id]
+fields:
+  - {ecs: "@timestamp", native: ts}
+  - {ecs: event.dataset, native: "LogType (notice -> zeek.notice)"}
+  - {ecs: zeek.session_id, native: uid}
+  - {ecs: source.ip, native: id.orig_h}
+  - {ecs: destination.ip, native: id.resp_h}
+  - {ecs: zeek.notice.note, native: note}
+  - {ecs: zeek.notice.msg, native: msg}
+  - {ecs: log.file.path, native: SourceFile}
+source:
+  registry: zeek-notice-promoted
+  kind: kusto
+  kql: |
+    database("network").Zeek
+    | where LogType == "notice"
+    | project Timestamp = Ts,
+              Entity = strcat(tostring(Record.["id.orig_h"]), " -> ",
+                              tostring(Record.["id.resp_h"])),
+              Details = pack("Note", tostring(Record.note), "Msg", tostring(Record.msg),
+                             "Uid", tostring(Record.uid), "SourceFile", SourceFile)

--- a/python/get_sybers_dfir/detect/rules_loader.py
+++ b/python/get_sybers_dfir/detect/rules_loader.py
@@ -218,6 +218,10 @@ def _check_esql(rule: dict, stripped: str) -> list[str]:
     for head in heads:
         if head not in _ESQL_PIPE_CMDS:
             problems.append(f"unknown ES|QL command {head!r}")
+    # Only STATS collapses rows into groups (an aggregate alert). INLINESTATS
+    # augments each row without collapsing it, so an INLINESTATS query stays
+    # non-aggregating here: it still emits one alert per matched document, so it
+    # must request METADATA and its evidence is a line, not an aggregate.
     aggregating = "STATS" in heads
     if not aggregating and not set(_ESQL_METADATA) <= meta:
         problems.append("non-aggregating ES|QL must request METADATA "
@@ -444,8 +448,10 @@ def validate_car_detections(template: dict, join_keys: dict) -> None:
         raise ValueError("car-detections: template must set index.mode: lookup (LOOKUP JOIN needs it)")
     mapped = _mapped_fields(((template.get("template") or {}).get("mappings") or {}).get("properties"))
     name = join_keys.get("lookup_index")
+    # Glob -> regex: escape every metacharacter first (so a '.' in a pattern is
+    # literal, not "any char"), then turn the escaped '*' back into '.*'.
     if not isinstance(name, str) or not any(
-            re.fullmatch(p.replace("*", ".*"), name) for p in patterns):
+            re.fullmatch(re.escape(p).replace(r"\*", ".*"), name) for p in patterns):
         raise ValueError("car-detections: join-keys lookup_index must match the template's index_patterns")
     joins = join_keys.get("join")
     if not isinstance(joins, list) or not joins:
@@ -494,9 +500,14 @@ def main(argv: list[str] | None = None) -> int:
         description="Load and validate the Elastic detection rules-as-code set; print a JSON summary.")
     ap.add_argument("--rules-dir", default=RULES_DIR)
     args = ap.parse_args(argv)
+    # Validate the car-detections contract from the SAME rules dir, so a custom
+    # --rules-dir is checked against its own car-detections/, not the built-in one.
+    car_dir = os.path.join(args.rules_dir, "car-detections")
     try:
         rules = list_rules(args.rules_dir)
-        validate_car_detections(*load_car_detections())
+        validate_car_detections(*load_car_detections(
+            os.path.join(car_dir, "car-detections.index-template.json"),
+            os.path.join(car_dir, "join-keys.yml")))
     except (ValueError, OSError) as e:
         print(json.dumps({"tool": "rules", "error": str(e)}), file=sys.stderr)
         return 1

--- a/python/get_sybers_dfir/detect/rules_loader.py
+++ b/python/get_sybers_dfir/detect/rules_loader.py
@@ -1,0 +1,508 @@
+"""Elastic detection rules-as-code — the Byakugan sibling of :mod:`.registry`.
+
+:mod:`.registry` is the HuntList for the Kusto backend: one Python dict per
+detection and a ``validate()`` that fails fast on a malformed entry. This module
+is the same idea for Elastic's own Detection Engine, with the detections as
+DATA: one YAML file per rule under ``detect/rules/``, each carrying an ES|QL or
+EQL query plus the contract for the TAGGED EVIDENCE LINE it produces. It loads
+the files, validates them with the registry's rigor, and exposes
+``list_rules()`` / ``validate()``.
+
+ADDITIVE. The Kusto registry, runner and emulator stay exactly as they are
+until Kusto retires at the end of phase 2 (decision D1). Nothing here imports
+them, so the rule set stays loadable after that retirement; the ids are shared
+(every rule file reuses its registry id, and ``tests/test_rules.py`` pins the
+two id sets equal, so a detection can neither be dropped silently nor exist
+twice under different names).
+
+Rule file shape (``rules/README.md`` documents the model in full)::
+
+    id: win-defender-tamper           # == registry id == file stem
+    name: Windows Defender disabled or reconfigured
+    status: ported | stub             # stub: query is a TODO, the KQL intent is kept
+    severity: low | medium | high | critical
+    risk_score: 47                    # optional, defaults from severity
+    attack: [T1562.001]               # ATT&CK technique ids (may be empty)
+    tactics: [TA0005]                 # optional ATT&CK tactic ids
+    language: esql | eql
+    index: [logs-dfir.evtx-*]         # the data streams the query reads
+    query: |                          # ported only; null/absent for a stub
+    evidence:                         # the tagged-evidence-line contract
+      shape: line | aggregate
+      stamped_by: query | engine
+      fields: [threat.technique.id, ...]
+    car_join: {key: event.id, via: direct | provenance, provenance: [...]}
+    fields: [{ecs: event.code, native: EventId}, ...]     # optional
+    source: {registry: <id>, kind: kusto | jsonl, kql: ... | match: ...}
+    todo: {query: ..., blockers: [...]}                    # stub only
+
+The query check is STRUCTURAL, not a parser. ES|QL must start with a FROM over
+exactly the declared data streams, chain only known commands, request
+``METADATA _id, _index, _version`` when it does not aggregate (that is what
+makes the Detection Engine emit one alert per matched source document), and
+stamp every field the evidence contract promises. EQL must be a
+``<category> where`` / ``sequence`` / ``sample`` query. Both must balance their
+brackets outside string literals and carry no KQL left-overs.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+import yaml
+
+RULES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "rules")
+CAR_DETECTIONS_DIR = os.path.join(RULES_DIR, "car-detections")
+CAR_DETECTIONS_TEMPLATE = os.path.join(CAR_DETECTIONS_DIR, "car-detections.index-template.json")
+CAR_DETECTIONS_JOIN_KEYS = os.path.join(CAR_DETECTIONS_DIR, "join-keys.yml")
+
+# Elastic's severity set (the registry's "info" maps to "low") and the Detection
+# Engine's canonical risk score for each — used when a rule declares none.
+SEVERITIES = ("low", "medium", "high", "critical")
+RISK_SCORES = {"low": 21, "medium": 47, "high": 73, "critical": 99}
+LANGUAGES = ("esql", "eql")
+STATUSES = ("ported", "stub")
+SHAPES = ("line", "aggregate")
+STAMPERS = ("query", "engine")
+SOURCE_KINDS = ("kusto", "jsonl")
+JOIN_VIAS = ("direct", "provenance")
+# The keys the car-detections lookup index can be joined on (guid travels as
+# event.id on every CAR object, and as process.entity_id on process). Kept in
+# lockstep with rules/car-detections/join-keys.yml (pinned by the tests).
+CAR_JOIN_KEYS = ("event.id", "process.entity_id")
+REQUIRED = ("id", "name", "status", "severity", "attack", "language", "index",
+            "evidence", "car_join", "source")
+
+_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_TECHNIQUE_RE = re.compile(r"^T\d{4}(?:\.\d{3})?$")
+_TACTIC_RE = re.compile(r"^TA\d{4}$")
+# A data stream pattern: logs-<dataset>-* (dataset may carry a wildcard segment,
+# e.g. logs-car.*-* for every CAR object).
+_INDEX_RE = re.compile(r"^logs-[a-z0-9_]+(?:\.[a-z0-9_*]+)*-\*$")
+# An ECS-style field path (@timestamp, event.code, winlog.event_data.ImagePath).
+_FIELD_RE = re.compile(r"^[@a-z][a-z0-9_]*(?:\.[A-Za-z0-9_]+)*$")
+_MATCH_RE = re.compile(r"^match_[a-z0-9_]+$")
+
+_ESQL_PIPE_CMDS = (
+    "WHERE", "EVAL", "KEEP", "DROP", "STATS", "INLINESTATS", "SORT", "LIMIT",
+    "RENAME", "LOOKUP JOIN", "MV_EXPAND", "GROK", "DISSECT", "ENRICH",
+    "CHANGE_POINT", "SAMPLE", "FORK", "COMPLETION", "RERANK", "FUSE",
+)
+_ESQL_METADATA = ("_id", "_index", "_version")
+_ESQL_FROM_RE = re.compile(r"^\s*FROM\s+(.+?)(?:\s+METADATA\s+(.+))?\s*$", re.I | re.S)
+_EQL_HEAD_RE = re.compile(r"^\s*(?:(?:sequence|sample)\b|[a-z_][\w.]*\s+where\b)", re.I)
+# KQL that has no business in an Elastic query — a port that still contains one
+# of these was not finished. Word-bounded (ES|QL's DATE_DIFF( is not iff().
+_KQL_LEFTOVERS = tuple(re.compile(p, re.I) for p in (
+    r"\bdatabase\(", r"\|\s*project\b", r"\|\s*extend\b", r"\|\s*summarize\b",
+    r"\bpack\(", r"=~", r"\bstrcat\(", r"\btostring\(", r"\btolong\(", r"\biff\(",
+    r"\bmatches\s+regex\b", r"\btake_any\(", r"\bmake_set\(", r"\bisnotempty\("))
+_BRACKETS = {")": "(", "]": "[", "}": "{"}
+
+
+# ---------------------------------------------------------------- pure query helpers
+def _strip_strings(text: str) -> str:
+    """The query with every string literal (``"..."`` and ``\"\"\"...\"\"\"``)
+    blanked to ``""``, so bracket balancing and command detection are not
+    fooled by quoted content (regexes, paths). Raises ValueError on an
+    unterminated literal. Pure."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        if text.startswith('"""', i):
+            j = text.find('"""', i + 3)
+            if j < 0:
+                raise ValueError("unterminated triple-quoted string")
+            out.append('""')
+            i = j + 3
+            continue
+        c = text[i]
+        if c == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                j += 2 if text[j] == "\\" else 1
+            if j >= n:
+                raise ValueError("unterminated string literal")
+            out.append('""')
+            i = j + 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def _unbalanced(stripped: str) -> str | None:
+    """The first bracket problem in an already string-stripped query, or None."""
+    stack: list[str] = []
+    for c in stripped:
+        if c in "([{":
+            stack.append(c)
+        elif c in _BRACKETS:
+            if not stack or stack[-1] != _BRACKETS[c]:
+                return f"unexpected {c!r}"
+            stack.pop()
+    return f"unclosed {stack[-1]!r}" if stack else None
+
+
+def _esql_commands(stripped: str) -> list[str]:
+    """The pipeline of an ES|QL query (string-stripped) as trimmed commands."""
+    return [c.strip() for c in stripped.split("|")]
+
+
+def _command_head(cmd: str) -> str:
+    words = cmd.split(None, 2)
+    if not words:
+        return ""
+    head = words[0].upper()
+    if head == "LOOKUP" and len(words) > 1:
+        head = "LOOKUP " + words[1].upper()
+    return head
+
+
+def _produces(stripped: str, field: str) -> bool:
+    """True when the (string-stripped) ES|QL assigns ``field`` (EVAL / STATS
+    ``field = ...``) or groups by it (``STATS ... BY field``)."""
+    if re.search(r"(?<![\w.])" + re.escape(field) + r"\s*=(?!=)", stripped):
+        return True
+    for cmd in _esql_commands(stripped):
+        if _command_head(cmd) in ("STATS", "INLINESTATS") and " BY " in cmd.upper():
+            keys = cmd[cmd.upper().rindex(" BY ") + 4:]
+            if field in {k.strip() for k in keys.split(",")}:
+                return True
+    return False
+
+
+def check_query(rule: dict) -> list[str]:
+    """Structural sanity problems with a ported rule's query (``[]`` = fine).
+    Not a parser: it checks the shape the Detection Engine needs, not that
+    every function call is valid."""
+    query = rule.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return ["query must be non-empty"]
+    problems: list[str] = []
+    for leftover in _KQL_LEFTOVERS:
+        m = leftover.search(query)
+        if m:
+            problems.append(f"KQL left-over {m.group(0)!r} in an Elastic query")
+    try:
+        stripped = _strip_strings(query)
+    except ValueError as e:
+        return problems + [str(e)]
+    bad = _unbalanced(stripped)
+    if bad:
+        problems.append(bad)
+    language = rule.get("language")
+    if language == "esql":
+        problems += _check_esql(rule, stripped)
+    elif language == "eql":
+        problems += _check_eql(rule, stripped)
+    return problems
+
+
+def _check_esql(rule: dict, stripped: str) -> list[str]:
+    problems: list[str] = []
+    cmds = _esql_commands(stripped)
+    m = _ESQL_FROM_RE.match(cmds[0])
+    if not m:
+        return ["ES|QL must start with FROM <data streams> [METADATA ...]"]
+    sources = {s.strip() for s in m.group(1).split(",") if s.strip()}
+    declared = set(rule.get("index") or [])
+    if sources != declared:
+        problems.append(f"FROM reads {sorted(sources)} but index declares {sorted(declared)}")
+    meta = {s.strip() for s in (m.group(2) or "").split(",") if s.strip()}
+    heads = [_command_head(c) for c in cmds[1:]]
+    for head in heads:
+        if head not in _ESQL_PIPE_CMDS:
+            problems.append(f"unknown ES|QL command {head!r}")
+    aggregating = "STATS" in heads
+    if not aggregating and not set(_ESQL_METADATA) <= meta:
+        problems.append("non-aggregating ES|QL must request METADATA "
+                        + ", ".join(_ESQL_METADATA) + " (one alert per matched document)")
+    shape = (rule.get("evidence") or {}).get("shape")
+    if aggregating and shape == "line":
+        problems.append("a STATS query produces aggregate evidence, not a line")
+    if not aggregating and shape == "aggregate":
+        problems.append("an aggregate evidence shape needs a STATS command")
+    if (rule.get("evidence") or {}).get("stamped_by") == "query":
+        for field in (rule.get("evidence") or {}).get("fields") or []:
+            if isinstance(field, str) and not _produces(stripped, field):
+                problems.append(f"evidence field {field!r} is promised but never stamped by the query")
+    return problems
+
+
+def _check_eql(rule: dict, stripped: str) -> list[str]:
+    problems: list[str] = []
+    if not _EQL_HEAD_RE.match(stripped):
+        problems.append("EQL must be a '<category> where ...', 'sequence' or 'sample' query")
+    if (rule.get("evidence") or {}).get("stamped_by") != "engine":
+        problems.append("EQL cannot stamp fields itself; evidence.stamped_by must be 'engine'")
+    return problems
+
+
+# ---------------------------------------------------------------------- loading
+def load(rules_dir: str = RULES_DIR) -> list[dict]:
+    """Every ``*.yml`` / ``*.yaml`` directly under ``rules_dir`` as a rule dict
+    (``_path`` attached; ``risk_score`` defaulted from a valid severity), in
+    path order. Subdirectories (car-detections/) are not rules. Raises
+    ValueError on a file that is not one YAML mapping."""
+    paths = sorted(glob.glob(os.path.join(rules_dir, "*.yml"))
+                   + glob.glob(os.path.join(rules_dir, "*.yaml")))
+    rules: list[dict] = []
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            try:
+                doc = yaml.safe_load(fh)
+            except yaml.YAMLError as e:
+                raise ValueError(f"{path}: not valid YAML: {e}") from e
+        if not isinstance(doc, dict):
+            raise ValueError(f"{path}: a rule file must be exactly one YAML mapping")
+        doc["_path"] = path
+        if "risk_score" not in doc and doc.get("severity") in RISK_SCORES:
+            doc["risk_score"] = RISK_SCORES[doc["severity"]]
+        rules.append(doc)
+    return rules
+
+
+def _str_list(v) -> bool:
+    return isinstance(v, list) and all(isinstance(s, str) and s.strip() for s in v)
+
+
+def validate(rules: list[dict] | None = None) -> None:
+    """Fail fast on a malformed rule set — a bad rule must stop the load before
+    anything is pushed to the Detection Engine, not half-install a rule set.
+    Mirrors :func:`registry.validate`: first problem raises ValueError, prefixed
+    with the rule id."""
+    rules = load() if rules is None else rules
+    seen: set[str] = set()
+    for r in rules:
+        rid = r.get("id", "")
+        prefix = f"rule {rid!r}: "
+        if not isinstance(rid, str) or not _ID_RE.match(rid):
+            raise ValueError(prefix + "id must be non-empty kebab-case")
+        if rid in seen:
+            raise ValueError(prefix + "duplicate id")
+        seen.add(rid)
+        path = r.get("_path")
+        if path and os.path.splitext(os.path.basename(path))[0] != rid:
+            raise ValueError(prefix + f"file must be named <id>.yml, not {os.path.basename(path)}")
+        missing = [k for k in REQUIRED if k not in r]
+        if missing:
+            raise ValueError(prefix + f"missing required field(s) {missing}")
+        name = r.get("name")
+        if not isinstance(name, str) or not name.strip() or '"' in name or "\\" in name:
+            raise ValueError(prefix + "name must be non-empty, without quotes/backslashes")
+        if r.get("status") not in STATUSES:
+            raise ValueError(prefix + f"status must be one of {STATUSES}")
+        if r.get("severity") not in SEVERITIES:
+            raise ValueError(prefix + f"severity must be one of {SEVERITIES}")
+        score = r.get("risk_score", RISK_SCORES[r["severity"]])
+        if not isinstance(score, int) or isinstance(score, bool) or not 0 <= score <= 100:
+            raise ValueError(prefix + "risk_score must be an integer 0..100")
+        attack = r.get("attack")
+        if not isinstance(attack, list) or not all(
+                isinstance(t, str) and _TECHNIQUE_RE.match(t) for t in attack):
+            raise ValueError(prefix + "attack must be a list of ATT&CK technique ids (T1234 / T1234.001)")
+        tactics = r.get("tactics", [])
+        if not isinstance(tactics, list) or not all(
+                isinstance(t, str) and _TACTIC_RE.match(t) for t in tactics):
+            raise ValueError(prefix + "tactics must be a list of ATT&CK tactic ids (TA0001)")
+        if r.get("language") not in LANGUAGES:
+            raise ValueError(prefix + f"language must be one of {LANGUAGES}")
+        index = r.get("index")
+        if not _str_list(index) or not index or not all(_INDEX_RE.match(i) for i in index):
+            raise ValueError(prefix + "index must be a non-empty list of logs-<dataset>-* data stream patterns")
+        _validate_evidence(prefix, r)
+        _validate_car_join(prefix, r.get("car_join"))
+        _validate_fields(prefix, r.get("fields"))
+        _validate_source(prefix, r.get("source"))
+        if r["status"] == "ported":
+            if "todo" in r:
+                raise ValueError(prefix + "a ported rule carries no todo block")
+            problems = check_query(r)
+            if problems:
+                raise ValueError(prefix + "query: " + "; ".join(problems))
+        else:
+            if r.get("query") is not None:
+                raise ValueError(prefix + "a stub must leave query null (put the intent in todo.query)")
+            todo = r.get("todo")
+            if not isinstance(todo, dict) or not isinstance(todo.get("query"), str) \
+                    or not todo["query"].strip():
+                raise ValueError(prefix + "a stub needs todo.query (the intended ES|QL/EQL)")
+            if not _str_list(todo.get("blockers")) or not todo["blockers"]:
+                raise ValueError(prefix + "a stub needs a non-empty todo.blockers list (why it is a stub)")
+
+
+def _validate_evidence(prefix: str, r: dict) -> None:
+    ev = r.get("evidence")
+    if not isinstance(ev, dict):
+        raise ValueError(prefix + "evidence must be a mapping (shape, stamped_by, fields)")
+    if ev.get("shape") not in SHAPES:
+        raise ValueError(prefix + f"evidence.shape must be one of {SHAPES}")
+    if ev.get("stamped_by") not in STAMPERS:
+        raise ValueError(prefix + f"evidence.stamped_by must be one of {STAMPERS}")
+    fields = ev.get("fields")
+    if not _str_list(fields) or not fields or not all(_FIELD_RE.match(f) for f in fields):
+        raise ValueError(prefix + "evidence.fields must be a non-empty list of field paths")
+    if ev["stamped_by"] == "engine" and not all(f.startswith("kibana.alert.") for f in fields):
+        raise ValueError(prefix + "engine-stamped evidence fields are the Detection Engine's kibana.alert.* fields")
+    if ev["stamped_by"] == "query":
+        has_technique = "threat.technique.id" in fields
+        if r.get("attack") and not has_technique:
+            raise ValueError(prefix + "a rule with ATT&CK techniques must stamp threat.technique.id on the evidence line")
+        if not r.get("attack") and has_technique:
+            raise ValueError(prefix + "no ATT&CK techniques declared, so threat.technique.id cannot be stamped")
+
+
+def _validate_car_join(prefix: str, cj) -> None:
+    if not isinstance(cj, dict):
+        raise ValueError(prefix + "car_join must be a mapping (key, via[, provenance])")
+    if cj.get("key") not in CAR_JOIN_KEYS:
+        raise ValueError(prefix + f"car_join.key must be one of {CAR_JOIN_KEYS}")
+    if cj.get("via") not in JOIN_VIAS:
+        raise ValueError(prefix + f"car_join.via must be one of {JOIN_VIAS}")
+    if cj["via"] == "provenance":
+        prov = cj.get("provenance")
+        if not _str_list(prov) or not prov or not all(_FIELD_RE.match(f) for f in prov):
+            raise ValueError(prefix + "car_join.via=provenance needs a non-empty provenance field list")
+
+
+def _validate_fields(prefix: str, fields) -> None:
+    if fields is None:
+        return
+    if not isinstance(fields, list) or not all(
+            isinstance(f, dict) and isinstance(f.get("ecs"), str) and _FIELD_RE.match(f["ecs"])
+            and isinstance(f.get("native"), str) and f["native"].strip() for f in fields):
+        raise ValueError(prefix + "fields must be a list of {ecs: <field path>, native: <lane field>}")
+
+
+def _validate_source(prefix: str, src) -> None:
+    if not isinstance(src, dict):
+        raise ValueError(prefix + "source must be a mapping (registry, kind, kql | match)")
+    if not isinstance(src.get("registry"), str) or not _ID_RE.match(src["registry"]):
+        raise ValueError(prefix + "source.registry must be the kebab-case registry id")
+    if src.get("kind") not in SOURCE_KINDS:
+        raise ValueError(prefix + f"source.kind must be one of {SOURCE_KINDS}")
+    if src["kind"] == "kusto":
+        if not isinstance(src.get("kql"), str) or not src["kql"].strip():
+            raise ValueError(prefix + "a kusto-sourced rule must keep the source KQL in source.kql")
+    elif not isinstance(src.get("match"), str) or not _MATCH_RE.match(src["match"]):
+        raise ValueError(prefix + "a jsonl-sourced rule must name the registry matcher in source.match")
+
+
+def list_rules(rules_dir: str = RULES_DIR) -> list[dict]:
+    """The validated rule set, sorted by id. The entry point for anything that
+    consumes the rules (an exporter, a runner, the CLI)."""
+    rules = load(rules_dir)
+    validate(rules)
+    return sorted(rules, key=lambda r: r["id"])
+
+
+def ported(rules: list[dict]) -> list[dict]:
+    return [r for r in rules if r.get("status") == "ported"]
+
+
+def stubs(rules: list[dict]) -> list[dict]:
+    return [r for r in rules if r.get("status") == "stub"]
+
+
+# ------------------------------------------------------- the car-detections contract
+def load_car_detections(template_path: str = CAR_DETECTIONS_TEMPLATE,
+                        join_keys_path: str = CAR_DETECTIONS_JOIN_KEYS) -> tuple[dict, dict]:
+    """The car-detections lookup index contract as data: (index template, join
+    keys). Both files are pure data the deploy step PUTs / the rules join on."""
+    with open(template_path, encoding="utf-8") as fh:
+        template = json.load(fh)
+    with open(join_keys_path, encoding="utf-8") as fh:
+        join_keys = yaml.safe_load(fh)
+    return template, join_keys
+
+
+def _mapped_fields(properties: dict, prefix: str = "") -> set[str]:
+    out: set[str] = set()
+    for name, spec in (properties or {}).items():
+        path = prefix + name
+        if isinstance(spec, dict) and "properties" in spec:
+            out |= _mapped_fields(spec["properties"], path + ".")
+        else:
+            out.add(path)
+    return out
+
+
+def validate_car_detections(template: dict, join_keys: dict) -> None:
+    """The lookup index must be a LOOKUP-mode index whose mapping carries every
+    join key the rules may join on, and the join-key data must agree with the
+    loader's CAR_JOIN_KEYS."""
+    patterns = template.get("index_patterns")
+    if not _str_list(patterns) or not patterns:
+        raise ValueError("car-detections: template needs index_patterns")
+    settings = (template.get("template") or {}).get("settings") or {}
+    if settings.get("index.mode") != "lookup":
+        raise ValueError("car-detections: template must set index.mode: lookup (LOOKUP JOIN needs it)")
+    mapped = _mapped_fields(((template.get("template") or {}).get("mappings") or {}).get("properties"))
+    name = join_keys.get("lookup_index")
+    if not isinstance(name, str) or not any(
+            re.fullmatch(p.replace("*", ".*"), name) for p in patterns):
+        raise ValueError("car-detections: join-keys lookup_index must match the template's index_patterns")
+    joins = join_keys.get("join")
+    if not isinstance(joins, list) or not joins:
+        raise ValueError("car-detections: join-keys needs a non-empty join list")
+    lookup_fields: list[str] = []
+    for j in joins:
+        if not isinstance(j, dict):
+            raise ValueError("car-detections: each join entry must be a mapping")
+        for k in ("car_field", "ecs_field", "lookup_field"):
+            if not isinstance(j.get(k), str) or not j[k].strip():
+                raise ValueError(f"car-detections: join entry needs {k}")
+        if j["ecs_field"] != j["lookup_field"]:
+            raise ValueError(f"car-detections: LOOKUP JOIN ON needs the same field name on both sides "
+                             f"({j['ecs_field']} != {j['lookup_field']})")
+        if j["lookup_field"] not in mapped:
+            raise ValueError(f"car-detections: join field {j['lookup_field']} is not mapped in the template")
+        lookup_fields.append(j["lookup_field"])
+    if set(lookup_fields) != set(CAR_JOIN_KEYS):
+        raise ValueError(f"car-detections: join keys {sorted(lookup_fields)} must equal CAR_JOIN_KEYS {sorted(CAR_JOIN_KEYS)}")
+    stamped = join_keys.get("stamped_fields")
+    if not _str_list(stamped) or not stamped or not set(stamped) <= mapped:
+        raise ValueError("car-detections: stamped_fields must list mapped fields of the lookup index")
+    example = join_keys.get("example_query")
+    if not isinstance(example, str) or not re.search(
+            r"LOOKUP JOIN\s+" + re.escape(name) + r"\s+ON\s+(" + "|".join(map(re.escape, CAR_JOIN_KEYS)) + r")\b", example):
+        raise ValueError("car-detections: example_query must LOOKUP JOIN the lookup index ON a join key")
+
+
+# ---------------------------------------------------------------------- summary
+def summary(rules: list[dict]) -> dict:
+    by_language: dict[str, int] = {}
+    for r in rules:
+        by_language[r["language"]] = by_language.get(r["language"], 0) + 1
+    return {
+        "tool": "rules", "rules": len(rules), "ported": len(ported(rules)),
+        "stub": len(stubs(rules)), "by_language": by_language,
+        "detections": {r["id"]: {"status": r["status"], "language": r["language"],
+                                 "severity": r["severity"], "index": r["index"],
+                                 "attack": r["attack"]} for r in rules},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="python -m get_sybers_dfir.detect.rules_loader",
+        description="Load and validate the Elastic detection rules-as-code set; print a JSON summary.")
+    ap.add_argument("--rules-dir", default=RULES_DIR)
+    args = ap.parse_args(argv)
+    try:
+        rules = list_rules(args.rules_dir)
+        validate_car_detections(*load_car_detections())
+    except (ValueError, OSError) as e:
+        print(json.dumps({"tool": "rules", "error": str(e)}), file=sys.stderr)
+        return 1
+    print(json.dumps(summary(rules), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/tests/test_rules.py
+++ b/python/tests/test_rules.py
@@ -1,0 +1,348 @@
+"""Unit tests for the Elastic detection rules-as-code loader (no Elastic needed).
+
+The rule files are data; these tests are what makes them a contract: every
+registry detection has exactly one rule file, ported rules carry structurally
+sound ES|QL/EQL that stamps what their evidence contract promises, stubs are
+explicit about what is still missing, and the car-detections lookup index
+agrees with the loader's join keys.
+"""
+import copy
+import os
+import re
+
+import pytest
+import yaml
+
+from get_sybers_dfir.detect import registry, rules_loader
+from get_sybers_dfir.detect import rules_loader as rl
+
+
+@pytest.fixture(scope="module")
+def rules():
+    return rl.list_rules()
+
+
+# ---- the seeded rule set ---------------------------------------------------
+def test_seeded_rules_validate(rules):
+    rl.validate(rules)                      # list_rules() already did; explicit
+
+
+def test_every_registry_detection_has_exactly_one_rule_file(rules):
+    # The full Kusto detection set is enumerated in Elastic — ported or stub —
+    # never silently dropped, and no rule exists that the registry does not know.
+    assert sorted(r["id"] for r in rules) == sorted(d["id"] for d in registry.DETECTIONS)
+    assert all(r["source"]["registry"] == r["id"] for r in rules)
+
+
+def test_rule_ids_unique_kebab_and_match_file_names(rules):
+    ids = [r["id"] for r in rules]
+    assert len(ids) == len(set(ids))
+    for r in rules:
+        assert r["id"] == r["id"].lower() and " " not in r["id"]
+        assert os.path.basename(r["_path"]) == r["id"] + ".yml"
+
+
+def test_required_fields_present(rules):
+    for r in rules:
+        for field in rl.REQUIRED:
+            assert field in r, f"{r['id']} lacks {field}"
+        assert r["severity"] in rl.SEVERITIES
+        assert r["language"] in rl.LANGUAGES
+        assert r["status"] in rl.STATUSES
+        assert all(i.startswith("logs-") for i in r["index"])
+        assert r["risk_score"] == rl.RISK_SCORES[r["severity"]]   # defaulted on load
+
+
+def test_rules_mirror_registry_metadata(rules):
+    # Severity / ATT&CK / source kind travel unchanged from the Kusto registry
+    # (severity "info" would map to "low"; no seeded detection uses it).
+    by_id = {d["id"]: d for d in registry.DETECTIONS}
+    for r in rules:
+        d = by_id[r["id"]]
+        assert r["attack"] == d["attack"]
+        assert r["severity"] == d["severity"]
+        assert r["source"]["kind"] == d["kind"]
+        if d["kind"] == "kusto":
+            assert r["source"]["kql"].strip() == d["query"].strip()
+        else:
+            assert r["source"]["match"] == d["match"].__name__
+
+
+def test_at_least_three_ported_rules_well_formed(rules):
+    ported = rl.ported(rules)
+    assert len(ported) >= 3
+    assert {"win-eventlog-cleared", "win-defender-tamper", "win-service-suspicious-path"} \
+        <= {r["id"] for r in ported}
+    for r in ported:
+        assert r["query"].strip() and "todo" not in r
+        assert rl.check_query(r) == []
+        if r["language"] == "esql":
+            assert r["query"].lstrip().upper().startswith("FROM ")
+            assert r["evidence"]["stamped_by"] == "query"
+            # the evidence line carries the rule identity inline ...
+            assert {"rule.id", "rule.name"} <= set(r["evidence"]["fields"])
+            assert f'rule.id = "{r["id"]}"' in r["query"]
+            # ... and its ATT&CK techniques, when it has any
+            if r["attack"]:
+                assert "threat.technique.id" in r["evidence"]["fields"]
+                assert all(t in r["query"] for t in r["attack"])
+        else:
+            assert re.search(r"\bwhere\b", r["query"])
+            assert r["evidence"]["stamped_by"] == "engine"
+            assert "kibana.alert.rule.threat" in r["evidence"]["fields"]
+
+
+def test_ported_languages_cover_both_dialects(rules):
+    langs = {r["language"] for r in rl.ported(rules)}
+    assert langs == {"esql", "eql"}
+
+
+def test_stubs_are_explicit(rules):
+    stubs = rl.stubs(rules)
+    assert stubs, "the scaffold keeps the unported detections as explicit stubs"
+    for r in stubs:
+        assert r["query"] is None
+        assert r["todo"]["query"].lstrip().upper().startswith("FROM ")
+        assert r["todo"]["blockers"]
+        assert r["index"][0] in r["todo"]["query"]
+        # the source detection is still fully described
+        assert r["source"]["kind"] in rl.SOURCE_KINDS
+    assert {r["id"] for r in stubs} >= {"sig-hayabusa-high", "sig-suricata-alert", "sig-yara-match"}
+
+
+def test_ported_plus_stub_is_the_whole_set(rules):
+    assert len(rl.ported(rules)) + len(rl.stubs(rules)) == len(rules) == len(registry.DETECTIONS)
+
+
+def test_summary_counts(rules):
+    s = rl.summary(rules)
+    assert s["rules"] == len(rules)
+    assert s["ported"] + s["stub"] == s["rules"]
+    assert set(s["detections"]) == {r["id"] for r in rules}
+    assert sum(s["by_language"].values()) == s["rules"]
+
+
+# ---- validate() rejects malformed rules ------------------------------------
+_BASE = {
+    "id": "x-1", "name": "t", "status": "ported", "severity": "low", "attack": ["T1055"],
+    "language": "esql", "index": ["logs-dfir.x-*"],
+    "query": ('FROM logs-dfir.x-* METADATA _id, _index, _version\n'
+              '| WHERE a == 1\n'
+              '| EVAL rule.id = "x-1", threat.technique.id = "T1055"\n'
+              '| LIMIT 10'),
+    "evidence": {"shape": "line", "stamped_by": "query",
+                 "fields": ["rule.id", "threat.technique.id"]},
+    "car_join": {"key": "event.id", "via": "direct"},
+    "source": {"registry": "x-1", "kind": "kusto", "kql": "T"},
+}
+
+
+def _patched(**patch):
+    return {**copy.deepcopy(_BASE), **patch}
+
+
+def test_base_rule_validates():
+    rl.validate([_patched()])
+
+
+@pytest.mark.parametrize("patch", [
+    {"id": "Bad_Case"},
+    {"status": "draft"},
+    {"severity": "info"},                              # Elastic has no info
+    {"severity": "urgent"},
+    {"risk_score": 101},
+    {"language": "kql"},
+    {"name": 'has "quotes"'},
+    {"attack": "T1055"},
+    {"attack": ["T10"]},
+    {"tactics": ["T1055"]},
+    {"index": []},
+    {"index": ["host.EvtxEcmdJson"]},
+    {"index": ["logs-dfir.x-*", "logs-dfir.y-*"]},     # FROM reads only one of them
+    {"evidence": {"shape": "line", "stamped_by": "query", "fields": []}},
+    {"evidence": {"shape": "line", "stamped_by": "query", "fields": ["rule.id"]}},   # attack set, technique unstamped
+    {"evidence": {"shape": "aggregate", "stamped_by": "query",
+                  "fields": ["rule.id", "threat.technique.id"]}},                  # no STATS
+    {"evidence": {"shape": "line", "stamped_by": "engine",
+                  "fields": ["rule.id", "threat.technique.id"]}},                  # engine stamps kibana.alert.*
+    {"car_join": {"key": "guid", "via": "direct"}},
+    {"car_join": {"key": "event.id", "via": "provenance"}},                        # needs provenance fields
+    {"fields": [{"ecs": "event.code"}]},
+    {"source": {"registry": "x-1", "kind": "sql", "kql": "T"}},
+    {"source": {"registry": "x-1", "kind": "kusto"}},
+    {"source": {"registry": "x-1", "kind": "jsonl", "match": "not_a_matcher"}},
+    {"todo": {"query": "FROM x", "blockers": ["b"]}},                              # ported rules carry no todo
+    {"query": "   "},
+])
+def test_validate_rejects_bad_rules(patch):
+    with pytest.raises(ValueError):
+        rl.validate([_patched(**patch)])
+
+
+def test_validate_rejects_duplicate_ids_and_misnamed_files():
+    with pytest.raises(ValueError, match="duplicate id"):
+        rl.validate([_patched(), _patched()])
+    with pytest.raises(ValueError, match="named <id>.yml"):
+        rl.validate([_patched(_path="/rules/other-name.yml")])
+
+
+def test_validate_stub_contract():
+    stub = _patched(status="stub", query=None,
+                    todo={"query": "FROM logs-dfir.x-* | WHERE a == 1", "blockers": ["why"]})
+    rl.validate([stub])
+    with pytest.raises(ValueError, match="query null"):
+        rl.validate([_patched(status="stub", todo={"query": "FROM x", "blockers": ["why"]})])
+    with pytest.raises(ValueError, match="todo.query"):
+        rl.validate([_patched(status="stub", query=None, todo={"blockers": ["why"]})])
+    with pytest.raises(ValueError, match="blockers"):
+        rl.validate([_patched(status="stub", query=None, todo={"query": "FROM x", "blockers": []})])
+
+
+def test_attackless_rule_must_not_stamp_technique():
+    ok = _patched(attack=[], query='FROM logs-dfir.x-* METADATA _id, _index, _version\n| EVAL rule.id = "x-1"',
+                  evidence={"shape": "line", "stamped_by": "query", "fields": ["rule.id"]})
+    rl.validate([ok])
+    with pytest.raises(ValueError, match="cannot be stamped"):
+        rl.validate([_patched(attack=[])])
+
+
+# ---- structural query checks -----------------------------------------------
+def _esql(query, **extra):
+    return _patched(query=query, **extra)
+
+
+def test_check_query_esql_shape():
+    assert rl.check_query(_patched()) == []
+    # missing METADATA on a non-aggregating query
+    probs = rl.check_query(_esql('FROM logs-dfir.x-*\n| WHERE a == 1\n| EVAL rule.id = "x-1", threat.technique.id = "T1055"'))
+    assert any("METADATA" in p for p in probs)
+    # aggregating query needs no METADATA but must declare the aggregate shape
+    agg = 'FROM logs-dfir.x-*\n| STATS n = COUNT(*) BY host.name\n| EVAL rule.id = "x-1", threat.technique.id = "T1055"'
+    assert any("aggregate" in p for p in rl.check_query(_esql(agg)))
+    assert rl.check_query(_esql(agg, evidence={"shape": "aggregate", "stamped_by": "query",
+                                               "fields": ["host.name", "n", "rule.id", "threat.technique.id"]})) == []
+    # not starting with FROM / wrong sources / unknown command
+    assert any("FROM" in p for p in rl.check_query(_esql("ROW a = 1")))
+    assert any("index declares" in p for p in rl.check_query(_esql(_BASE["query"].replace("logs-dfir.x-*", "logs-dfir.y-*"))))
+    assert any("unknown ES|QL command" in p for p in rl.check_query(_esql(_BASE["query"] + "\n| PROJECT a")))
+
+
+def test_check_query_promised_fields_must_be_stamped():
+    probs = rl.check_query(_patched(evidence={"shape": "line", "stamped_by": "query",
+                                              "fields": ["rule.id", "threat.technique.id", "threat.tactic.id"]}))
+    assert probs == ["evidence field 'threat.tactic.id' is promised but never stamped by the query"]
+
+
+def test_check_query_kql_leftovers_and_brackets():
+    probs = rl.check_query(_esql('FROM logs-dfir.x-* METADATA _id, _index, _version\n| WHERE tostring(a) == "1" =~ b\n| EVAL rule.id = "x-1", threat.technique.id = "T1055"'))
+    assert any("tostring(" in p for p in probs) and any("=~" in p for p in probs)
+    # DATE_DIFF( is not the KQL iff(
+    assert not any("iff(" in p for p in rl.check_query(
+        _esql(_BASE["query"].replace("a == 1", "DATE_DIFF(\"hour\", a, b) > 1"))))
+    assert any("unclosed" in p for p in rl.check_query(_esql(_BASE["query"].replace("== 1", "== (1"))))
+    assert any("unexpected" in p for p in rl.check_query(_esql(_BASE["query"].replace("== 1", "== 1)"))))
+    assert any("unterminated" in p for p in rl.check_query(_esql(_BASE["query"] + '\n| WHERE b == "open')))
+
+
+def test_check_query_ignores_bracket_and_pipe_characters_inside_strings():
+    q = (_BASE["query"] + '\n| WHERE TO_LOWER(a) RLIKE """.*(\\\\users\\\\|\\\\c[$]).*""" AND b != "(|["')
+    assert rl.check_query(_esql(q)) == []
+
+
+def test_check_query_eql_shape():
+    eql = _patched(language="eql", query='any where event.code == "1102"',
+                   evidence={"shape": "line", "stamped_by": "engine",
+                             "fields": ["kibana.alert.rule.threat"]})
+    assert rl.check_query(eql) == []
+    assert rl.check_query({**eql, "query": 'sequence by host.name [any where a == 1] [any where b == 2]'}) == []
+    assert any("<category> where" in p for p in rl.check_query({**eql, "query": 'event.code == "1102"'}))
+    # EQL cannot stamp: the evidence contract must say the engine does
+    bad = {**eql, "evidence": {"shape": "line", "stamped_by": "query", "fields": ["rule.id", "threat.technique.id"]}}
+    assert any("stamped_by" in p for p in rl.check_query(bad))
+
+
+# ---- loading from disk -----------------------------------------------------
+def test_load_reads_only_top_level_rule_files(tmp_path):
+    (tmp_path / "car-detections").mkdir()
+    (tmp_path / "car-detections" / "ignored.yml").write_text("id: nope\n")
+    (tmp_path / "x-1.yml").write_text(yaml.safe_dump(_BASE))
+    rules = rl.load(str(tmp_path))
+    assert [r["id"] for r in rules] == ["x-1"]
+    assert rules[0]["_path"].endswith("x-1.yml") and rules[0]["risk_score"] == 21
+    assert [r["id"] for r in rl.list_rules(str(tmp_path))] == ["x-1"]
+
+
+def test_load_rejects_non_mapping_and_bad_yaml(tmp_path):
+    (tmp_path / "x-1.yml").write_text("- just\n- a list\n")
+    with pytest.raises(ValueError, match="one YAML mapping"):
+        rl.load(str(tmp_path))
+    (tmp_path / "x-1.yml").write_text("id: [unclosed\n")
+    with pytest.raises(ValueError, match="not valid YAML"):
+        rl.load(str(tmp_path))
+
+
+def test_main_prints_summary_and_fails_on_bad_dir(tmp_path, capsys):
+    assert rl.main([]) == 0
+    out = capsys.readouterr().out
+    assert '"ported"' in out and '"win-eventlog-cleared"' in out
+    (tmp_path / "x-1.yml").write_text("id: Bad\n")
+    assert rl.main(["--rules-dir", str(tmp_path)]) == 1
+    assert "kebab-case" in capsys.readouterr().err
+
+
+# ---- the car-detections lookup index contract ------------------------------
+@pytest.fixture(scope="module")
+def car_contract():
+    return rl.load_car_detections()
+
+
+def test_car_detections_contract_validates(car_contract):
+    template, join_keys = car_contract
+    rl.validate_car_detections(template, join_keys)
+    assert template["template"]["settings"]["index.mode"] == "lookup"
+    assert join_keys["lookup_index"] == "car-detections"
+    assert {j["lookup_field"] for j in join_keys["join"]} == set(rl.CAR_JOIN_KEYS)
+    assert "LOOKUP JOIN car-detections ON event.id" in join_keys["example_query"]
+    assert "logs-car." in join_keys["example_query"]
+
+
+def test_car_detections_stamps_the_threat_fields(car_contract):
+    _template, join_keys = car_contract
+    stamped = set(join_keys["stamped_fields"])
+    assert {"threat.technique.id", "threat.tactic.id", "rule.id", "detection.id"} <= stamped
+
+
+def test_every_rule_joins_on_a_declared_key(rules, car_contract):
+    _template, join_keys = car_contract
+    keys = {j["lookup_field"] for j in join_keys["join"]}
+    for r in rules:
+        assert r["car_join"]["key"] in keys, r["id"]
+
+
+def test_validate_car_detections_rejects_drift(car_contract):
+    template, join_keys = (copy.deepcopy(c) for c in car_contract)
+    with pytest.raises(ValueError, match="index.mode"):
+        rl.validate_car_detections({**template, "template": {**template["template"], "settings": {}}}, join_keys)
+    bad = copy.deepcopy(join_keys)
+    bad["join"][0]["lookup_field"] = "guid"
+    with pytest.raises(ValueError, match="same field name"):
+        rl.validate_car_detections(template, bad)
+    bad = copy.deepcopy(join_keys)
+    bad["join"] = bad["join"][:1]
+    with pytest.raises(ValueError, match="CAR_JOIN_KEYS"):
+        rl.validate_car_detections(template, bad)
+    bad = copy.deepcopy(join_keys)
+    bad["example_query"] = "FROM logs-car.*-*"
+    with pytest.raises(ValueError, match="example_query"):
+        rl.validate_car_detections(template, bad)
+
+
+# ---- additive: the Kusto side is untouched ---------------------------------
+def test_kusto_registry_still_validates_and_loader_does_not_import_it():
+    import inspect
+    registry.validate()
+    # The rule set must stay loadable after Kusto retires (D1): the loader
+    # shares ids with the registry but never imports it.
+    src = inspect.getsource(rules_loader)
+    assert "from .registry" not in src and "import registry" not in src
+    assert not hasattr(rules_loader, "DETECTIONS")


### PR DESCRIPTION
## What

The Kusto detection registry re-expressed for **Elastic's own Detection Engine** as **rules-as-code data**, next to the existing Kusto path. Fully **additive**: `registry.py`, the runner, the emulator and `kusto/schema/50-detections.kql` are untouched and stay until Kusto/ADX retires at the end of phase 2 (decision **D1**). This is the enabler that makes that retirement possible.

- **`detect/rules/<id>.yml`** — one file per registry detection, reusing the registry id (tests pin the two id sets equal, so nothing is dropped silently). All 10 enumerated: **6 ported** to correct ES|QL/EQL (`win-eventlog-cleared` as EQL; `win-defender-tamper`, `win-service-suspicious-path`, `win-prefetch-dualuse-tool`, `zeek-notice-promoted`, `zeek-dns-oversized-query` as ES|QL, the DNS one as the `STATS` aggregate shape) and **4 explicit `status: stub`** (`vol-malfind-injection` + the three signature lanes) carrying the intended query as `todo.query`, concrete blockers, and the verbatim source KQL / matcher.
- **Tagged-evidence-line contract per rule (`evidence`)** — the alert **is** the matched evidence document: non-aggregating ES|QL reads `METADATA _id, _index, _version` and stamps `rule.*` / `threat.tactic.*` / `threat.technique.*` inline via `EVAL`; aggregate (`STATS`) and EQL (engine-stamped) shapes declared explicitly. Each rule declares its `car_join` (`event.id` | `process.entity_id`, direct/provenance) and an ECS←native `fields` block (the spec for the later ingest pipelines). Targets follow the foundation stream's `logs-dfir.<type>-*` / `logs-car.<object>-*` data streams.
- **`detect/rules/car-detections/`** — the "car-detections lookup index" contract as data: an index template (`index.mode: lookup`, strict mappings) + `join-keys.yml` (CAR `guid` → `event.id` on every object, `process.entity_id` on process; the reference `LOOKUP JOIN car-detections ON event.id` query).
- **`detect/rules_loader.py`** — loads + validates in `registry.validate()` style plus a structural query check (FROM over the declared streams, known commands, METADATA on non-aggregating queries, promised evidence fields actually stamped, no KQL leftovers). Does **not** import the registry, so the set outlives Kusto.
- **`detect/rules/README.md`** — the model, evidence semantics, LOOKUP JOIN, and a KQL→ES|QL/EQL coverage table. **`tests/test_rules.py`** — 52 tests.

## ansible-lint scope fix
`.ansible-lint` runs `--profile production` over the whole repo and auto-discovers the new rule YAML, failing on `yaml[line-length]` for long ES|QL lines. These are rule **data**, not ansible (own gate: `rules_loader.py` + `tests/test_rules.py`), so `python/get_sybers_dfir/detect/rules/` is added to `exclude_paths`, consistent with `data_store/`. ansible-lint still lints the collection + container ansible.

## Checks
```
pytest python/tests/test_rules.py python/tests/test_detect.py   -> 73 passed
./tests/run-checks.sh   -> passed, 0 failed   (ansible-lint green after the exclude)
```
CI (`checks` run #435) is green. Scope: `detect/rules/**`, `detect/rules_loader.py`, `tests/test_rules.py`, `.ansible-lint`. No Kusto/emulator changes, no `docker/**`, no `pyproject` edits.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu)_