### PR TITLE
stix: OpenCTI/CTI wiring — cti-* copy, indicator-match contract, sightings back (P4/S2)

### DIFF
--- a/python/get_sybers_dfir/detect/rules/README.md
+++ b/python/get_sybers_dfir/detect/rules/README.md
@@ -130,6 +130,32 @@ fields against the CAR row's flattened native bag (`via: provenance`) — e.g.
 `log.file.path` + `winlog.record_id` for an EVTX-sourced rule. Requires
 Elasticsearch 9.x (`LOOKUP JOIN` GA; technical preview in 8.18); Basic licence.
 
+## The CTI indicator-match rule (`cti/`)
+
+[`cti/cti-indicator-match.yml`](cti/cti-indicator-match.yml) is the one
+Detection Engine **`threat_match`** rule: it compares `logs-dfir.*` /
+`logs-car.*` evidence fields (`source.ip`, `destination.ip`, `dns.question.name`,
+`url.original`, `file.hash.*`, `process.hash.*`, `registry.key`) with the
+`threat.indicator.*` atomics of the **`cti-*`** index — the Elasticsearch copy
+of OpenCTI's STIX indicators that `dxdfir stix pull` writes
+([`stix/cti/cti.index-template.json`](../../stix/cti/cti.index-template.json);
+which STIX comparison lands where is
+[`stix/cti/pattern-mapping.yml`](../../stix/cti/pattern-mapping.yml)). Same
+file shape as the rules above plus the threat-match keys: `type: threat_match`,
+`language: kuery` (Elastic's name for the Kibana query language), `threat_index`,
+`threat_query`, `threat_indicator_path`, `threat_mapping` (each list item an OR
+alternative, its entries ANDed). The alert is the matched evidence document
+plus the engine's `threat.enrichments[]` (the indicator's fields and
+`matched.{field,atomic,id,index}`), which `dxdfir stix sightings` turns into
+STIX sightings of the platform's own indicator.
+
+It is Byakugan-native, not a registry port, so it lives beside the top-level
+rule set (which the tests pin to the Kusto registry) rather than in it:
+[`rules_loader.load_cti_contract()` / `validate_indicator_match()`](../rules_loader.py)
+check it against the cti-* template — every `threat_mapping` value must be a
+field the copy fills, every `threat_index` pattern one the template covers —
+and the loader's CLI validates it alongside the rule set.
+
 ## Coverage: KQL -> ES|QL / EQL
 
 Every registry detection, ported or stub (the tests fail if one goes missing):

--- a/python/get_sybers_dfir/detect/rules/cti/cti-indicator-match.yml
+++ b/python/get_sybers_dfir/detect/rules/cti/cti-indicator-match.yml
@@ -1,0 +1,91 @@
+# Byakugan Elastic detection rule (rules-as-code), indicator-match flavour.
+# Model: ../README.md ("The CTI indicator-match rule"). Validated by
+# rules_loader.validate_indicator_match() against the cti-* index template
+# (python/get_sybers_dfir/stix/cti/cti.index-template.json). Not a registry
+# port — CTI matching is Byakugan-native — so it lives beside the top-level
+# rule set (which the tests pin to the Kusto registry) rather than in it.
+id: cti-indicator-match
+name: CTI indicator match (OpenCTI indicator seen in evidence)
+type: threat_match
+status: ported
+severity: high
+attack: []            # the technique rides on the matched indicator, not on the rule
+tactics: []
+# Elastic calls the Kibana query language "kuery" in rule JSON — not the Kusto
+# KQL the other rules keep in their source column.
+language: kuery
+# Every Byakugan evidence stream: delivered native evidence and the CAR objects.
+index: [logs-dfir.*-*, logs-car.*-*]
+# The evidence side needs no pre-filter: the engine builds the match query from
+# the indicators themselves (one should-clause per threat_mapping entry) and
+# ANDs it with this.
+query: "*:*"
+# The cti-* copy of OpenCTI's indicators (dxdfir stix pull): one document per
+# STIX indicator, _id = the STIX id, atomic values under threat.indicator.*.
+threat_index: [cti-*]
+threat_language: kuery
+# A revoked indicator stays in the copy (so a re-pull overwrites the earlier
+# version) but never matches; neither does one whose valid_until has passed.
+# A missing valid_until means no expiry — NOT <range> keeps field-less documents.
+threat_query: 'not stix.revoked:true and not stix.valid_until < "now"'
+threat_indicator_path: threat.indicator
+# Each list item is an OR alternative; the entries inside one item are ANDed.
+# `field` is the evidence-side ECS field, `value` the indicator-side field the
+# copy fills. stix/cti/pattern-mapping.yml decides which STIX comparison lands
+# where; the tests pin every `value` here to that mapping and to the template.
+threat_mapping:
+  - entries: [{field: source.ip, type: mapping, value: threat.indicator.ip}]
+  - entries: [{field: destination.ip, type: mapping, value: threat.indicator.ip}]
+  - entries: [{field: dns.question.name, type: mapping, value: threat.indicator.url.domain}]
+  - entries: [{field: destination.domain, type: mapping, value: threat.indicator.url.domain}]
+  - entries: [{field: url.domain, type: mapping, value: threat.indicator.url.domain}]
+  - entries: [{field: url.original, type: mapping, value: threat.indicator.url.original}]
+  - entries: [{field: url.full, type: mapping, value: threat.indicator.url.original}]
+  - entries: [{field: file.hash.md5, type: mapping, value: threat.indicator.file.hash.md5}]
+  - entries: [{field: file.hash.sha1, type: mapping, value: threat.indicator.file.hash.sha1}]
+  - entries: [{field: file.hash.sha256, type: mapping, value: threat.indicator.file.hash.sha256}]
+  - entries: [{field: process.hash.md5, type: mapping, value: threat.indicator.file.hash.md5}]
+  - entries: [{field: process.hash.sha1, type: mapping, value: threat.indicator.file.hash.sha1}]
+  - entries: [{field: process.hash.sha256, type: mapping, value: threat.indicator.file.hash.sha256}]
+  - entries: [{field: registry.key, type: mapping, value: threat.indicator.registry.key}]
+items_per_search: 9000
+concurrent_searches: 1
+# The alert is the matched evidence document plus what the engine adds: its
+# kibana.alert.* identity and one threat.enrichments[] item per matched
+# indicator — the indicator's threat.indicator.* copied whole, plus matched.*
+# (which evidence field held which value, and the cti-* document it came from).
+# The sightings push (dxdfir stix sightings) reads enrichments.indicator.id and
+# matched.atomic: those two are the round-trip contract back to OpenCTI.
+evidence:
+  shape: line
+  stamped_by: engine
+  fields:
+    - kibana.alert.rule.rule_id
+    - kibana.alert.rule.name
+    - kibana.alert.uuid
+    - kibana.alert.original_time
+    - threat.enrichments.indicator.id
+    - threat.enrichments.indicator.type
+    - threat.enrichments.indicator.provider
+    - threat.enrichments.indicator.marking.tlp
+    - threat.enrichments.matched.atomic
+    - threat.enrichments.matched.field
+    - threat.enrichments.matched.id
+    - threat.enrichments.matched.index
+    - threat.enrichments.matched.type
+    - threat.enrichments.feed.name
+# A match on a logs-car.* line carries the CAR guid as event.id already. (A
+# match on native logs-dfir.* evidence is a lead on that line, not a CAR row.)
+car_join:
+  key: event.id
+  via: direct
+fields:
+  - {ecs: source.ip, native: "id.orig_h (zeek) / src_ip (suricata, CAR flow)"}
+  - {ecs: destination.ip, native: "id.resp_h (zeek) / dest_ip (suricata, CAR flow)"}
+  - {ecs: dns.question.name, native: "query (zeek dns)"}
+  - {ecs: url.original, native: "uri (zeek http)"}
+  - {ecs: file.hash.md5, native: "md5_hash (CAR file)"}
+  - {ecs: file.hash.sha1, native: "sha1_hash (CAR file)"}
+  - {ecs: file.hash.sha256, native: "sha256_hash (CAR file)"}
+  - {ecs: process.hash.md5, native: "md5_hash (CAR process)"}
+  - {ecs: registry.key, native: "key (CAR registry)"}

--- a/python/get_sybers_dfir/detect/rules_loader.py
+++ b/python/get_sybers_dfir/detect/rules_loader.py
@@ -59,6 +59,24 @@ RULES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "rules")
 CAR_DETECTIONS_DIR = os.path.join(RULES_DIR, "car-detections")
 CAR_DETECTIONS_TEMPLATE = os.path.join(CAR_DETECTIONS_DIR, "car-detections.index-template.json")
 CAR_DETECTIONS_JOIN_KEYS = os.path.join(CAR_DETECTIONS_DIR, "join-keys.yml")
+# The CTI indicator-match rule contract (rules/cti/): one Detection Engine
+# threat_match rule as data, checked against the cti-* index template the
+# exchange package (stix/cti) writes — by path only; nothing is imported.
+CTI_DIR = os.path.join(RULES_DIR, "cti")
+CTI_RULE = os.path.join(CTI_DIR, "cti-indicator-match.yml")
+CTI_TEMPLATE = os.path.normpath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir, "stix", "cti", "cti.index-template.json"))
+THREAT_MATCH = "threat_match"
+# Elastic's names for the Kibana query languages a threat_match rule speaks
+# (not the Kusto "KQL" the rules' source column keeps).
+KIBANA_LANGUAGES = ("kuery", "lucene")
+THREAT_MAPPING_TYPES = ("mapping",)
+THREAT_MATCH_REQUIRED = ("id", "name", "type", "status", "severity", "attack", "language", "index",
+                         "query", "threat_index", "threat_language", "threat_indicator_path",
+                         "threat_mapping", "evidence", "car_join")
+# What the sightings push (stix/cti/sightings.py) reads off an indicator-match
+# alert: the platform's indicator id and the value that matched.
+ROUND_TRIP_FIELDS = ("threat.enrichments.indicator.id", "threat.enrichments.matched.atomic")
 
 # Elastic's severity set (the registry's "info" maps to "low") and the Detection
 # Engine's canonical risk score for each — used when a rule declares none.
@@ -340,7 +358,7 @@ def validate(rules: list[dict] | None = None) -> None:
                 raise ValueError(prefix + "a stub needs a non-empty todo.blockers list (why it is a stub)")
 
 
-def _validate_evidence(prefix: str, r: dict) -> None:
+def _validate_evidence(prefix: str, r: dict, engine_prefixes: tuple[str, ...] = ("kibana.alert.",)) -> None:
     ev = r.get("evidence")
     if not isinstance(ev, dict):
         raise ValueError(prefix + "evidence must be a mapping (shape, stamped_by, fields)")
@@ -351,8 +369,9 @@ def _validate_evidence(prefix: str, r: dict) -> None:
     fields = ev.get("fields")
     if not _str_list(fields) or not fields or not all(_FIELD_RE.match(f) for f in fields):
         raise ValueError(prefix + "evidence.fields must be a non-empty list of field paths")
-    if ev["stamped_by"] == "engine" and not all(f.startswith("kibana.alert.") for f in fields):
-        raise ValueError(prefix + "engine-stamped evidence fields are the Detection Engine's kibana.alert.* fields")
+    if ev["stamped_by"] == "engine" and not all(f.startswith(engine_prefixes) for f in fields):
+        raise ValueError(prefix + "engine-stamped evidence fields are the Detection Engine's "
+                         + " / ".join(p + "*" for p in engine_prefixes) + " fields")
     if ev["stamped_by"] == "query":
         has_technique = "threat.technique.id" in fields
         if r.get("attack") and not has_technique:
@@ -480,6 +499,166 @@ def validate_car_detections(template: dict, join_keys: dict) -> None:
         raise ValueError("car-detections: example_query must LOOKUP JOIN the lookup index ON a join key")
 
 
+# ------------------------------------------------- the CTI indicator-match contract
+def load_cti_contract(rule_path: str = CTI_RULE, template_path: str = CTI_TEMPLATE) -> tuple[dict, dict]:
+    """The indicator-match rule (rules/cti/) and the cti-* index template it
+    reads, both as data: ``(rule, template)``. The rule gets ``_path`` and a
+    defaulted ``risk_score`` exactly as :func:`load` gives the rule set."""
+    with open(rule_path, encoding="utf-8") as fh:
+        try:
+            rule = yaml.safe_load(fh)
+        except yaml.YAMLError as e:
+            raise ValueError(f"{rule_path}: not valid YAML: {e}") from e
+    if not isinstance(rule, dict):
+        raise ValueError(f"{rule_path}: a rule file must be exactly one YAML mapping")
+    rule["_path"] = rule_path
+    if "risk_score" not in rule and rule.get("severity") in RISK_SCORES:
+        rule["risk_score"] = RISK_SCORES[rule["severity"]]
+    with open(template_path, encoding="utf-8") as fh:
+        template = json.load(fh)
+    return rule, template
+
+
+def _covered(pattern: str, index_patterns: list[str]) -> bool:
+    """True when ``pattern`` is one of the template's index patterns, or a
+    name / narrower glob one of them matches (glob -> regex as above)."""
+    return any(pattern == p or re.fullmatch(re.escape(p).replace(r"\*", ".*"), pattern)
+               for p in index_patterns)
+
+
+def _mapping_node(template: dict, path: str) -> dict | None:
+    """The template's mapping definition at dotted ``path``, or None."""
+    node: dict = {"properties": ((template.get("template") or {}).get("mappings") or {}).get("properties") or {}}
+    for seg in path.split("."):
+        nxt = (node.get("properties") or {}).get(seg)
+        if not isinstance(nxt, dict):
+            return None
+        node = nxt
+    return node
+
+
+def validate_indicator_match(rule: dict, template: dict | None = None) -> None:
+    """Fail fast on a malformed indicator-match rule (``rules/cti/``) — the
+    Detection Engine's ``threat_match`` shape: a Kibana-language query over
+    the evidence streams, the threat index, the indicator path and the
+    field-to-field mapping — with :func:`validate`'s rigor (first problem
+    raises ValueError prefixed with the rule id). Given the cti-* index
+    ``template``, every indicator-side field the mapping reads must be mapped
+    there under the indicator path, and every ``threat_index`` pattern must
+    be one the template covers."""
+    if not isinstance(rule, dict):
+        raise ValueError("indicator-match rule: a rule must be a mapping")
+    rid = rule.get("id", "")
+    prefix = f"rule {rid!r}: "
+    if not isinstance(rid, str) or not _ID_RE.match(rid):
+        raise ValueError(prefix + "id must be non-empty kebab-case")
+    path = rule.get("_path")
+    if path and os.path.splitext(os.path.basename(path))[0] != rid:
+        raise ValueError(prefix + f"file must be named <id>.yml, not {os.path.basename(path)}")
+    if rule.get("type") != THREAT_MATCH:
+        raise ValueError(prefix + f"type must be {THREAT_MATCH!r} (an indicator-match rule)")
+    missing = [k for k in THREAT_MATCH_REQUIRED if k not in rule]
+    if missing:
+        raise ValueError(prefix + f"missing required field(s) {missing}")
+    name = rule.get("name")
+    if not isinstance(name, str) or not name.strip() or '"' in name or "\\" in name:
+        raise ValueError(prefix + "name must be non-empty, without quotes/backslashes")
+    if rule.get("status") != "ported" or "todo" in rule:
+        raise ValueError(prefix + "an indicator-match rule has no stub form (the indicators are the query): "
+                         "status must be 'ported', without a todo block")
+    if rule.get("severity") not in SEVERITIES:
+        raise ValueError(prefix + f"severity must be one of {SEVERITIES}")
+    score = rule.get("risk_score", RISK_SCORES[rule["severity"]])
+    if not isinstance(score, int) or isinstance(score, bool) or not 0 <= score <= 100:
+        raise ValueError(prefix + "risk_score must be an integer 0..100")
+    attack = rule.get("attack")
+    if not isinstance(attack, list) or not all(
+            isinstance(t, str) and _TECHNIQUE_RE.match(t) for t in attack):
+        raise ValueError(prefix + "attack must be a list of ATT&CK technique ids (T1234 / T1234.001)")
+    tactics = rule.get("tactics", [])
+    if not isinstance(tactics, list) or not all(
+            isinstance(t, str) and _TACTIC_RE.match(t) for t in tactics):
+        raise ValueError(prefix + "tactics must be a list of ATT&CK tactic ids (TA0001)")
+    for key in ("language", "threat_language"):
+        if rule.get(key) not in KIBANA_LANGUAGES:
+            raise ValueError(prefix + f"{key} must be one of {KIBANA_LANGUAGES} (Elastic's names for the Kibana query languages)")
+    index = rule.get("index")
+    if not _str_list(index) or not index or not all(_INDEX_RE.match(i) for i in index):
+        raise ValueError(prefix + "index must be a non-empty list of logs-<dataset>-* data stream patterns")
+    for key in ("query", "threat_query"):
+        q = rule.get(key)
+        if key == "threat_query" and q is None:
+            continue                                    # optional: no filter on the indicators
+        if not isinstance(q, str) or not q.strip():
+            raise ValueError(prefix + f"{key} must be a non-empty Kibana-language query")
+        if re.match(r"^\s*FROM\s", q, re.I):
+            raise ValueError(prefix + f"{key} is ES|QL; an indicator-match rule speaks {KIBANA_LANGUAGES}")
+        for leftover in _KQL_LEFTOVERS:
+            m = leftover.search(q)
+            if m:
+                raise ValueError(prefix + f"{key}: KQL left-over {m.group(0)!r} in an Elastic query")
+        try:
+            bad = _unbalanced(_strip_strings(q))
+        except ValueError as e:
+            bad = str(e)
+        if bad:
+            raise ValueError(prefix + f"{key}: {bad}")
+    threat_index = rule.get("threat_index")
+    if not _str_list(threat_index) or not threat_index:
+        raise ValueError(prefix + "threat_index must be a non-empty list of index patterns (cti-*)")
+    if template is not None:
+        patterns = template.get("index_patterns")
+        if not _str_list(patterns) or not patterns:
+            raise ValueError(prefix + "the cti-* template has no index_patterns")
+        for ti in threat_index:
+            if not _covered(ti, patterns):
+                raise ValueError(prefix + f"threat_index {ti!r} is not covered by the cti-* template's index_patterns {patterns}")
+    tip = rule.get("threat_indicator_path")
+    if not isinstance(tip, str) or not _FIELD_RE.match(tip):
+        raise ValueError(prefix + "threat_indicator_path must be a field path (threat.indicator)")
+    mapped: set[str] | None = None
+    if template is not None:
+        node = _mapping_node(template, tip)
+        if not node or not isinstance(node.get("properties"), dict):
+            raise ValueError(prefix + f"threat_indicator_path {tip} is not mapped as an object in the cti-* template")
+        mapped = _mapped_fields(((template.get("template") or {}).get("mappings") or {}).get("properties"))
+    groups = rule.get("threat_mapping")
+    if not isinstance(groups, list) or not groups:
+        raise ValueError(prefix + "threat_mapping must be a non-empty list of {entries: [...]} groups")
+    seen_pairs: set[tuple[str, str]] = set()
+    for g in groups:
+        entries = g.get("entries") if isinstance(g, dict) else None
+        if not isinstance(entries, list) or not entries:
+            raise ValueError(prefix + "each threat_mapping group needs a non-empty entries list")
+        for e in entries:
+            if not isinstance(e, dict) or e.get("type") not in THREAT_MAPPING_TYPES:
+                raise ValueError(prefix + "threat_mapping entries are {field, type: mapping, value}")
+            field, value = e.get("field"), e.get("value")
+            if not isinstance(field, str) or not _FIELD_RE.match(field):
+                raise ValueError(prefix + f"threat_mapping field {field!r} must be an evidence field path")
+            if not isinstance(value, str) or not _FIELD_RE.match(value) or not value.startswith(tip + "."):
+                raise ValueError(prefix + f"threat_mapping value {value!r} must be a field under {tip}.")
+            if mapped is not None and value not in mapped:
+                raise ValueError(prefix + f"threat_mapping value {value} is not mapped in the cti-* template")
+            if (field, value) in seen_pairs:
+                raise ValueError(prefix + f"threat_mapping maps {field} -> {value} twice")
+            seen_pairs.add((field, value))
+    for key in ("items_per_search", "concurrent_searches"):
+        v = rule.get(key)
+        if v is not None and (not isinstance(v, int) or isinstance(v, bool) or v < 1):
+            raise ValueError(prefix + f"{key} must be a positive integer")
+    _validate_evidence(prefix, rule, engine_prefixes=("kibana.alert.", "threat.enrichments."))
+    ev = rule["evidence"]
+    if ev.get("stamped_by") != "engine" or ev.get("shape") != "line":
+        raise ValueError(prefix + "an indicator match is one engine-enriched alert per matched evidence "
+                         "document: evidence.shape line, stamped_by engine")
+    if not set(ROUND_TRIP_FIELDS) <= set(ev["fields"]):
+        raise ValueError(prefix + "evidence.fields must carry the round-trip pair the sightings push reads: "
+                         + ", ".join(ROUND_TRIP_FIELDS))
+    _validate_car_join(prefix, rule.get("car_join"))
+    _validate_fields(prefix, rule.get("fields"))
+
+
 # ---------------------------------------------------------------------- summary
 def summary(rules: list[dict]) -> dict:
     by_language: dict[str, int] = {}
@@ -503,11 +682,17 @@ def main(argv: list[str] | None = None) -> int:
     # Validate the car-detections contract from the SAME rules dir, so a custom
     # --rules-dir is checked against its own car-detections/, not the built-in one.
     car_dir = os.path.join(args.rules_dir, "car-detections")
+    cti_rule = os.path.join(args.rules_dir, "cti", "cti-indicator-match.yml")
     try:
         rules = list_rules(args.rules_dir)
         validate_car_detections(*load_car_detections(
             os.path.join(car_dir, "car-detections.index-template.json"),
             os.path.join(car_dir, "join-keys.yml")))
+        # The CTI indicator-match contract is one per deployment, not per
+        # detection: a rules dir that carries it is checked against the
+        # built-in cti-* template; one that does not is not made to.
+        if os.path.isfile(cti_rule):
+            validate_indicator_match(*load_cti_contract(cti_rule, CTI_TEMPLATE))
     except (ValueError, OSError) as e:
         print(json.dumps({"tool": "rules", "error": str(e)}), file=sys.stderr)
         return 1

--- a/python/get_sybers_dfir/stix/README.md
+++ b/python/get_sybers_dfir/stix/README.md
@@ -58,9 +58,54 @@ the push is tested with a stub and no platform — see
 
 Config precedence: file < environment (`DXDFIR_OPENCTI_URL`,
 `DXDFIR_OPENCTI_TOKEN`, `DXDFIR_OPENCTI_CONNECTOR_ID`, `DXDFIR_STIX_CASE`,
-`DXDFIR_STIX_TLP`, `DXDFIR_STIX_RULES_DIR`) < flags. See
+`DXDFIR_STIX_TLP`, `DXDFIR_STIX_RULES_DIR`, `DXDFIR_CTI_INDEX`) < flags. See
 [`config.py`](config.py) for the file shape.
 
+## CTI: OpenCTI indicators in, sightings back out (`pull` / `sightings`)
+
+OpenCTI stays the wire; the matching is Elastic's own indicator-match rule.
+The CTI direction runs through the same client and the same stubbed transport:
+
 ```bash
-cd python && python -m pytest tests/test_stix_export.py
+dxdfir stix pull --out cti.ndjson [--since 2026-08-01T00:00:00Z] [--bundle-out pulled.json]
+curl -sS -XPOST "$ES/_bulk" -H 'Content-Type: application/x-ndjson' --data-binary @cti.ndjson
+dxdfir stix sightings --alerts alerts.json --case CASE-17 --push
+```
+
+1. **Pull** — `OpenCTIClient.pull_indicators()` pages the platform's STIX 2.1
+   indicators (with the markings and creator identities they reference) into
+   one bundle; `--since` makes it incremental (`modified` after the watermark).
+2. **Copy** — [`cti/indicators.py`](cti/indicators.py) breaks every pattern
+   into its `=` comparisons and lands each value under the ECS
+   `threat.indicator.*` field that [`cti/pattern-mapping.yml`](cti/pattern-mapping.yml)
+   names (`[ipv4-addr:value = '…']` -> `threat.indicator.ip`,
+   `file:hashes.'SHA-256'` -> `threat.indicator.file.hash.sha256`, …), plus
+   `threat.indicator.{id,type,name,confidence,provider,marking.tlp,…}`,
+   `stix.{pattern,valid_from,valid_until,revoked,…}` and
+   `opencti.{id,score,detection}`. Out come `_bulk` lines keyed on the STIX id
+   (`_id`, so a re-pull upserts) for the `cti-*` index that
+   [`cti/cti.index-template.json`](cti/cti.index-template.json) describes
+   (`PUT _index_template/cti`; strict mapping — the copy refuses to emit a
+   field the template does not map). YARA/Sigma patterns, CIDRs and unmapped
+   observables are skipped and counted. `--from-bundle` normalises an
+   already-pulled bundle offline, no platform needed.
+3. **Match** — the indicator-match rule
+   [`detect/rules/cti/cti-indicator-match.yml`](../detect/rules/cti/cti-indicator-match.yml)
+   compares `logs-dfir.*` / `logs-car.*` evidence fields with `threat.indicator.*`
+   (`threat_mapping`); its alerts carry `threat.enrichments[]` — the indicator's
+   fields and `matched.{field,atomic,id,index}`.
+4. **Sightings back** — [`cti/sightings.py`](cti/sightings.py) turns those
+   alerts into one `sighting` per (indicator, host, matched value) whose
+   `sighting_of_ref` is the platform's own indicator id (the indicator is not
+   re-emitted), the matched value as the spec's SCO in an `observed-data`, the
+   host as `where_sighted_refs`, alerts of the same match collapsed into
+   `count`; case-scoped ids, pushed through `push_bundle`.
+
+`cti.index` / `DXDFIR_CTI_INDEX` / `--index` names the concrete `cti-*` index
+the bulk lines target (default `cti-opencti`). Both verbs are exercised in
+[`test_cti.py`](../../tests/test_cti.py) against recording transports — no
+platform, no Elasticsearch, no secrets.
+
+```bash
+cd python && python -m pytest tests/test_stix_export.py tests/test_cti.py
 ```

--- a/python/get_sybers_dfir/stix/__init__.py
+++ b/python/get_sybers_dfir/stix/__init__.py
@@ -24,15 +24,24 @@ OpenCTI through a thin client whose transport is an interface, so the exchange
 is unit-testable without a live platform (:mod:`.opencti`). Endpoint and token
 come from the environment / a config file, never from the tree.
 
+The CTI direction runs through the same client (:mod:`.cti`): OpenCTI's STIX
+indicators are pulled and copied into the Elastic ``cti-*`` index — atomics
+under ECS ``threat.indicator.*`` — for Elastic's own indicator-match rule to
+flag evidence against, and the alerts that rule raises go back as sightings of
+the platform's indicators. The engine is Elastic's; OpenCTI is the wire.
+
     dxdfir stix export --hits detections.jsonl --bundle piiat.json --out bundle.json [--push]
+    dxdfir stix pull --out cti.ndjson
+    dxdfir stix sightings --alerts alerts.json --out sightings.json [--push]
 """
 from .config import StixConfig, load_config
 from .export import build_bundle, run_export, validate_bundle
 from .hits import Hit, hit_from_document, read_hits
-from .opencti import OpenCTIClient, PushResult, Transport
+from .opencti import OpenCTIClient, PullResult, PushResult, Transport
+from .cti import run_pull, run_sightings, to_cti_docs
 
 __all__ = [
-    "Hit", "OpenCTIClient", "PushResult", "StixConfig", "Transport",
+    "Hit", "OpenCTIClient", "PullResult", "PushResult", "StixConfig", "Transport",
     "build_bundle", "hit_from_document", "load_config", "read_hits",
-    "run_export", "validate_bundle",
+    "run_export", "run_pull", "run_sightings", "to_cti_docs", "validate_bundle",
 ]

--- a/python/get_sybers_dfir/stix/cli.py
+++ b/python/get_sybers_dfir/stix/cli.py
@@ -1,9 +1,11 @@
 """``dxdfir stix`` — the exchange verbs (Typer sub-app registered by ``cli.py``).
 
     dxdfir stix export --hits detections.jsonl [--bundle piiat.json] --out bundle.json [--push]
+    dxdfir stix pull --out cti.ndjson [--since 2026-01-01T00:00:00Z]        # OpenCTI -> cti-* copy
+    dxdfir stix sightings --alerts alerts.json --out sightings.json [--push]  # matches -> OpenCTI
 
-Exit codes: 0 exported (and pushed, if asked); 1 the bundle failed validation
-or the push was refused; 2 bad input / missing configuration.
+Exit codes: 0 done (and pushed, if asked); 1 the bundle failed validation, the
+push was refused, or the pull was; 2 bad input / missing configuration.
 """
 from __future__ import annotations
 
@@ -15,7 +17,9 @@ import typer
 
 from . import export as _export
 from .config import load_config
+from .cti import run_pull, run_sightings
 from .objects import TLP_LEVELS
+from .opencti import DEFAULT_PAGE_SIZE
 
 app = typer.Typer(
     help="STIX 2.1 exchange — detections as sightings/indicators, PIIAT bundles passed through, optional OpenCTI push.",
@@ -68,6 +72,120 @@ def export(
             cfg, [str(p) for p in hits or []], [str(p) for p in bundle or []])
     except (OSError, ValueError) as e:
         typer.secho(f"export failed: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2) from None
+
+    indent = None if compact else 2
+    to_stdout = not cfg.out and summary["ok"]
+    if to_stdout:                       # the bundle IS the output; the summary goes to stderr
+        sys.stdout.write(json.dumps(bundle_doc, indent=indent, ensure_ascii=False, default=str) + "\n")
+        sys.stderr.write(json.dumps(summary, indent=indent, ensure_ascii=False, default=str) + "\n")
+    else:
+        sys.stdout.write(json.dumps(summary, indent=indent, ensure_ascii=False, default=str) + "\n")
+    if not summary["ok"]:
+        for problem in summary["validation"]["errors"]:
+            typer.secho(f"   • {problem}", fg=typer.colors.RED, err=True)
+        if summary.get("push") and not summary["push"]["ok"]:
+            typer.secho(f"   • {summary['push']['message']}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def pull(
+    out: Path = typer.Option(
+        None, "--out", help="Write the cti-* copy as Elasticsearch _bulk lines (NDJSON) here (default: stdout)."),
+    bundle_out: Path = typer.Option(
+        None, "--bundle-out",
+        help="Also keep the pulled STIX 2.1 indicator bundle here (re-normalise it later with --from-bundle)."),
+    from_bundle: Path = typer.Option(
+        None, "--from-bundle",
+        help="Normalise an already-pulled STIX bundle instead of contacting OpenCTI (no endpoint/token needed)."),
+    index: str = typer.Option(
+        None, "--index",
+        help="The cti-* index the bulk lines target (default: config cti.index / $DXDFIR_CTI_INDEX, else cti-opencti)."),
+    since: str = typer.Option(
+        None, "--since", help="Incremental: only indicators modified after this timestamp (e.g. 2026-01-01T00:00:00Z)."),
+    page_size: int = typer.Option(DEFAULT_PAGE_SIZE, "--page-size", help="Indicators per GraphQL page."),
+    max_pages: int = typer.Option(None, "--max-pages", help="Stop after this many pages (safety valve)."),
+    config: Path = typer.Option(None, "--config", help="JSON/YAML config file (see stix/README.md)."),
+    compact: bool = typer.Option(False, "--compact", help="Single-line JSON summary instead of indented."),
+) -> None:
+    """Pull OpenCTI's STIX 2.1 indicators and write the cti-* copy that Elastic's
+    indicator-match rule reads (atomics under threat.indicator.*), as _bulk lines keyed
+    on the STIX id. Endpoint/token from $DXDFIR_OPENCTI_URL / $DXDFIR_OPENCTI_TOKEN or the
+    config file — never flags.
+    """
+    try:
+        cfg = load_config(str(config) if config else None, cti_index=index)
+    except (OSError, ValueError) as e:
+        typer.secho(f"bad config: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2) from None
+    if not from_bundle and not (cfg.opencti_url and cfg.opencti_token):
+        typer.secho("pull needs the OpenCTI endpoint AND token: set $DXDFIR_OPENCTI_URL and "
+                    "$DXDFIR_OPENCTI_TOKEN (or opencti.url / opencti.token in --config) — or give "
+                    "--from-bundle to normalise an already-pulled bundle offline.",
+                    fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    try:
+        summary, lines = run_pull(
+            cfg, out=str(out) if out else None, bundle_out=str(bundle_out) if bundle_out else None,
+            from_bundle=str(from_bundle) if from_bundle else None, since=since,
+            page_size=page_size, max_pages=max_pages)
+    except (OSError, ValueError) as e:
+        typer.secho(f"pull failed: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2) from None
+
+    indent = None if compact else 2
+    if not out and summary["ok"]:       # the bulk lines ARE the output; the summary goes to stderr
+        sys.stdout.write("".join(line + "\n" for line in lines))
+        sys.stderr.write(json.dumps(summary, indent=indent, ensure_ascii=False, default=str) + "\n")
+    else:
+        sys.stdout.write(json.dumps(summary, indent=indent, ensure_ascii=False, default=str) + "\n")
+    if not summary["ok"]:
+        for problem in summary["validation"]["errors"]:
+            typer.secho(f"   • {problem}", fg=typer.colors.RED, err=True)
+        if summary.get("pull") and not summary["pull"].get("ok", True):
+            typer.secho(f"   • {summary['pull']['message']}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def sightings(
+    alerts: list[Path] = typer.Option(
+        None, "--alerts",
+        help="Indicator-match alerts: an Elasticsearch _search response over .alerts-security.alerts-*, "
+             "a JSON array, one document, or JSON Lines (repeatable)."),
+    out: Path = typer.Option(None, "--out", help="Write the sightings bundle here (default: config `out`, else stdout)."),
+    config: Path = typer.Option(None, "--config", help="JSON/YAML config file (see stix/README.md)."),
+    case: str = typer.Option(None, "--case", help="Case id scoping the sighting ids (default: the alerts' rule execution id)."),
+    tlp: str = typer.Option(None, "--tlp", help="TLP marking on exported objects: " + "|".join(TLP_LEVELS) + "|none."),
+    push: bool = typer.Option(
+        False, "--push",
+        help="Also push to OpenCTI (endpoint/token from $DXDFIR_OPENCTI_URL / $DXDFIR_OPENCTI_TOKEN "
+             "or the config file — never flags)."),
+    compact: bool = typer.Option(False, "--compact", help="Single-line JSON output instead of indented."),
+) -> None:
+    """Turn indicator-match alerts into STIX 2.1 sightings of the OpenCTI indicators they
+    matched (sighting_of_ref = the platform's own indicator id), write the bundle,
+    optionally push it back.
+    """
+    if not alerts:
+        typer.secho("nothing to sight: give --alerts", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    try:
+        cfg = load_config(str(config) if config else None, case_id=case, tlp=tlp,
+                          out=str(out) if out else None, push=True if push else None)
+    except (OSError, ValueError) as e:
+        typer.secho(f"bad config: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2) from None
+    if cfg.push and not (cfg.opencti_url and cfg.opencti_token):
+        typer.secho("--push needs the OpenCTI endpoint AND token: set $DXDFIR_OPENCTI_URL and "
+                    "$DXDFIR_OPENCTI_TOKEN (or opencti.url / opencti.token in --config).",
+                    fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    try:
+        summary, bundle_doc = run_sightings(cfg, [str(p) for p in alerts])
+    except (OSError, ValueError) as e:
+        typer.secho(f"sightings failed: {e}", fg=typer.colors.RED, err=True)
         raise typer.Exit(2) from None
 
     indent = None if compact else 2

--- a/python/get_sybers_dfir/stix/config.py
+++ b/python/get_sybers_dfir/stix/config.py
@@ -18,6 +18,8 @@ Config file shape (every key optional)::
       url: https://opencti.example.internal
       token: ...                 # prefer DXDFIR_OPENCTI_TOKEN
       connector_id: ...          # optional; a deterministic default otherwise
+    cti:
+      index: cti-opencti         # the cti-* index `dxdfir stix pull` writes for
 """
 from __future__ import annotations
 
@@ -36,15 +38,18 @@ ENV_CONNECTOR_ID = "DXDFIR_OPENCTI_CONNECTOR_ID"
 ENV_CASE = "DXDFIR_STIX_CASE"
 ENV_TLP = "DXDFIR_STIX_TLP"
 ENV_RULES_DIR = "DXDFIR_STIX_RULES_DIR"
+ENV_CTI_INDEX = "DXDFIR_CTI_INDEX"
+DEFAULT_CTI_INDEX = "cti-opencti"
 
 _ENV_KEYS = {ENV_URL: "opencti_url", ENV_TOKEN: "opencti_token",
              ENV_CONNECTOR_ID: "opencti_connector_id", ENV_CASE: "case_id",
-             ENV_TLP: "tlp", ENV_RULES_DIR: "rules_dir"}
+             ENV_TLP: "tlp", ENV_RULES_DIR: "rules_dir", ENV_CTI_INDEX: "cti_index"}
 _FILE_KEYS = {"case": "case_id", "case_id": "case_id", "producer": "producer", "tlp": "tlp",
               "out": "out", "rules_dir": "rules_dir", "push": "push", "timeout": "timeout",
               "opencti_url": "opencti_url", "opencti_token": "opencti_token",
-              "opencti_connector_id": "opencti_connector_id"}
+              "opencti_connector_id": "opencti_connector_id", "cti_index": "cti_index"}
 _OPENCTI_KEYS = {"url": "opencti_url", "token": "opencti_token", "connector_id": "opencti_connector_id"}
+_CTI_KEYS = {"index": "cti_index"}
 
 
 @dataclass
@@ -59,6 +64,7 @@ class StixConfig:
     opencti_url: str | None = None
     opencti_token: str | None = None
     opencti_connector_id: str | None = None
+    cti_index: str = DEFAULT_CTI_INDEX
 
     def redacted(self) -> dict:
         """For summaries and logs: the token is only ever shown as present/absent."""
@@ -88,6 +94,8 @@ def _read_file(path: str) -> dict:
     for k, v in doc.items():
         if k == "opencti" and isinstance(v, dict):
             out.update({_OPENCTI_KEYS[kk]: vv for kk, vv in v.items() if kk in _OPENCTI_KEYS})
+        elif k == "cti" and isinstance(v, dict):
+            out.update({_CTI_KEYS[kk]: vv for kk, vv in v.items() if kk in _CTI_KEYS})
         elif k in _FILE_KEYS:
             out[_FILE_KEYS[k]] = v
     return out
@@ -119,6 +127,7 @@ def load_config(path: str | None = None, env: Mapping[str, str] | None = None,
         v = getattr(cfg, k)
         if v is not None:
             setattr(cfg, k, str(v))
+    cfg.cti_index = str(cfg.cti_index or DEFAULT_CTI_INDEX)
     return cfg
 
 

--- a/python/get_sybers_dfir/stix/cti/__init__.py
+++ b/python/get_sybers_dfir/stix/cti/__init__.py
@@ -1,0 +1,27 @@
+"""CTI in, sightings out — the OpenCTI wiring around Elastic's indicator match.
+
+OpenCTI stays an exchange interface (decision D4); the matching is Elastic's
+own. Two verbs, both behind the stubbed-transport client of :mod:`..opencti`:
+
+- :func:`run_pull` — OpenCTI's STIX 2.1 indicators -> ``cti-*`` documents
+  (Elasticsearch ``_bulk`` lines) with their atomics under ECS
+  ``threat.indicator.*``, which the Detection Engine's indicator-match rule
+  (``detect/rules/cti/cti-indicator-match.yml``) reads (:mod:`.indicators`;
+  the field mapping is ``pattern-mapping.yml``, the index shape
+  ``cti.index-template.json``).
+- :func:`run_sightings` — indicator-match alerts -> STIX ``sighting`` objects
+  of the platform's own indicators, pushed back (:mod:`.sightings`).
+"""
+from .indicators import (
+    INDEX_TEMPLATE, PATTERN_MAPPING, PatternMapping, bulk_lines, load_pattern_mapping, load_template,
+    parse_pattern, run_pull, template_fields, to_cti_doc, to_cti_docs, validate_pattern_mapping,
+    validate_template,
+)
+from .sightings import alert_sightings, build_sightings_bundle, enrichments, read_alerts, run_sightings
+
+__all__ = [
+    "INDEX_TEMPLATE", "PATTERN_MAPPING", "PatternMapping", "alert_sightings", "build_sightings_bundle",
+    "bulk_lines", "enrichments", "load_pattern_mapping", "load_template", "parse_pattern", "read_alerts",
+    "run_pull", "run_sightings", "template_fields", "to_cti_doc", "to_cti_docs",
+    "validate_pattern_mapping", "validate_template",
+]

--- a/python/get_sybers_dfir/stix/cti/cti.index-template.json
+++ b/python/get_sybers_dfir/stix/cti/cti.index-template.json
@@ -1,0 +1,129 @@
+{
+  "index_patterns": ["cti-*"],
+  "priority": 500,
+  "_meta": {
+    "description": "Byakugan cti-* index: the Elasticsearch copy of OpenCTI's STIX 2.1 indicators, one document per indicator with its atomic values under threat.indicator.* (ECS), so the Detection Engine's indicator-match rule (detect/rules/cti/cti-indicator-match.yml, threat_indicator_path threat.indicator) can flag logs-dfir.* / logs-car.* evidence against them. _id is the STIX indicator id, so a re-pull upserts instead of duplicating. Written by `dxdfir stix pull` (stix/cti/indicators.py; which STIX comparison lands where is pattern-mapping.yml). Strict mapping: a field the copy step does not know cannot slip in unmapped.",
+    "owner": "DX_DFIR python/get_sybers_dfir/stix/cti",
+    "document_id": "<threat.indicator.id> (the STIX indicator id)",
+    "indicator_path": "threat.indicator"
+  },
+  "template": {
+    "settings": {
+      "index.number_of_replicas": 0,
+      "index.refresh_interval": "5s"
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "@timestamp": {"type": "date"},
+        "event": {
+          "properties": {
+            "kind": {"type": "keyword"},
+            "category": {"type": "keyword"},
+            "type": {"type": "keyword"},
+            "dataset": {"type": "keyword"},
+            "module": {"type": "keyword"}
+          }
+        },
+        "tags": {"type": "keyword"},
+        "threat": {
+          "properties": {
+            "feed": {
+              "properties": {
+                "name": {"type": "keyword"},
+                "reference": {"type": "keyword"},
+                "description": {"type": "keyword"}
+              }
+            },
+            "indicator": {
+              "properties": {
+                "id": {"type": "keyword"},
+                "type": {"type": "keyword"},
+                "name": {"type": "keyword"},
+                "description": {"type": "keyword", "ignore_above": 4096},
+                "provider": {"type": "keyword"},
+                "reference": {"type": "keyword"},
+                "confidence": {"type": "keyword"},
+                "sightings": {"type": "long"},
+                "first_seen": {"type": "date"},
+                "last_seen": {"type": "date"},
+                "modified_at": {"type": "date"},
+                "ip": {"type": "ip"},
+                "port": {"type": "long"},
+                "mac": {"type": "keyword"},
+                "email": {
+                  "properties": {
+                    "address": {"type": "keyword"}
+                  }
+                },
+                "url": {
+                  "properties": {
+                    "original": {"type": "keyword", "ignore_above": 4096},
+                    "domain": {"type": "keyword"}
+                  }
+                },
+                "file": {
+                  "properties": {
+                    "name": {"type": "keyword"},
+                    "hash": {
+                      "properties": {
+                        "md5": {"type": "keyword"},
+                        "sha1": {"type": "keyword"},
+                        "sha256": {"type": "keyword"},
+                        "sha512": {"type": "keyword"},
+                        "ssdeep": {"type": "keyword"}
+                      }
+                    }
+                  }
+                },
+                "registry": {
+                  "properties": {
+                    "key": {"type": "keyword"}
+                  }
+                },
+                "x509": {
+                  "properties": {
+                    "serial_number": {"type": "keyword"}
+                  }
+                },
+                "as": {
+                  "properties": {
+                    "number": {"type": "long"}
+                  }
+                },
+                "marking": {
+                  "properties": {
+                    "tlp": {"type": "keyword"},
+                    "tlp_version": {"type": "keyword"}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "stix": {
+          "properties": {
+            "id": {"type": "keyword"},
+            "pattern": {"type": "keyword", "ignore_above": 8191},
+            "pattern_type": {"type": "keyword"},
+            "valid_from": {"type": "date"},
+            "valid_until": {"type": "date"},
+            "revoked": {"type": "boolean"},
+            "created": {"type": "date"},
+            "modified": {"type": "date"},
+            "indicator_types": {"type": "keyword"},
+            "confidence": {"type": "integer"}
+          }
+        },
+        "opencti": {
+          "properties": {
+            "id": {"type": "keyword"},
+            "score": {"type": "integer"},
+            "detection": {"type": "boolean"},
+            "main_observable_type": {"type": "keyword"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/python/get_sybers_dfir/stix/cti/indicators.py
+++ b/python/get_sybers_dfir/stix/cti/indicators.py
@@ -1,0 +1,489 @@
+"""OpenCTI's STIX 2.1 indicators -> the ``cti-*`` copy Elastic's indicator-match reads.
+
+The detection engine stays Elastic (decision D4): OpenCTI is only where the
+indicators come from. This module turns STIX indicator objects — pulled by
+:meth:`..opencti.OpenCTIClient.pull_indicators`, or read from any STIX bundle
+— into documents for the ``cti-*`` index whose atomic values sit under ECS
+``threat.indicator.*``, the ``threat_indicator_path`` the Detection Engine's
+indicator-match rule (``detect/rules/cti/cti-indicator-match.yml``) reads.
+Their ``_id`` is the STIX indicator id, so a re-pull upserts.
+
+Which STIX comparison lands in which field is DATA (``pattern-mapping.yml``);
+the index shape is DATA too (``cti.index-template.json``, strict mapping), and
+:func:`to_cti_docs` refuses to emit a field the template does not map. The
+pattern reader is deliberately not a STIX pattern parser: it lifts the
+unnegated ``=`` comparisons out of a pattern (the only thing an indicator
+match can use) and leaves the verbatim pattern under ``stix.pattern`` as the
+authoritative expression. An indicator that yields no atomic (a YARA / Sigma
+pattern, a CIDR, an unmapped observable) is skipped and counted, never
+guessed. Pure apart from the file loaders; nothing here touches a store.
+"""
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import re
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+import yaml
+
+from .. import objects as o
+from ..config import StixConfig
+from ..export import load_bundle, validate_bundle, write_bundle
+from ..hits import flatten
+from ..opencti import DEFAULT_PAGE_SIZE, OpenCTIClient, Transport
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+PATTERN_MAPPING = os.path.join(_HERE, "pattern-mapping.yml")
+INDEX_TEMPLATE = os.path.join(_HERE, "cti.index-template.json")
+DEFAULT_FEED = "opencti"
+VALUE_TYPES = ("ip", "integer", "string")
+# ECS threat.indicator.confidence, spelled as ECS expects (STIX 2.1 §3.2's
+# None / Low / Med / High scale: 0, 1-29, 30-69, 70-100).
+CONFIDENCE_LABELS = ("Not Specified", "None", "Low", "Medium", "High")
+_TLP_RANK = {"WHITE": 0, "CLEAR": 0, "GREEN": 1, "AMBER": 2, "AMBER+STRICT": 3, "RED": 4}
+_TLP_V2_ONLY = ("CLEAR", "AMBER+STRICT")
+_SPEC_TLP_NAMES = {mid: level.upper() for level, mid in o.TLP_MARKING_IDS.items()}
+_INDICATOR_ID_RE = re.compile(r"^indicator--[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+_FIELD_RE = re.compile(r"^[@a-z][a-z0-9_]*(?:\.[A-Za-z0-9_]+)*$")
+_SCO_TYPE_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_INDEX_RE = re.compile(r"^cti-[a-z0-9_.*-]*$")       # a cti-* pattern or a concrete cti- name
+_ES_TYPES = {"ip": ("ip",), "integer": ("long", "integer", "short"), "string": ("keyword", "wildcard", "text")}
+
+# One STIX comparison expression: an object path (type:property, property
+# segments plain or quoted, list indexes allowed), an optional NOT, a
+# comparator and a literal. Only the unnegated '=' form with a string or
+# number literal is an atomic indicator; everything else is passed over.
+_PATH = (r"[a-z][a-z0-9-]*:(?:[A-Za-z0-9_]+|'[^']*'|\"[^\"]*\")"
+         r"(?:\.(?:[A-Za-z0-9_-]+|'[^']*'|\"[^\"]*\")|\[[^\]]*\])*")
+_COMPARISON_RE = re.compile(
+    r"(?P<path>" + _PATH + r")\s*(?P<neg>NOT\s+)?"
+    r"(?P<op>!=|<=|>=|=|<|>|IN|LIKE|MATCHES|ISSUBSET|ISSUPERSET)\s*"
+    r"(?P<value>'(?:[^'\\]|\\.)*'|-?\d+(?:\.\d+)?|true|false)", re.I)
+
+
+# ------------------------------------------------------------------ the pattern
+def parse_pattern(pattern: str) -> list[tuple[str, str]]:
+    """The unnegated ``=`` comparisons of a STIX pattern as ``(object path,
+    value)`` pairs in order — quotes around property names stripped
+    (``file:hashes.'SHA-256'`` -> ``file:hashes.SHA-256``), string escapes
+    undone. Not a parser: qualifiers, observation operators and every other
+    comparator are passed over; they cannot be atomic indicators."""
+    out: list[tuple[str, str]] = []
+    for m in _COMPARISON_RE.finditer(pattern or ""):
+        if m.group("neg") or m.group("op") != "=":
+            continue
+        raw = m.group("value")
+        value = re.sub(r"\\(.)", r"\1", raw[1:-1]) if raw.startswith("'") else raw
+        out.append((re.sub(r"['\"]", "", m.group("path")), value))
+    return out
+
+
+def _key(path: str) -> str:
+    """A lookup key that forgives the spellings producers use for the same
+    property (``file:hashes.'SHA-256'`` / ``file:hashes.sha256``)."""
+    return re.sub(r"[-_'\"]", "", str(path)).lower()
+
+
+# ------------------------------------------------------------- pattern mapping
+def validate_pattern_mapping(doc) -> None:
+    """The mapping data must name an indicator path and a non-empty list of
+    comparisons, each with a STIX object path, an ECS field under that path, a
+    type and a value type — no two comparisons for the same path."""
+    if not isinstance(doc, dict):
+        raise ValueError("pattern-mapping: must be a mapping (indicator_path, comparisons)")
+    ip = doc.get("indicator_path")
+    if not isinstance(ip, str) or not _FIELD_RE.match(ip):
+        raise ValueError("pattern-mapping: indicator_path must be a field path (threat.indicator)")
+    comps = doc.get("comparisons")
+    if not isinstance(comps, list) or not comps:
+        raise ValueError("pattern-mapping: comparisons must be a non-empty list")
+    seen: set[str] = set()
+    for c in comps:
+        if not isinstance(c, dict):
+            raise ValueError("pattern-mapping: each comparison must be a mapping")
+        stix = c.get("stix")
+        if not isinstance(stix, str) or ":" not in stix or not stix.strip():
+            raise ValueError(f"pattern-mapping: {c}: stix must be a STIX object path (<type>:<property>)")
+        if _key(stix) in seen:
+            raise ValueError(f"pattern-mapping: {stix!r} is mapped twice")
+        seen.add(_key(stix))
+        ecs = c.get("ecs")
+        if not isinstance(ecs, str) or not _FIELD_RE.match(ecs) or not ecs.startswith(ip + "."):
+            raise ValueError(f"pattern-mapping: {stix!r}: ecs must be a field under {ip}.")
+        if not isinstance(c.get("type"), str) or not _SCO_TYPE_RE.match(c["type"]):
+            raise ValueError(f"pattern-mapping: {stix!r}: type must be the STIX SCO type name")
+        if c.get("value_type") not in VALUE_TYPES:
+            raise ValueError(f"pattern-mapping: {stix!r}: value_type must be one of {VALUE_TYPES}")
+
+
+class PatternMapping:
+    """``pattern-mapping.yml`` loaded: which STIX comparison lands in which
+    ``threat.indicator.*`` field."""
+
+    def __init__(self, doc: dict):
+        validate_pattern_mapping(doc)
+        self.indicator_path: str = doc["indicator_path"]
+        self.comparisons: list[dict] = list(doc["comparisons"])
+        self._by_key = {_key(c["stix"]): c for c in self.comparisons}
+
+    def lookup(self, path: str) -> dict | None:
+        return self._by_key.get(_key(path))
+
+    @property
+    def ecs_fields(self) -> set[str]:
+        return {c["ecs"] for c in self.comparisons}
+
+
+def load_pattern_mapping(path: str = PATTERN_MAPPING) -> PatternMapping:
+    with open(path, encoding="utf-8") as fh:
+        try:
+            doc = yaml.safe_load(fh)
+        except yaml.YAMLError as e:
+            raise ValueError(f"{path}: invalid YAML: {e}") from e
+    return PatternMapping(doc)
+
+
+# -------------------------------------------------------------- index template
+def load_template(path: str = INDEX_TEMPLATE) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _properties(template: dict) -> dict:
+    return (((template.get("template") or {}).get("mappings") or {}).get("properties")) or {}
+
+
+def mapping_node(template: dict, path: str) -> dict | None:
+    """The mapping definition at dotted ``path`` (a leaf field or an object
+    with ``properties``), or ``None`` when the template does not map it."""
+    node: dict = {"properties": _properties(template)}
+    for seg in path.split("."):
+        nxt = (node.get("properties") or {}).get(seg)
+        if not isinstance(nxt, dict):
+            return None
+        node = nxt
+    return node
+
+
+def template_fields(template: dict) -> dict[str, str]:
+    """Every leaf field the template maps, ``{dotted path: Elasticsearch type}``."""
+    out: dict[str, str] = {}
+
+    def walk(properties: dict, prefix: str) -> None:
+        for name, spec in (properties or {}).items():
+            path = prefix + str(name)
+            if isinstance(spec, dict) and isinstance(spec.get("properties"), dict):
+                walk(spec["properties"], path + ".")
+            else:
+                out[path] = str((spec or {}).get("type", "object")) if isinstance(spec, dict) else "?"
+    walk(_properties(template), "")
+    return out
+
+
+def validate_template(template, mapping: PatternMapping | None = None) -> None:
+    """The cti-* template must be an index template over ``cti-*`` patterns
+    with a STRICT mapping that carries the indicator path as an object, its
+    ``id``, and the ``stix.*`` fields the rule's ``threat_query`` reads; with
+    ``mapping`` given, every ECS target of the pattern mapping must be mapped
+    with an Elasticsearch type that accepts its value type."""
+    if not isinstance(template, dict):
+        raise ValueError("cti template: must be a mapping")
+    patterns = template.get("index_patterns")
+    if not isinstance(patterns, list) or not patterns or not all(
+            isinstance(p, str) and _INDEX_RE.match(p) for p in patterns):
+        raise ValueError("cti template: index_patterns must be a non-empty list of cti-* patterns")
+    mappings = (template.get("template") or {}).get("mappings") or {}
+    if mappings.get("dynamic") != "strict":
+        raise ValueError("cti template: mappings.dynamic must be 'strict' (an unmapped field cannot slip in)")
+    fields = template_fields(template)
+    ip = (template.get("_meta") or {}).get("indicator_path") or (mapping.indicator_path if mapping else "threat.indicator")
+    if mapping and ip != mapping.indicator_path:
+        raise ValueError(f"cti template: _meta.indicator_path {ip!r} != pattern-mapping indicator_path {mapping.indicator_path!r}")
+    node = mapping_node(template, ip)
+    if not node or not isinstance(node.get("properties"), dict):
+        raise ValueError(f"cti template: {ip} must be mapped as an object (threat_indicator_path)")
+    for field, es_type in ((ip + ".id", "keyword"), ("@timestamp", "date"), ("stix.revoked", "boolean"),
+                           ("stix.valid_until", "date"), ("stix.pattern", "keyword")):
+        if fields.get(field) != es_type:
+            raise ValueError(f"cti template: {field} must be mapped as {es_type}")
+    for c in (mapping.comparisons if mapping else []):
+        if c["ecs"] not in fields:
+            raise ValueError(f"cti template: pattern-mapping target {c['ecs']} ({c['stix']}) is not mapped")
+        if fields[c["ecs"]] not in _ES_TYPES[c["value_type"]]:
+            raise ValueError(f"cti template: {c['ecs']} is {fields[c['ecs']]}, which does not hold a {c['value_type']}")
+
+
+# --------------------------------------------------------------- normalisation
+def confidence_label(value) -> str:
+    """STIX ``confidence`` (0..100) as ECS ``threat.indicator.confidence``."""
+    if value is None or isinstance(value, bool):
+        return "Not Specified"
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return "Not Specified"
+    if n < 0 or n > 100:
+        return "Not Specified"
+    if n == 0:
+        return "None"
+    return "Low" if n <= 29 else "Medium" if n <= 69 else "High"
+
+
+def tlp_names(objects: Iterable[dict]) -> dict[str, str]:
+    """``{marking-definition id: TLP level}`` — the spec's four fixed ids plus
+    every TLP marking carried in ``objects`` (OpenCTI's TLP 2.0 levels have
+    platform ids, so they resolve only through their marking objects)."""
+    names = dict(_SPEC_TLP_NAMES)
+    for x in objects:
+        if not isinstance(x, dict) or x.get("type") != "marking-definition" or not isinstance(x.get("id"), str):
+            continue
+        level = None
+        definition = x.get("definition")
+        if isinstance(definition, dict) and definition.get("tlp"):
+            level = str(definition["tlp"])
+        elif str(x.get("definition_type") or "").lower() == "tlp" and x.get("name"):
+            level = str(x["name"]).split(":", 1)[-1]
+        if level:
+            names[x["id"]] = level.strip().upper()
+    return names
+
+
+def tlp_of(refs, names: dict[str, str]) -> str | None:
+    """The most restrictive TLP level among ``object_marking_refs``, or None."""
+    levels = [names[r] for r in (refs or []) if isinstance(r, str) and r in names and names[r] in _TLP_RANK]
+    return max(levels, key=_TLP_RANK.__getitem__) if levels else None
+
+
+def coerce_value(value, value_type: str):
+    """``value`` as the Elasticsearch field accepts it, or ``None`` when it
+    cannot index (a CIDR in an ``ip`` field, text in an integer)."""
+    s = str(value).strip() if value is not None else ""
+    if not s:
+        return None
+    if value_type == "ip":
+        try:
+            return str(ipaddress.ip_address(s))
+        except ValueError:
+            return None
+    if value_type == "integer":
+        try:
+            return int(s)
+        except ValueError:
+            return None
+    return s
+
+
+def _set(doc: dict, path: str, value) -> None:
+    if value is None or value == "" or value == []:
+        return
+    node = doc
+    parts = path.split(".")
+    for seg in parts[:-1]:
+        node = node.setdefault(seg, {})
+    node[parts[-1]] = value
+
+
+@dataclass
+class Normalised:
+    doc: dict | None
+    reason: str | None = None       # why there is no document
+    dropped: int = 0                # values the pattern named that cannot index
+
+
+def to_cti_doc(indicator: dict, *, mapping: PatternMapping, now: str,
+               markings: dict[str, str] | None = None, identities: dict[str, str] | None = None,
+               feed: str = DEFAULT_FEED) -> Normalised:
+    """One STIX indicator -> one ``cti-*`` document (``Normalised.doc``), or
+    the reason there is none: ``not_indicator``, ``bad_id``,
+    ``pattern_type:<x>`` (only STIX patterns hold atomics), ``no_pattern``,
+    ``no_comparison``, ``unmapped`` (no comparison the mapping knows),
+    ``bad_value`` (every known comparison's value cannot index)."""
+    if not isinstance(indicator, dict) or indicator.get("type") != "indicator":
+        return Normalised(None, "not_indicator")
+    sid = indicator.get("id")
+    if not isinstance(sid, str) or not _INDICATOR_ID_RE.match(sid):
+        return Normalised(None, "bad_id")
+    ptype = str(indicator.get("pattern_type") or "stix").lower()
+    if ptype != "stix":
+        return Normalised(None, f"pattern_type:{ptype}")
+    pattern = indicator.get("pattern")
+    if not isinstance(pattern, str) or not pattern.strip():
+        return Normalised(None, "no_pattern")
+    comparisons = parse_pattern(pattern)
+    if not comparisons:
+        return Normalised(None, "no_comparison")
+    atomics: dict[str, list] = {}
+    types: list[str] = []
+    known = dropped = 0
+    for path, value in comparisons:
+        entry = mapping.lookup(path)
+        if entry is None:
+            continue
+        known += 1
+        v = coerce_value(value, entry["value_type"])
+        if v is None:
+            dropped += 1
+            continue
+        values = atomics.setdefault(entry["ecs"], [])
+        if v not in values:
+            values.append(v)
+        if entry["type"] not in types:
+            types.append(entry["type"])
+    if not atomics:
+        return Normalised(None, "unmapped" if not known else "bad_value", dropped)
+
+    doc: dict = {"@timestamp": now}
+    _set(doc, "event.kind", "enrichment")
+    _set(doc, "event.category", ["threat"])
+    _set(doc, "event.type", ["indicator"])
+    _set(doc, "event.dataset", f"cti.{feed}")
+    _set(doc, "event.module", feed)
+    _set(doc, "threat.feed.name", feed)
+    ip = mapping.indicator_path
+    _set(doc, ip + ".id", sid)
+    _set(doc, ip + ".type", types[0])
+    for ecs, values in atomics.items():
+        _set(doc, ecs, values[0] if len(values) == 1 else values)
+    _set(doc, ip + ".name", _text(indicator.get("name")))
+    _set(doc, ip + ".description", _text(indicator.get("description")))
+    _set(doc, ip + ".confidence", confidence_label(indicator.get("confidence")))
+    _set(doc, ip + ".first_seen", o.stix_timestamp(indicator.get("valid_from")))
+    _set(doc, ip + ".modified_at", o.stix_timestamp(indicator.get("modified")))
+    provider = (identities or {}).get(indicator.get("created_by_ref") or "")
+    _set(doc, ip + ".provider", provider)
+    refs = [r for r in (indicator.get("external_references") or []) if isinstance(r, dict)]
+    _set(doc, ip + ".reference", next((str(r["url"]) for r in refs if r.get("url")), None))
+    level = tlp_of(indicator.get("object_marking_refs"), markings or _SPEC_TLP_NAMES)
+    _set(doc, ip + ".marking.tlp", level)
+    if level in _TLP_V2_ONLY:
+        _set(doc, ip + ".marking.tlp_version", "2.0")
+    _set(doc, "stix.id", sid)
+    _set(doc, "stix.pattern", pattern)
+    _set(doc, "stix.pattern_type", ptype)
+    for k in ("valid_from", "valid_until", "created", "modified"):
+        _set(doc, "stix." + k, o.stix_timestamp(indicator.get(k)))
+    _set(doc, "stix.revoked", bool(indicator.get("revoked")))
+    confidence = indicator.get("confidence")
+    if isinstance(confidence, int) and not isinstance(confidence, bool):
+        _set(doc, "stix.confidence", confidence)
+    _set(doc, "stix.indicator_types", [str(t) for t in (indicator.get("indicator_types") or []) if t])
+    _set(doc, "tags", [str(t) for t in (indicator.get("labels") or []) if t])
+    _set(doc, "opencti.id", _text(indicator.get("x_opencti_id")))
+    score = indicator.get("x_opencti_score")
+    if isinstance(score, int) and not isinstance(score, bool):
+        _set(doc, "opencti.score", score)
+    if isinstance(indicator.get("x_opencti_detection"), bool):
+        _set(doc, "opencti.detection", indicator["x_opencti_detection"])
+    _set(doc, "opencti.main_observable_type", _text(indicator.get("x_opencti_main_observable_type")))
+    return Normalised(doc, None, dropped)
+
+
+def _text(value) -> str | None:
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def document_id(doc: dict) -> str:
+    """The ``_id`` a cti-* document is written under: its STIX indicator id."""
+    return str(flatten(doc).get("threat.indicator.id") or "")
+
+
+def to_cti_docs(objects: Iterable[dict], *, mapping: PatternMapping | None = None, now: str | None = None,
+                feed: str = DEFAULT_FEED, template: dict | None = None) -> tuple[list[dict], dict]:
+    """Every indicator in ``objects`` (a bundle's object list — its
+    marking-definitions resolve TLP, its identities the provider) as cti-*
+    documents, plus a report: indicators seen, documents made, values dropped,
+    and the skipped indicators counted by reason. With ``template`` given, a
+    document carrying a field the template does not map is a defect in this
+    module's data and raises."""
+    mapping = mapping or load_pattern_mapping()
+    now = now or o.utc_now()
+    objs = [x for x in objects if isinstance(x, dict)]
+    markings = tlp_names(objs)
+    identities = {x["id"]: str(x["name"]) for x in objs
+                  if x.get("type") == "identity" and isinstance(x.get("id"), str) and x.get("name")}
+    fields = template_fields(template) if template else None
+    docs: list[dict] = []
+    report: dict = {"indicators": 0, "docs": 0, "dropped_values": 0, "skipped": {}}
+    for x in objs:
+        if x.get("type") != "indicator":
+            continue
+        report["indicators"] += 1
+        result = to_cti_doc(x, mapping=mapping, now=now, markings=markings, identities=identities, feed=feed)
+        report["dropped_values"] += result.dropped
+        if result.doc is None:
+            report["skipped"][result.reason] = report["skipped"].get(result.reason, 0) + 1
+            continue
+        if fields is not None:
+            extra = sorted(k for k in flatten(result.doc) if k not in fields)
+            if extra:
+                raise ValueError(f"{x.get('id')}: document carries field(s) the cti-* template does not map: "
+                                 f"{extra} — pattern-mapping.yml and cti.index-template.json disagree")
+        docs.append(result.doc)
+    report["docs"] = len(docs)
+    return docs, report
+
+
+def bulk_lines(docs: Iterable[dict], index: str) -> Iterator[str]:
+    """Elasticsearch ``_bulk`` body lines for ``docs`` — an ``index`` action
+    keyed on the STIX id (so a re-pull upserts), then the document — ready for
+    ``POST /_bulk``. The index must be one the cti-* template covers."""
+    if not isinstance(index, str) or not _INDEX_RE.match(index) or "*" in index:
+        raise ValueError(f"cti index must be a concrete cti-* name (the template covers cti-*): {index!r}")
+    for doc in docs:
+        yield json.dumps({"index": {"_index": index, "_id": document_id(doc)}}, separators=(",", ":"))
+        yield json.dumps(doc, ensure_ascii=False, separators=(",", ":"), default=str)
+
+
+# ---------------------------------------------------------------------- the verb
+def run_pull(cfg: StixConfig, *, out: str | None = None, bundle_out: str | None = None,
+             from_bundle: str | None = None, since: str | None = None,
+             page_size: int = DEFAULT_PAGE_SIZE, max_pages: int | None = None,
+             transport: Transport | None = None, now: str | None = None) -> tuple[dict, list[str]]:
+    """Pull OpenCTI's indicators (or read an already-pulled bundle with
+    ``from_bundle`` — no platform needed), validate them, keep the bundle
+    (``bundle_out``), normalise to cti-* documents and write the ``_bulk``
+    lines to ``out``. Returns ``(summary, lines)``; ``summary["ok"]`` is False
+    when the platform refused or the bundle failed validation (nothing is
+    written then). ``ValueError`` on a bad ``since`` or an input that is not a
+    bundle."""
+    summary: dict = {"tool": "stix-pull", "config": cfg.redacted(), "index": cfg.cti_index,
+                     "pull": None, "validation": {"errors": [], "warnings": []},
+                     "bundle": None, "copy": None, "out": None, "ok": True}
+    if from_bundle:
+        bundle = load_bundle(str(from_bundle))
+        summary["pull"] = {"from_bundle": str(from_bundle), "objects": len(bundle["objects"])}
+    else:
+        client = OpenCTIClient(cfg.opencti_url, cfg.opencti_token, connector_id=cfg.opencti_connector_id,
+                               transport=transport, timeout=cfg.timeout)
+        result = client.pull_indicators(since=since, page_size=page_size, max_pages=max_pages)
+        summary["pull"] = result.as_dict()
+        if not result.ok or result.bundle is None:
+            summary["ok"] = False
+            return summary, []
+        bundle = result.bundle
+    if bundle["objects"]:
+        errors, warnings = validate_bundle(bundle)
+        summary["validation"] = {"errors": errors, "warnings": warnings}
+        if errors:
+            summary["ok"] = False
+            return summary, []
+    if bundle_out:
+        write_bundle(bundle, bundle_out)
+        summary["bundle"] = bundle_out
+    docs, report = to_cti_docs(bundle["objects"], now=now, template=load_template())
+    summary["copy"] = report
+    lines = list(bulk_lines(docs, cfg.cti_index))
+    if out:
+        parent = os.path.dirname(os.path.abspath(out))
+        os.makedirs(parent, exist_ok=True)
+        with open(out, "w", encoding="utf-8") as fh:
+            for line in lines:
+                fh.write(line + "\n")
+        summary["out"] = out
+    return summary, lines

--- a/python/get_sybers_dfir/stix/cti/pattern-mapping.yml
+++ b/python/get_sybers_dfir/stix/cti/pattern-mapping.yml
@@ -1,0 +1,43 @@
+# STIX 2.1 indicator pattern -> the ECS threat.indicator.* copy in cti-*
+# (data, not prose; applied by stix/cti/indicators.py, pinned by tests/test_cti.py).
+#
+# WHAT: Elastic's indicator-match rule (detect/rules/cti/cti-indicator-match.yml)
+# compares evidence fields with atomic values held under threat_indicator_path
+# (threat.indicator.*) in the cti-* index. OpenCTI hands out STIX patterns
+# ([ipv4-addr:value = '203.0.113.9']), so the copy step breaks every pattern
+# into its `=` comparisons and lands each value under the ECS field named here.
+#
+# KEYS: `stix` is the comparison's object path with the quotes STIX allows
+# around a property name stripped (file:hashes.'SHA-256' -> file:hashes.SHA-256);
+# `ecs` is the threat.indicator.* field the value lands in (every one is mapped
+# in cti.index-template.json — the tests pin that); `type` becomes ECS
+# threat.indicator.type, which by design is the STIX SCO type name;
+# `value_type` says what the field's Elasticsearch type accepts (ip / integer /
+# string), so a value that cannot index is skipped and counted, never bulked
+# into a rejection.
+#
+# Only an unnegated `=` comparison yields a value: `!=`, NOT, LIKE, MATCHES,
+# IN and the ordering comparators cannot be atomic indicators. A compound
+# pattern (AND / OR) lands every value it names — any-of semantics — and the
+# verbatim pattern stays under stix.pattern as the authoritative expression.
+
+indicator_path: threat.indicator
+
+comparisons:
+  - {stix: "ipv4-addr:value", ecs: threat.indicator.ip, type: ipv4-addr, value_type: ip}
+  - {stix: "ipv6-addr:value", ecs: threat.indicator.ip, type: ipv6-addr, value_type: ip}
+  - {stix: "domain-name:value", ecs: threat.indicator.url.domain, type: domain-name, value_type: string}
+  # OpenCTI's own Hostname observable (not a STIX 2.1 SCO); a name is a name.
+  - {stix: "hostname:value", ecs: threat.indicator.url.domain, type: hostname, value_type: string}
+  - {stix: "url:value", ecs: threat.indicator.url.original, type: url, value_type: string}
+  - {stix: "file:hashes.MD5", ecs: threat.indicator.file.hash.md5, type: file, value_type: string}
+  - {stix: "file:hashes.SHA-1", ecs: threat.indicator.file.hash.sha1, type: file, value_type: string}
+  - {stix: "file:hashes.SHA-256", ecs: threat.indicator.file.hash.sha256, type: file, value_type: string}
+  - {stix: "file:hashes.SHA-512", ecs: threat.indicator.file.hash.sha512, type: file, value_type: string}
+  - {stix: "file:hashes.SSDEEP", ecs: threat.indicator.file.hash.ssdeep, type: file, value_type: string}
+  - {stix: "file:name", ecs: threat.indicator.file.name, type: file, value_type: string}
+  - {stix: "email-addr:value", ecs: threat.indicator.email.address, type: email-addr, value_type: string}
+  - {stix: "windows-registry-key:key", ecs: threat.indicator.registry.key, type: windows-registry-key, value_type: string}
+  - {stix: "mac-addr:value", ecs: threat.indicator.mac, type: mac-addr, value_type: string}
+  - {stix: "autonomous-system:number", ecs: threat.indicator.as.number, type: autonomous-system, value_type: integer}
+  - {stix: "x509-certificate:serial_number", ecs: threat.indicator.x509.serial_number, type: x509-certificate, value_type: string}

--- a/python/get_sybers_dfir/stix/cti/sightings.py
+++ b/python/get_sybers_dfir/stix/cti/sightings.py
@@ -1,0 +1,227 @@
+"""Indicator-match alerts -> STIX 2.1 sightings of OpenCTI's own indicators.
+
+The round trip's second half. When the Detection Engine's indicator-match rule
+(``detect/rules/cti/cti-indicator-match.yml``) flags an evidence line against
+the ``cti-*`` copy, the alert carries one ``threat.enrichments[]`` item per
+matched indicator: the indicator's ``threat.indicator.*`` (whose ``id`` is the
+STIX id the copy was made from) plus ``matched.{field, atomic, id, index}``.
+This module reads those alerts and emits, per (indicator, host, matched
+value), one ``sighting`` whose ``sighting_of_ref`` IS the platform's indicator
+id — so OpenCTI attaches the sighting to the indicator it already holds
+instead of receiving a second copy of it. The matched value becomes the spec's
+SCO wrapped in an ``observed-data``; the host that saw it (or, when the alert
+names none, the producer) is ``where_sighted_refs``. Alerts with the same
+(indicator, host, value) collapse into one sighting with ``count``,
+``first_seen`` / ``last_seen`` spanning them; re-running over the same alerts
+in the same case yields the same ids (case-scoped, decision D4).
+
+The platform's indicator is NOT re-emitted — an incoming object under its id
+would be an update of the platform's own record — so ``validate_bundle``
+warns (the reference resolves on the platform) and never errors on it.
+Alerts without an enrichment, and enrichments without an indicator id, are
+skipped and counted, never guessed.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from .. import objects as o
+from ..config import StixConfig
+from ..export import UNCASED, make_bundle, summarise, validate_bundle, write_bundle
+from ..hits import flatten, iter_documents
+from ..opencti import OpenCTIClient, Transport
+
+_INDICATOR_ID_RE = re.compile(r"^indicator--[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+_HASH_FIELD_RE = re.compile(r"(?:^|\.)hash\.(md5|sha1|sha256|sha512)$")
+_HASH_LABELS = {"md5": "MD5", "sha1": "SHA-1", "sha256": "SHA-256", "sha512": "SHA-512"}
+
+
+def _scalar(v):
+    if isinstance(v, (list, tuple)):
+        return next((x for x in v if x is not None), None)
+    return v
+
+
+def _str(v) -> str:
+    v = _scalar(v)
+    return "" if v is None else str(v)
+
+
+def _first(f: dict, *keys):
+    for k in keys:
+        v = f.get(k)
+        if v not in (None, "", []):
+            return v
+    return None
+
+
+def enrichments(doc: dict) -> list[dict]:
+    """The alert's ``threat.enrichments`` items, each flattened to dotted keys
+    (``indicator.id``, ``matched.atomic`` ...), from a nested or an already
+    dotted document."""
+    items = flatten(doc).get("threat.enrichments")
+    if isinstance(items, dict):
+        items = [items]
+    return [flatten(e) for e in (items or []) if isinstance(e, dict)]
+
+
+def matched_observable(field: str, atomic) -> dict | None:
+    """The matched value as the spec's SCO — an address, a file (by the hash
+    the field names), a domain name or a URL — or ``None`` when the field is
+    none of those (a registry key match is sighted without an observable)."""
+    if atomic in (None, ""):
+        return None
+    if field == "ip" or field.endswith(".ip"):
+        return o.ip_address(atomic)
+    m = _HASH_FIELD_RE.search(field)
+    if m:
+        return o.file_observable(hashes={_HASH_LABELS[m.group(1)]: atomic})
+    if field == "dns.question.name" or field.endswith(".domain"):
+        return o.domain_name(atomic)
+    if field.startswith("url."):
+        return o.url(atomic)
+    return None
+
+
+def alert_sightings(alerts: Iterable[dict], *, case_id: str | None = None,
+                    producer: str = o.DEFAULT_PRODUCER, tlp: str | None = "amber",
+                    now: str | None = None) -> tuple[dict[str, dict], dict]:
+    """The object graph for indicator-match ``alerts`` (keyed by id, insertion
+    ordered) and a report: alerts read, enrichments seen, sightings made, and
+    what was skipped by reason."""
+    alerts = [a for a in alerts if isinstance(a, dict)]
+    now = now or o.utc_now()
+    flat = [flatten(a) for a in alerts]
+    case = case_id or next((_str(f.get("kibana.alert.rule.execution.uuid"))
+                            for f in flat if f.get("kibana.alert.rule.execution.uuid")), UNCASED)
+    marking_ref = None
+    objs: dict[str, dict] = {}
+    report: dict = {"alerts": len(alerts), "enrichments": 0, "sightings": 0, "skipped": {}}
+
+    def put(obj: dict) -> str:
+        o.mark(obj, marking_ref)
+        objs.setdefault(obj["id"], obj)
+        return obj["id"]
+
+    def skip(reason: str) -> None:
+        report["skipped"][reason] = report["skipped"].get(reason, 0) + 1
+
+    created_by = put(o.producer_identity(producer, now))
+    if tlp and str(tlp).lower() not in ("none", "no", "off", ""):
+        marking_ref = put(o.tlp_marking(tlp))
+        o.mark(objs[created_by], marking_ref)
+
+    for a, f in zip(alerts, flat, strict=True):
+        items = enrichments(a)
+        if not items:
+            skip("no_enrichment")
+            continue
+        host = _str(_first(f, "host.name", "host.hostname"))
+        seen_at = o.stix_timestamp(_scalar(_first(f, "kibana.alert.original_time", "@timestamp")))
+        detected_at = o.stix_timestamp(_scalar(f.get("@timestamp"))) or now
+        rule_id = _str(_first(f, "kibana.alert.rule.rule_id", "rule.id"))
+        rule_name = _str(_first(f, "kibana.alert.rule.name", "rule.name"))
+        alert_id = _str(_first(f, "kibana.alert.uuid", "_id"))
+        source = _str(_first(f, "_index", "kibana.alert.ancestors.index"))
+        for e in items:
+            report["enrichments"] += 1
+            ref = _str(_first(e, "indicator.id", "matched.id"))
+            if not _INDICATOR_ID_RE.match(ref):
+                skip("no_indicator_ref")
+                continue
+            field, atomic = _str(e.get("matched.field")), _scalar(e.get("matched.atomic"))
+            key = o.canonical([ref, host, field, "" if atomic is None else str(atomic)])
+            sid = o.case_scoped_id("sighting", case, key)
+            if sid in objs:
+                s = objs[sid]
+                s["count"] = int(s.get("count", 1)) + 1
+                if seen_at:
+                    s["first_seen"] = min(s.get("first_seen") or seen_at, seen_at)
+                    s["last_seen"] = max(s.get("last_seen") or seen_at, seen_at)
+                ids = s["x_dxdfir"].setdefault("alert_ids", [])
+                if alert_id and alert_id not in ids:
+                    ids.append(alert_id)
+                continue
+            where = [put(o.host_identity(host, now, created_by))] if host else [created_by]
+            sco = matched_observable(field, atomic)
+            observed = None
+            if sco:
+                when = seen_at or now
+                observed = [put(o.observed_data(case, key, [put(sco)], when, when, now, created_by))]
+            custom = {"case_id": case, "detection_id": rule_id, "source": source,
+                      "feed": _str(e.get("feed.name")),
+                      "matched": {"field": field, "atomic": atomic,
+                                  "index": _str(e.get("matched.index")), "id": _str(e.get("matched.id"))},
+                      "indicator": {"type": _str(e.get("indicator.type")), "name": _str(e.get("indicator.name")),
+                                    "provider": _str(e.get("indicator.provider"))},
+                      "alert_ids": [alert_id] if alert_id else []}
+            description = f"{rule_name or rule_id or 'indicator match'}: {field} = {atomic}" + \
+                (f" on {host}" if host else "")
+            put(o.sighting(case, key, ref, detected_at, created_by, first_seen=seen_at, last_seen=seen_at,
+                           count=1, observed_data_refs=observed, where_sighted_refs=where,
+                           description=description, custom=custom))
+            report["sightings"] += 1
+    return objs, report
+
+
+def build_sightings_bundle(alerts: Iterable[dict], **kw) -> dict:
+    """Indicator-match alerts -> one STIX 2.1 bundle (see :func:`alert_sightings` for ``kw``)."""
+    return make_bundle(alert_sightings(alerts, **kw)[0])
+
+
+def read_alerts(path: str) -> tuple[list[dict], dict]:
+    """Every document in ``path`` (an Elasticsearch ``_search`` response over
+    ``.alerts-security.alerts-*``, a JSON array, one document, or JSON Lines)
+    plus a small report; unparseable JSONL lines are counted, not read."""
+    docs: list[dict] = []
+    report = {"path": str(path), "kind": "alerts", "documents": 0, "unparseable": 0}
+    for doc in iter_documents(str(path)):
+        if doc.get("__unparseable__"):
+            report["unparseable"] += 1
+            continue
+        docs.append(doc)
+    report["documents"] = len(docs)
+    return docs, report
+
+
+def run_sightings(cfg: StixConfig, alert_paths: Iterable[str], *, transport: Transport | None = None,
+                  now: str | None = None) -> tuple[dict, dict]:
+    """Read alerts, build the sightings bundle, validate, write ``cfg.out``
+    (if set), push to OpenCTI (if ``cfg.push``). Returns ``(summary, bundle)``;
+    ``summary["ok"]`` is False when validation failed (nothing is written or
+    pushed then) or the push was refused. ``ValueError`` when no alert was
+    read or none carries an indicator-match enrichment."""
+    summary: dict = {"tool": "stix-sightings", "config": cfg.redacted(), "inputs": [],
+                     "bundle": None, "validation": {"errors": [], "warnings": []},
+                     "push": None, "ok": True}
+    alerts: list[dict] = []
+    for p in alert_paths:
+        docs, report = read_alerts(str(p))
+        alerts.extend(docs)
+        summary["inputs"].append(report)
+    if not alerts:
+        raise ValueError("nothing to sight: no alerts were read")
+    objs, report = alert_sightings(alerts, case_id=cfg.case_id, producer=cfg.producer, tlp=cfg.tlp, now=now)
+    summary["sightings"] = report
+    if not report["sightings"]:
+        raise ValueError("no indicator-match enrichment in the alerts "
+                         "(threat.enrichments[] with an indicator id) — nothing to sight")
+    bundle = make_bundle(objs)
+    errors, warnings = validate_bundle(bundle)
+    summary["validation"] = {"errors": errors, "warnings": warnings}
+    summary["summary"] = summarise(bundle)
+    summary["bundle_id"] = bundle["id"]
+    if errors:
+        summary["ok"] = False
+        return summary, bundle
+    if cfg.out:
+        write_bundle(bundle, cfg.out)
+        summary["bundle"] = cfg.out
+    if cfg.push:
+        client = OpenCTIClient(cfg.opencti_url, cfg.opencti_token, connector_id=cfg.opencti_connector_id,
+                               transport=transport, timeout=cfg.timeout)
+        result = client.push_bundle(bundle)
+        summary["push"] = result.as_dict()
+        summary["ok"] = result.ok
+    return summary, bundle

--- a/python/get_sybers_dfir/stix/objects.py
+++ b/python/get_sybers_dfir/stix/objects.py
@@ -248,6 +248,24 @@ def ip_address(value) -> dict | None:
             "id": sco_id(stix_type, {"value": v}), "value": v}
 
 
+def domain_name(value) -> dict | None:
+    """A ``domain-name`` SCO (spec id over the lower-cased name, trailing dot
+    dropped), or ``None`` when ``value`` is not a name."""
+    v = str(value or "").strip().rstrip(".").lower()
+    if not v or " " in v or "/" in v:
+        return None
+    return {"type": "domain-name", "spec_version": SPEC_VERSION,
+            "id": sco_id("domain-name", {"value": v}), "value": v}
+
+
+def url(value) -> dict | None:
+    """A ``url`` SCO (spec id over the value as given), or ``None`` when empty."""
+    v = str(value or "").strip()
+    if not v or " " in v:
+        return None
+    return {"type": "url", "spec_version": SPEC_VERSION, "id": sco_id("url", {"value": v}), "value": v}
+
+
 def file_observable(name: str | None = None, hashes: dict | None = None) -> dict | None:
     """A ``file`` SCO. Id-contributing properties per §2.9: ONE hash (MD5 >
     SHA-1 > SHA-256 > SHA-512) and the name, whichever are present."""

--- a/python/get_sybers_dfir/stix/opencti.py
+++ b/python/get_sybers_dfir/stix/opencti.py
@@ -1,17 +1,21 @@
-"""OpenCTI exchange client — a scaffold: one call, one interface, no secrets.
+"""OpenCTI exchange client — two calls, one interface, no secrets.
 
-OpenCTI is an EXCHANGE interface only (D4): the engine stays Elastic, and all
-this client does is hand a finished STIX 2.1 bundle to the platform. It speaks
-the platform's GraphQL bundle-push mutation over HTTPS with a bearer token.
+OpenCTI is an EXCHANGE interface only (D4): the engine stays Elastic. This
+client does exactly two things with the platform's GraphQL API over HTTPS with
+a bearer token: it hands a finished STIX 2.1 bundle to the platform
+(``push_bundle`` — sightings and indicators out), and it pulls the platform's
+STIX 2.1 indicators back as a bundle (``pull_indicators`` — CTI in, which
+:mod:`.cti.indicators` then copies into the ``cti-*`` index for Elastic's
+indicator match).
 
 The network call sits behind :class:`Transport` (``post(url, headers, body,
 timeout) -> (status, text)``). :class:`UrllibTransport` is the stdlib default;
 a test passes a recording stub and asserts the exact request — endpoint,
-``Authorization`` header, serialised bundle — without a platform. Endpoint and
-token are constructor arguments that the caller sources from the environment
-or a config file (:mod:`.config`); nothing here knows a real URL or token, and
-:class:`OpenCTIClient` never echoes the token (``repr`` masks it, results omit
-it).
+``Authorization`` header, serialised bundle or query — without a platform.
+Endpoint and token are constructor arguments that the caller sources from the
+environment or a config file (:mod:`.config`); nothing here knows a real URL or
+token, and :class:`OpenCTIClient` never echoes the token (``repr`` masks it,
+results omit it).
 """
 from __future__ import annotations
 
@@ -23,15 +27,53 @@ from dataclasses import asdict, dataclass
 from typing import Protocol
 from urllib.parse import urlparse
 
-from .objects import DEFAULT_PRODUCER, global_id
+from .objects import DEFAULT_PRODUCER, SPEC_VERSION, global_id, stix_timestamp
 
 DEFAULT_TIMEOUT = 60.0
+DEFAULT_PAGE_SIZE = 200
 
 # The platform's bundle-push mutation, kept in one place: the scaffold pins the
 # exchange interface, not a particular OpenCTI schema revision — adjust here.
 GRAPHQL_MUTATION = """\
 mutation DxdfirStixBundlePush($connectorId: String!, $bundle: String!) {
   stixBundlePush(connectorId: $connectorId, bundle: $bundle)
+}"""
+
+# The indicator pull: the STIX 2.1 indicator properties plus the marking and
+# creator objects they reference, paged by cursor in ``modified`` order so an
+# incremental pull (``--since``) resumes where the last one ended. Same rule as
+# the mutation — one schema revision (6.x list fields) pinned here, and
+# :func:`node_to_indicator` reads both the list and the ``edges`` shapes.
+GRAPHQL_INDICATORS_QUERY = """\
+query DxdfirIndicators($first: Int!, $after: ID, $filters: FilterGroup) {
+  indicators(first: $first, after: $after, filters: $filters, orderBy: modified, orderMode: asc) {
+    edges {
+      node {
+        id
+        standard_id
+        name
+        description
+        pattern
+        pattern_type
+        valid_from
+        valid_until
+        revoked
+        confidence
+        created
+        modified
+        indicator_types
+        x_opencti_score
+        x_opencti_detection
+        x_opencti_main_observable_type
+        objectLabel { value }
+        objectMarking { standard_id definition_type definition created }
+        createdBy { standard_id name identity_class created modified }
+        externalReferences { edges { node { source_name url external_id } } }
+        killChainPhases { kill_chain_name phase_name }
+      }
+    }
+    pageInfo { endCursor hasNextPage globalCount }
+  }
 }"""
 
 
@@ -73,6 +115,24 @@ class PushResult:
         return asdict(self)
 
 
+@dataclass
+class PullResult:
+    ok: bool
+    status: int
+    message: str
+    indicators: int                 # distinct indicators pulled
+    pages: int = 0
+    skipped: int = 0                # nodes without a STIX id / pattern
+    bundle: dict | None = None      # the indicators + the markings / identities they reference
+
+    def as_dict(self) -> dict:
+        """For summaries: the bundle is counted, not repeated."""
+        return {"ok": self.ok, "status": self.status, "message": self.message,
+                "indicators": self.indicators, "pages": self.pages, "skipped": self.skipped,
+                "bundle_id": self.bundle["id"] if self.bundle else None,
+                "objects": len(self.bundle["objects"]) if self.bundle else 0}
+
+
 def graphql_url(endpoint: str) -> str:
     base = endpoint.strip().rstrip("/")
     # Refuse a non-HTTPS endpoint up front: the client sends a bearer token, and
@@ -91,6 +151,111 @@ def default_connector_id(producer: str = DEFAULT_PRODUCER) -> str:
     return global_id("connector", "opencti", producer).split("--", 1)[1]
 
 
+def indicator_filters(since: str | None) -> dict | None:
+    """The platform's filter group for an incremental pull — indicators
+    ``modified`` after ``since`` — or ``None`` for everything. ``ValueError``
+    when ``since`` is not a timestamp."""
+    if since in (None, ""):
+        return None
+    ts = stix_timestamp(since)
+    if not ts:
+        raise ValueError(f"since must be a timestamp (e.g. 2026-01-01T00:00:00Z): {since!r}")
+    return {"mode": "and", "filterGroups": [],
+            "filters": [{"key": "modified", "values": [ts], "operator": "gt", "mode": "or"}]}
+
+
+def _nodes(value) -> list[dict]:
+    """The items of an OpenCTI list field, whichever shape the schema revision
+    uses — a plain list, or a connection with ``edges[].node``."""
+    if isinstance(value, dict):
+        value = [e.get("node") for e in value.get("edges") or [] if isinstance(e, dict)]
+    return [v for v in (value or []) if isinstance(v, dict)]
+
+
+def node_to_indicator(node) -> tuple[dict | None, list[dict]]:
+    """One ``indicators`` node -> ``(STIX 2.1 indicator, context objects)`` —
+    the marking-definitions and creator identity it references, as minimal
+    STIX objects — or ``(None, [])`` when the node has no STIX id or pattern.
+    Platform-only properties ride along as ``x_opencti_*``."""
+    if not isinstance(node, dict):
+        return None, []
+    sid, pattern = node.get("standard_id"), node.get("pattern")
+    if not isinstance(sid, str) or not sid.startswith("indicator--") \
+            or not isinstance(pattern, str) or not pattern.strip():
+        return None, []
+    context: list[dict] = []
+    marking_refs: list[str] = []
+    for m in _nodes(node.get("objectMarking")):
+        mid = m.get("standard_id")
+        if not isinstance(mid, str) or not mid.startswith("marking-definition--"):
+            continue
+        marking_refs.append(mid)
+        dtype = str(m.get("definition_type") or "statement").lower()
+        definition = str(m.get("definition") or "")
+        marking = {"type": "marking-definition", "spec_version": SPEC_VERSION, "id": mid,
+                   "definition_type": dtype, "name": definition}
+        created = stix_timestamp(m.get("created"))
+        if created:
+            marking["created"] = created
+        marking["definition"] = {"tlp": definition.split(":", 1)[-1].lower()} if dtype == "tlp" \
+            else {"statement": definition}
+        context.append(marking)
+    created_by = None
+    creator = node.get("createdBy")
+    if isinstance(creator, dict) and isinstance(creator.get("standard_id"), str) \
+            and creator["standard_id"].startswith("identity--"):
+        created_by = creator["standard_id"]
+        identity = {"type": "identity", "spec_version": SPEC_VERSION, "id": created_by,
+                    "name": str(creator.get("name") or created_by),
+                    "identity_class": str(creator.get("identity_class") or "unknown")}
+        for k in ("created", "modified"):
+            ts = stix_timestamp(creator.get(k))
+            if ts:
+                identity[k] = ts
+        context.append(identity)
+
+    ind: dict = {"type": "indicator", "spec_version": SPEC_VERSION, "id": sid}
+    for k in ("created", "modified", "valid_from", "valid_until"):
+        ts = stix_timestamp(node.get(k))
+        if ts:
+            ind[k] = ts
+    if "valid_from" not in ind and "created" in ind:
+        ind["valid_from"] = ind["created"]          # what the platform itself defaults to
+    if created_by:
+        ind["created_by_ref"] = created_by
+    for k in ("name", "description"):
+        if node.get(k) not in (None, ""):
+            ind[k] = str(node[k])
+    ind["pattern"] = pattern
+    ind["pattern_type"] = str(node.get("pattern_type") or "stix")
+    ind["revoked"] = bool(node.get("revoked"))
+    if isinstance(node.get("confidence"), int) and not isinstance(node.get("confidence"), bool):
+        ind["confidence"] = node["confidence"]
+    types = [str(t) for t in (node.get("indicator_types") or []) if t]
+    if types:
+        ind["indicator_types"] = types
+    labels = [str(lab["value"]) for lab in _nodes(node.get("objectLabel")) if lab.get("value")]
+    if labels:
+        ind["labels"] = labels
+    if marking_refs:
+        ind["object_marking_refs"] = marking_refs
+    refs = [{k: str(r[k]) for k in ("source_name", "url", "external_id") if r.get(k)}
+            for r in _nodes(node.get("externalReferences"))]
+    refs = [r for r in refs if r.get("source_name")]
+    if refs:
+        ind["external_references"] = refs
+    phases = [{"kill_chain_name": str(p["kill_chain_name"]), "phase_name": str(p["phase_name"])}
+              for p in _nodes(node.get("killChainPhases")) if p.get("kill_chain_name") and p.get("phase_name")]
+    if phases:
+        ind["kill_chain_phases"] = phases
+    if node.get("id") not in (None, ""):
+        ind["x_opencti_id"] = str(node["id"])
+    for k in ("x_opencti_score", "x_opencti_detection", "x_opencti_main_observable_type"):
+        if node.get(k) is not None:
+            ind[k] = node[k]
+    return ind, context
+
+
 class OpenCTIClient:
     def __init__(self, url: str | None, token: str | None, *, connector_id: str | None = None,
                  transport: Transport | None = None, timeout: float = DEFAULT_TIMEOUT):
@@ -107,37 +272,99 @@ class OpenCTIClient:
     def __repr__(self) -> str:
         return f"OpenCTIClient(url={self.url!r}, connector_id={self.connector_id!r}, token='***')"
 
-    def request(self, bundle: dict) -> tuple[str, dict[str, str], bytes]:
-        """The exact ``(url, headers, body)`` a push sends — pure, for tests."""
-        payload = {
-            "query": GRAPHQL_MUTATION,
-            "variables": {
-                "connectorId": self.connector_id,
-                "bundle": json.dumps(bundle, ensure_ascii=False, separators=(",", ":"), default=str),
-            },
-        }
+    def _envelope(self, query: str, variables: dict) -> tuple[str, dict[str, str], bytes]:
         headers = {"Authorization": f"Bearer {self._token}",
                    "Content-Type": "application/json", "Accept": "application/json"}
+        payload = {"query": query, "variables": variables}
         return self.url, headers, json.dumps(payload, ensure_ascii=False).encode("utf-8")
 
-    def push_bundle(self, bundle: dict) -> PushResult:
-        """Upload ``bundle``; the result says whether the platform accepted it."""
-        n = len(bundle.get("objects") or [])
-        url, headers, body = self.request(bundle)
+    def request(self, bundle: dict) -> tuple[str, dict[str, str], bytes]:
+        """The exact ``(url, headers, body)`` a push sends — pure, for tests."""
+        return self._envelope(GRAPHQL_MUTATION, {
+            "connectorId": self.connector_id,
+            "bundle": json.dumps(bundle, ensure_ascii=False, separators=(",", ":"), default=str),
+        })
+
+    def request_indicators(self, *, first: int = DEFAULT_PAGE_SIZE, after: str | None = None,
+                           since: str | None = None) -> tuple[str, dict[str, str], bytes]:
+        """The exact ``(url, headers, body)`` one page of the pull sends — pure."""
+        return self._envelope(GRAPHQL_INDICATORS_QUERY, {
+            "first": int(first), "after": after, "filters": indicator_filters(since)})
+
+    def _graphql(self, url: str, headers: Mapping[str, str], body: bytes, *,
+                 refused: str) -> tuple[int, dict | None, str | None]:
+        """POST one GraphQL document; ``(status, response, error)`` — ``error``
+        is the operator-facing reason when the call did not succeed (the
+        transport failed, the token was rejected, the platform answered with
+        errors), ``None`` when the response is usable."""
         status, text = self._transport.post(url, headers, body, self.timeout)
         if status == 0:
-            return PushResult(False, 0, f"OpenCTI unreachable at {url}: {text or 'no response'}", n)
+            return 0, None, f"OpenCTI unreachable at {url}: {text or 'no response'}"
         if status in (401, 403):
-            return PushResult(False, status, "OpenCTI rejected the token (check DXDFIR_OPENCTI_TOKEN)", n)
+            return status, None, "OpenCTI rejected the token (check DXDFIR_OPENCTI_TOKEN)"
         try:
             doc = json.loads(text) if text.strip() else {}
         except ValueError:
             doc = None
         if status != 200 or not isinstance(doc, dict):
-            return PushResult(False, status, f"OpenCTI HTTP {status}: {(text or '').strip()[:300]}", n)
+            return status, None, f"OpenCTI HTTP {status}: {(text or '').strip()[:300]}"
         errors = doc.get("errors")
         if errors:
             first = errors[0] if isinstance(errors, list) and errors else errors
             msg = first.get("message", str(first)) if isinstance(first, dict) else str(first)
-            return PushResult(False, status, f"OpenCTI refused the bundle: {msg}", n, doc)
+            return status, doc, f"{refused}: {msg}"
+        return status, doc, None
+
+    def push_bundle(self, bundle: dict) -> PushResult:
+        """Upload ``bundle``; the result says whether the platform accepted it."""
+        n = len(bundle.get("objects") or [])
+        url, headers, body = self.request(bundle)
+        status, doc, error = self._graphql(url, headers, body, refused="OpenCTI refused the bundle")
+        if error:
+            return PushResult(False, status, error, n, doc)
         return PushResult(True, status, f"pushed {n} object(s) to {url}", n, doc)
+
+    def pull_indicators(self, *, since: str | None = None, page_size: int = DEFAULT_PAGE_SIZE,
+                        max_pages: int | None = None) -> PullResult:
+        """Every indicator the platform holds (``modified`` after ``since`` when
+        given), paged, as one STIX 2.1 bundle with the markings and identities
+        they reference. ``max_pages`` is a safety valve — the result says when
+        it stopped the pull short."""
+        objects: dict[str, dict] = {}
+        after: str | None = None
+        pages = skipped = count = status = 0
+        truncated = False
+        while True:
+            url, headers, body = self.request_indicators(first=page_size, after=after, since=since)
+            status, doc, error = self._graphql(url, headers, body, refused="OpenCTI refused the indicator query")
+            if error:
+                return PullResult(False, status, error, count, pages, skipped)
+            data = doc.get("data") if isinstance(doc, dict) else None
+            conn = data.get("indicators") if isinstance(data, dict) else None
+            if not isinstance(conn, dict):
+                return PullResult(False, status, "OpenCTI answered without an indicators connection "
+                                  "(schema drift? see GRAPHQL_INDICATORS_QUERY)", count, pages, skipped)
+            pages += 1
+            for edge in conn.get("edges") or []:
+                ind, context = node_to_indicator(edge.get("node") if isinstance(edge, dict) else None)
+                if ind is None:
+                    skipped += 1
+                    continue
+                if ind["id"] not in objects:
+                    count += 1
+                objects[ind["id"]] = ind
+                for obj in context:
+                    objects.setdefault(obj["id"], obj)
+            info = conn.get("pageInfo") or {}
+            if not info.get("hasNextPage") or not info.get("endCursor"):
+                break
+            if max_pages and pages >= max_pages:
+                truncated = True
+                break
+            after = str(info["endCursor"])
+        # Same derivation as export.bundle_id: the same content is the same bundle.
+        bundle = {"type": "bundle", "id": global_id("bundle", *sorted(objects)), "objects": list(objects.values())}
+        message = f"pulled {count} indicator(s) from {self.url} in {pages} page(s)"
+        if truncated:
+            message += f" — stopped at max_pages={max_pages}, more remain"
+        return PullResult(True, status, message, count, pages, skipped, bundle)

--- a/python/tests/test_cti.py
+++ b/python/tests/test_cti.py
@@ -1,0 +1,598 @@
+"""Unit tests for the OpenCTI / CTI wiring around Elastic's indicator match.
+
+Three legs, none of them live: OpenCTI's indicators pulled through a
+recording transport and copied into cti-* documents (threat.indicator.*),
+the indicator-match rule contract validated against the cti-* template, and
+indicator-match alerts turned into sightings of the platform's own indicators
+and pushed back through the same stub. No network, no platform, no
+Elasticsearch, no secrets.
+"""
+import copy
+import json
+import uuid
+
+import pytest
+from typer.testing import CliRunner
+
+from get_sybers_dfir import cli
+from get_sybers_dfir.detect import rules_loader as rl
+from get_sybers_dfir.stix import config, export, objects, opencti
+from get_sybers_dfir.stix.cti import indicators as ind
+from get_sybers_dfir.stix.cti import sightings as sg
+from get_sybers_dfir.stix.hits import flatten
+
+NOW = "2026-09-02T10:00:00.000Z"
+SCO_NS = uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7")
+TLP_AMBER = objects.TLP_MARKING_IDS["amber"]
+
+
+def _sid(kind, name):
+    return f"{kind}--{uuid.uuid5(uuid.NAMESPACE_URL, 'test-cti/' + name)}"
+
+
+IND_IP, IND_HASH, IND_DOMAIN = _sid("indicator", "ip"), _sid("indicator", "hash"), _sid("indicator", "domain")
+IND_YARA, IND_CIDR, IND_URL = _sid("indicator", "yara"), _sid("indicator", "cidr"), _sid("indicator", "url")
+IDENTITY = _sid("identity", "acme")
+MARKING_STRICT = _sid("marking-definition", "amber-strict")
+SHA256, MD5 = "a" * 64, "b" * 32
+
+
+def _indicator(sid, pattern, **extra):
+    base = {"type": "indicator", "spec_version": "2.1", "id": sid, "name": "n",
+            "created": "2026-08-01T00:00:00.000Z", "modified": "2026-08-15T00:00:00.000Z",
+            "pattern": pattern, "pattern_type": "stix", "valid_from": "2026-08-01T00:00:00.000Z",
+            "created_by_ref": IDENTITY, "object_marking_refs": [TLP_AMBER]}
+    base.update(extra)
+    return base
+
+
+# What a pull yields (or any STIX bundle holds): indicators plus the marking /
+# identity objects they reference.
+BUNDLE_OBJECTS = [
+    _indicator(IND_IP, "[ipv4-addr:value = '203.0.113.9']", name="C2 beacon", confidence=85, labels=["c2"],
+               external_references=[{"source_name": "x", "url": "https://ref.example.test/1"}],
+               x_opencti_id="oc-1", x_opencti_score=80, x_opencti_detection=True,
+               x_opencti_main_observable_type="IPv4-Addr"),
+    _indicator(IND_HASH, f"[file:hashes.'SHA-256' = '{SHA256}' OR file:hashes.MD5 = '{MD5}']",
+               confidence=40, valid_until="2027-01-01T00:00:00.000Z", revoked=False),
+    _indicator(IND_DOMAIN, "[domain-name:value = 'evil.example' AND domain-name:value != 'good.example']",
+               confidence=0, object_marking_refs=[MARKING_STRICT]),
+    _indicator(IND_YARA, "rule x { condition: true }", pattern_type="yara"),
+    _indicator(IND_CIDR, "[ipv4-addr:value = '203.0.113.0/24']"),
+    _indicator(IND_URL, "[url:value = 'https://evil.example/p?q=1'] FOLLOWEDBY [mutex:name = 'm']", revoked=True),
+    {"type": "identity", "spec_version": "2.1", "id": IDENTITY, "created": NOW, "modified": NOW,
+     "name": "ACME CTI", "identity_class": "organization"},
+    objects.tlp_marking("amber"),
+    {"type": "marking-definition", "spec_version": "2.1", "id": MARKING_STRICT, "created": NOW,
+     "definition_type": "tlp", "name": "TLP:AMBER+STRICT", "definition": {"tlp": "amber+strict"}},
+]
+
+
+class RecordingTransport:
+    def __init__(self, responses=None, status=200, text='{"data": {"stixBundlePush": true}}'):
+        self.calls, self.responses, self.status, self.text = [], list(responses or []), status, text
+
+    def post(self, url, headers, body, timeout):
+        self.calls.append((url, dict(headers), body, timeout))
+        return self.responses.pop(0) if self.responses else (self.status, self.text)
+
+
+# ---- the data: pattern mapping + index template ----------------------------
+def test_pattern_mapping_and_template_agree():
+    m, t = ind.load_pattern_mapping(), ind.load_template()
+    ind.validate_pattern_mapping({"indicator_path": m.indicator_path, "comparisons": m.comparisons})
+    ind.validate_template(t, m)
+    fields = ind.template_fields(t)
+    assert t["index_patterns"] == ["cti-*"] and t["template"]["mappings"]["dynamic"] == "strict"
+    assert fields["threat.indicator.ip"] == "ip" and fields["threat.indicator.id"] == "keyword"
+    assert m.indicator_path == "threat.indicator" == t["_meta"]["indicator_path"]
+    assert m.ecs_fields <= set(fields)                      # every comparison lands in a mapped field
+    assert {c["type"] for c in m.comparisons} >= {"ipv4-addr", "ipv6-addr", "domain-name", "url", "file", "email-addr"}
+    assert m.lookup("file:hashes.'SHA-256'")["ecs"] == "threat.indicator.file.hash.sha256"
+    assert m.lookup("file:hashes.sha256")["ecs"] == "threat.indicator.file.hash.sha256"   # forgiving spelling
+    assert m.lookup("process:pid") is None
+
+
+def test_validate_pattern_mapping_and_template_reject_drift():
+    m, t = ind.load_pattern_mapping(), ind.load_template()
+    with pytest.raises(ValueError, match="mapped twice"):
+        ind.validate_pattern_mapping({"indicator_path": "threat.indicator", "comparisons": m.comparisons + [m.comparisons[0]]})
+    with pytest.raises(ValueError, match="under threat.indicator"):
+        ind.validate_pattern_mapping({"indicator_path": "threat.indicator", "comparisons": [
+            {"stix": "a:b", "ecs": "source.ip", "type": "a", "value_type": "ip"}]})
+    props = lambda tpl: tpl["template"]["mappings"]["properties"]["threat"]["properties"]["indicator"]["properties"]  # noqa: E731
+    bad = copy.deepcopy(t)
+    bad["template"]["mappings"]["dynamic"] = True
+    with pytest.raises(ValueError, match="strict"):
+        ind.validate_template(bad, m)
+    bad = copy.deepcopy(t)
+    del props(bad)["ip"]
+    with pytest.raises(ValueError, match="not mapped"):
+        ind.validate_template(bad, m)
+    bad = copy.deepcopy(t)
+    props(bad)["ip"] = {"type": "keyword"}
+    with pytest.raises(ValueError, match="does not hold"):
+        ind.validate_template(bad, m)
+    bad = copy.deepcopy(t)
+    bad["index_patterns"] = ["logs-*"]
+    with pytest.raises(ValueError, match="cti-"):
+        ind.validate_template(bad, m)
+
+
+# ---- the pattern reader ----------------------------------------------------
+def test_parse_pattern_lifts_only_unnegated_equalities():
+    assert ind.parse_pattern("[ipv4-addr:value = '203.0.113.9']") == [("ipv4-addr:value", "203.0.113.9")]
+    assert ind.parse_pattern("[file:hashes.'SHA-256' = 'ab' OR file:hashes.MD5 = 'cd']") == \
+        [("file:hashes.SHA-256", "ab"), ("file:hashes.MD5", "cd")]
+    compound = ("[domain-name:value = 'a.example' AND domain-name:value != 'b.example' AND url:value NOT = 'c'"
+                " AND file:name LIKE 'x%' AND file:size > 10] FOLLOWEDBY [ipv6-addr:value = '2001:db8::1'] WITHIN 600 SECONDS")
+    assert ind.parse_pattern(compound) == [("domain-name:value", "a.example"), ("ipv6-addr:value", "2001:db8::1")]
+    assert ind.parse_pattern("[file:name = 'it\\'s.exe']") == [("file:name", "it's.exe")]
+    assert ind.parse_pattern("[autonomous-system:number = 64512]") == [("autonomous-system:number", "64512")]
+    assert ind.parse_pattern("rule x { condition: true }") == [] and ind.parse_pattern("") == []
+
+
+# ---- indicators -> cti-* documents ------------------------------------------
+def test_indicators_become_cti_docs_with_threat_indicator_fields():
+    docs, report = ind.to_cti_docs(BUNDLE_OBJECTS, now=NOW, template=ind.load_template())
+    assert report["indicators"] == 6 and report["docs"] == 4
+    assert report["skipped"] == {"pattern_type:yara": 1, "bad_value": 1}      # a YARA rule, a CIDR: counted, not guessed
+    by_id = {ind.document_id(d): d for d in docs}
+    ip = by_id[IND_IP]
+    assert ip["@timestamp"] == NOW
+    assert ip["event"] == {"kind": "enrichment", "category": ["threat"], "type": ["indicator"],
+                           "dataset": "cti.opencti", "module": "opencti"}
+    ti = ip["threat"]["indicator"]
+    assert ti["id"] == IND_IP and ti["type"] == "ipv4-addr" and ti["ip"] == "203.0.113.9"
+    assert ti["name"] == "C2 beacon" and ti["confidence"] == "High" and ti["provider"] == "ACME CTI"
+    assert ti["marking"] == {"tlp": "AMBER"} and ti["reference"] == "https://ref.example.test/1"
+    assert ti["first_seen"] == "2026-08-01T00:00:00.000Z" and ti["modified_at"] == "2026-08-15T00:00:00.000Z"
+    assert ip["threat"]["feed"] == {"name": "opencti"} and ip["tags"] == ["c2"]
+    assert ip["stix"]["pattern"] == "[ipv4-addr:value = '203.0.113.9']" and ip["stix"]["revoked"] is False
+    assert ip["stix"]["confidence"] == 85 and ip["stix"]["id"] == IND_IP
+    assert ip["opencti"] == {"id": "oc-1", "score": 80, "detection": True, "main_observable_type": "IPv4-Addr"}
+    h = by_id[IND_HASH]["threat"]["indicator"]
+    assert h["type"] == "file" and h["file"]["hash"] == {"sha256": SHA256, "md5": MD5} and h["confidence"] == "Medium"
+    assert by_id[IND_HASH]["stix"]["valid_until"] == "2027-01-01T00:00:00.000Z"
+    d = by_id[IND_DOMAIN]["threat"]["indicator"]
+    assert d["url"] == {"domain": "evil.example"} and d["confidence"] == "None"    # the != comparison is no atomic
+    assert d["marking"] == {"tlp": "AMBER+STRICT", "tlp_version": "2.0"}         # resolved through its marking object
+    u = by_id[IND_URL]
+    assert u["threat"]["indicator"]["url"] == {"original": "https://evil.example/p?q=1"} and u["stix"]["revoked"] is True
+    # every field written is one the STRICT template maps (else the bulk would be rejected)
+    fields = ind.template_fields(ind.load_template())
+    for doc in docs:
+        assert set(flatten(doc)) <= set(fields)
+
+
+def test_cti_doc_skip_reasons_values_and_markings():
+    m = ind.load_pattern_mapping()
+
+    def one(**extra):
+        obj = _indicator(IND_IP, "[ipv4-addr:value = '1.1.1.1']")
+        obj.update(extra)
+        return ind.to_cti_doc(obj, mapping=m, now=NOW)
+    assert one().doc["threat"]["indicator"]["ip"] == "1.1.1.1"
+    assert one(pattern="[mutex:name = 'x']").reason == "unmapped"
+    assert one(pattern="[ipv4-addr:value != '1.1.1.1']").reason == "no_comparison"
+    assert one(pattern="").reason == "no_pattern"
+    assert one(pattern_type="sigma").reason == "pattern_type:sigma"
+    assert one(id="indicator--not-a-uuid").reason == "bad_id"
+    assert ind.to_cti_doc({"type": "identity", "id": IDENTITY}, mapping=m, now=NOW).reason == "not_indicator"
+    two = one(pattern="[ipv4-addr:value = '1.1.1.1' OR ipv4-addr:value = '2.2.2.2' OR ipv4-addr:value = '1.1.1.1'"
+                      " OR ipv4-addr:value = '10.0.0.0/8']")
+    assert two.doc["threat"]["indicator"]["ip"] == ["1.1.1.1", "2.2.2.2"] and two.dropped == 1
+    assert one(confidence=None).doc["threat"]["indicator"]["confidence"] == "Not Specified"
+    assert (ind.confidence_label(29), ind.confidence_label(30), ind.confidence_label(70)) == ("Low", "Medium", "High")
+    assert ind.confidence_label(101) == "Not Specified" and ind.confidence_label(0) == "None"
+    # an unknown marking id resolves to no TLP; the spec's four ids need no context; the strictest wins
+    unknown = one(object_marking_refs=["marking-definition--" + str(uuid.uuid4())])
+    assert "marking" not in unknown.doc["threat"]["indicator"]
+    assert one(object_marking_refs=[TLP_AMBER, objects.TLP_MARKING_IDS["red"]]).doc["threat"]["indicator"]["marking"] == {"tlp": "RED"}
+    # a mapping target the template does not map is a defect, surfaced — not a rejected bulk later
+    off = ind.PatternMapping({"indicator_path": "threat.indicator", "comparisons": [
+        {"stix": "ipv4-addr:value", "ecs": "threat.indicator.nope", "type": "ipv4-addr", "value_type": "ip"}]})
+    with pytest.raises(ValueError, match="does not map"):
+        ind.to_cti_docs(BUNDLE_OBJECTS[:1], mapping=off, now=NOW, template=ind.load_template())
+
+
+def test_bulk_lines_are_upserts_keyed_on_the_stix_id():
+    docs, _ = ind.to_cti_docs(BUNDLE_OBJECTS, now=NOW)
+    lines = list(ind.bulk_lines(docs, "cti-opencti"))
+    assert len(lines) == 2 * len(docs) and all("\n" not in line for line in lines)
+    assert json.loads(lines[0]) == {"index": {"_index": "cti-opencti", "_id": IND_IP}}
+    assert json.loads(lines[1]) == docs[0]
+    for bad in ("cti-*", "logs-cti", ""):
+        with pytest.raises(ValueError):
+            list(ind.bulk_lines(docs, bad))
+
+
+# ---- the pull, through the stubbed transport -------------------------------
+def _node(sid, pattern, **extra):
+    node = {"id": "oc-" + sid[-4:], "standard_id": sid, "name": "n", "description": None, "pattern": pattern,
+            "pattern_type": "stix", "valid_from": "2026-08-01T00:00:00.000Z", "valid_until": None, "revoked": False,
+            "confidence": 85, "created": "2026-08-01T00:00:00.000Z", "modified": "2026-08-15T00:00:00.000Z",
+            "indicator_types": ["malicious-activity"], "x_opencti_score": 80, "x_opencti_detection": True,
+            "x_opencti_main_observable_type": "IPv4-Addr",
+            "objectLabel": [{"value": "c2"}],
+            "objectMarking": [{"standard_id": TLP_AMBER, "definition_type": "TLP", "definition": "TLP:AMBER",
+                               "created": "2017-01-20T00:00:00.000Z"}],
+            "createdBy": {"standard_id": IDENTITY, "name": "ACME CTI", "identity_class": "organization",
+                          "created": NOW, "modified": NOW},
+            "externalReferences": {"edges": [{"node": {"source_name": "x", "url": "https://ref.example.test/1",
+                                                       "external_id": None}}]},
+            "killChainPhases": [{"kill_chain_name": "mitre-attack", "phase_name": "command-and-control"}]}
+    node.update(extra)
+    return node
+
+
+def _page(nodes, cursor, more):
+    return 200, json.dumps({"data": {"indicators": {
+        "edges": [{"node": n} for n in nodes],
+        "pageInfo": {"endCursor": cursor, "hasNextPage": more, "globalCount": 3}}}})
+
+
+def test_pull_indicators_pages_through_the_stubbed_transport():
+    rec = RecordingTransport(responses=[
+        _page([_node(IND_IP, "[ipv4-addr:value = '203.0.113.9']"),
+               _node(IND_HASH, f"[file:hashes.'SHA-256' = '{SHA256}']")], "c1", True),
+        _page([_node(IND_DOMAIN, "[domain-name:value = 'evil.example']"),
+               {"standard_id": "indicator--x", "pattern": None}], "c2", False),
+    ])
+    client = opencti.OpenCTIClient("https://opencti.example.test", "tok-123", transport=rec, timeout=5)
+    result = client.pull_indicators(since="2026-08-01T00:00:00Z", page_size=2)
+    assert result.ok and result.indicators == 3 and result.pages == 2 and result.skipped == 1
+    # the exact requests: endpoint, bearer, the indicators query, cursor pagination, the since filter
+    assert [c[0] for c in rec.calls] == ["https://opencti.example.test/graphql"] * 2
+    assert rec.calls[0][1]["Authorization"] == "Bearer tok-123" and rec.calls[0][3] == 5.0
+    first, second = (json.loads(c[2]) for c in rec.calls)
+    assert first["query"].startswith("query DxdfirIndicators") and "indicators(" in first["query"]
+    assert first["variables"]["first"] == 2 and first["variables"]["after"] is None
+    assert first["variables"]["filters"]["filters"] == [
+        {"key": "modified", "values": ["2026-08-01T00:00:00.000Z"], "operator": "gt", "mode": "or"}]
+    assert second["variables"]["after"] == "c1"
+    # the bundle: the three indicators plus the marking / identity they reference, valid STIX 2.1
+    bundle = result.bundle
+    assert bundle["type"] == "bundle" and bundle["id"].startswith("bundle--")
+    assert export.summarise(bundle)["by_type"] == {"identity": 1, "indicator": 3, "marking-definition": 1}
+    assert export.validate_bundle(bundle) == ([], [])
+    ip = next(x for x in bundle["objects"] if x["id"] == IND_IP)
+    assert ip["pattern_type"] == "stix" and ip["created_by_ref"] == IDENTITY and ip["object_marking_refs"] == [TLP_AMBER]
+    assert ip["labels"] == ["c2"] and ip["external_references"] == [{"source_name": "x", "url": "https://ref.example.test/1"}]
+    assert ip["kill_chain_phases"] == [{"kill_chain_name": "mitre-attack", "phase_name": "command-and-control"}]
+    assert ip["x_opencti_id"] == "oc-" + IND_IP[-4:] and ip["x_opencti_score"] == 80 and ip["revoked"] is False
+    marking = next(x for x in bundle["objects"] if x["type"] == "marking-definition")
+    assert marking["definition"] == {"tlp": "amber"} and marking["definition_type"] == "tlp"
+    # ... and normalises straight into cti-* documents, provider and TLP resolved from the bundle
+    docs, report = ind.to_cti_docs(bundle["objects"], now=NOW)
+    assert report["docs"] == 3 and {ind.document_id(d) for d in docs} == {IND_IP, IND_HASH, IND_DOMAIN}
+    assert docs[0]["threat"]["indicator"]["provider"] == "ACME CTI"
+    assert docs[0]["threat"]["indicator"]["marking"] == {"tlp": "AMBER"}
+    # the token never reaches a summary; the summary counts the bundle instead of repeating it
+    assert "tok-123" not in json.dumps(result.as_dict()) and result.as_dict()["objects"] == 5
+    assert "tok-123" not in repr(client)
+
+
+def test_pull_indicators_reports_refusals_and_max_pages():
+    def pull(*responses, **kw):
+        client = opencti.OpenCTIClient("https://x.test", "t", transport=RecordingTransport(responses=list(responses)))
+        return client.pull_indicators(**kw)
+    assert not pull((401, "")).ok and "token" in pull((401, "")).message
+    refused = pull((200, '{"errors": [{"message": "Cannot query field filters"}]}'))
+    assert not refused.ok and "Cannot query field filters" in refused.message
+    down = pull((0, "connection refused"))
+    assert not down.ok and "unreachable" in down.message
+    drift = pull((200, '{"data": {"nope": 1}}'))
+    assert not drift.ok and "schema drift" in drift.message
+    assert not pull((500, "<html>boom</html>")).ok
+    # max_pages stops a runaway pull and says so
+    page = _page([_node(IND_IP, "[ipv4-addr:value = '1.1.1.1']")], "c", True)
+    capped = pull(page, page, page, max_pages=2)
+    assert capped.ok and capped.pages == 2 and "max_pages" in capped.message and capped.indicators == 1
+    # an empty platform is an empty (valid) result; a bad --since is refused before any request
+    empty = pull(_page([], None, False))
+    assert empty.ok and empty.indicators == 0 and empty.bundle["objects"] == []
+    with pytest.raises(ValueError):
+        pull(page, since="yesterday")
+    assert opencti.indicator_filters(None) is None
+
+
+# ---- indicator-match alerts -> sightings -----------------------------------
+def _alert(atomic="203.0.113.9", field="source.ip", ref=IND_IP, host="PC1", uuid_="al-1",
+           when="2026-08-31T12:00:00Z", extra_enrichment=None):
+    enrichments = [{"indicator": {"id": ref, "type": "ipv4-addr", "name": "C2 beacon", "provider": "ACME CTI",
+                                  "marking": {"tlp": "AMBER"}},
+                    "matched": {"atomic": atomic, "field": field, "id": ref, "index": "cti-opencti",
+                                "type": "indicator_match_rule"},
+                    "feed": {"name": "opencti"}}]
+    if extra_enrichment:
+        enrichments.append(extra_enrichment)
+    doc = {"@timestamp": "2026-09-02T09:00:00Z", "_index": ".alerts-security.alerts-default", "_id": uuid_,
+           "kibana": {"alert": {"uuid": uuid_, "original_time": when,
+                                "rule": {"rule_id": "cti-indicator-match", "name": "CTI indicator match",
+                                         "execution": {"uuid": "exec-1"}}}},
+           "source": {"ip": atomic}, "threat": {"enrichments": enrichments}}
+    if host:
+        doc["host"] = {"name": host}
+    return doc
+
+
+def test_indicator_match_alert_becomes_a_sighting_of_the_platform_indicator():
+    hash_hit = {"indicator": {"id": IND_HASH, "type": "file"},
+                "matched": {"atomic": SHA256, "field": "file.hash.sha256", "id": IND_HASH, "index": "cti-opencti",
+                            "type": "indicator_match_rule"}, "feed": {"name": "opencti"}}
+    bundle = sg.build_sightings_bundle([_alert(extra_enrichment=hash_hit)], case_id="CASE-17", now=NOW)
+    sightings = [x for x in bundle["objects"] if x["type"] == "sighting"]
+    by_ref = {s["sighting_of_ref"]: s for s in sightings}
+    assert set(by_ref) == {IND_IP, IND_HASH}                 # OpenCTI's own indicator ids ...
+    assert not [x for x in bundle["objects"] if x["type"] == "indicator"]   # ... never re-emitted
+    s = by_ref[IND_IP]
+    assert s["id"].startswith("sighting--") and s["spec_version"] == "2.1" and s["count"] == 1
+    assert s["first_seen"] == s["last_seen"] == "2026-08-31T12:00:00.000Z"
+    assert s["created"] == "2026-09-02T09:00:00.000Z"       # the alert's own time
+    host = next(x for x in bundle["objects"] if x["type"] == "identity" and x["name"] == "PC1")
+    assert s["where_sighted_refs"] == [host["id"]] and host["identity_class"] == "system"
+    od = next(x for x in bundle["objects"] if x["id"] == s["observed_data_refs"][0])
+    ip = next(x for x in bundle["objects"] if x["id"] == od["object_refs"][0])
+    assert ip == {"type": "ipv4-addr", "spec_version": "2.1", "value": "203.0.113.9",
+                  "id": "ipv4-addr--" + str(uuid.uuid5(SCO_NS, '{"value":"203.0.113.9"}')),
+                  "object_marking_refs": [TLP_AMBER]}
+    assert next(x for x in bundle["objects"] if x["type"] == "file")["hashes"] == {"SHA-256": SHA256}
+    assert s["x_dxdfir"]["matched"] == {"field": "source.ip", "atomic": "203.0.113.9", "index": "cti-opencti", "id": IND_IP}
+    assert s["x_dxdfir"]["detection_id"] == "cti-indicator-match" and s["x_dxdfir"]["alert_ids"] == ["al-1"]
+    assert s["x_dxdfir"]["case_id"] == "CASE-17" and s["x_dxdfir"]["feed"] == "opencti"
+    assert s["x_dxdfir"]["indicator"]["name"] == "C2 beacon"
+    assert "203.0.113.9" in s["description"] and "PC1" in s["description"]
+    errors, warnings = export.validate_bundle(bundle)
+    assert errors == [] and warnings and all("sighting_of_ref" in w for w in warnings)   # lives on the platform: warned
+    assert export.summarise(bundle)["sightings"] == 2
+
+
+def test_sightings_collapse_and_scope():
+    a1 = _alert(uuid_="al-1", when="2026-08-31T12:00:00Z")
+    a2 = _alert(uuid_="al-2", when="2026-08-30T08:00:00Z")
+    other_host, no_host = _alert(uuid_="al-3", host="PC2"), _alert(uuid_="al-4", host=None)
+    objs, report = sg.alert_sightings(
+        [a1, a2, other_host, no_host, {"event": {"id": "no enrichment"}}, _alert(ref="not-an-id", uuid_="al-5")],
+        case_id="CASE-1", now=NOW)
+    assert report == {"alerts": 6, "enrichments": 5, "sightings": 3,
+                      "skipped": {"no_enrichment": 1, "no_indicator_ref": 1}}
+    sightings = [x for x in objs.values() if x["type"] == "sighting"]
+    collapsed = next(s for s in sightings if s["count"] == 2)
+    assert collapsed["first_seen"] == "2026-08-30T08:00:00.000Z" and collapsed["last_seen"] == "2026-08-31T12:00:00.000Z"
+    assert collapsed["x_dxdfir"]["alert_ids"] == ["al-1", "al-2"]
+    producer = next(x for x in objs.values() if x["type"] == "identity" and x["name"] == "DX_DFIR")
+    unhosted = next(s for s in sightings if s["x_dxdfir"]["alert_ids"] == ["al-4"])
+    assert unhosted["where_sighted_refs"] == [producer["id"]]       # nobody named: the pipeline saw it
+    # case-scoped ids: idempotent within a case, distinct across cases; no case given: the rule execution id
+    ids = {s["id"] for s in sightings}
+    again, _ = sg.alert_sightings([a1, a2, other_host, no_host], case_id="CASE-1", now=NOW)
+    assert {k for k, v in again.items() if v["type"] == "sighting"} == ids
+    elsewhere, _ = sg.alert_sightings([a1], case_id="CASE-2", now=NOW)
+    assert not {k for k, v in elsewhere.items() if v["type"] == "sighting"} & ids
+    uncased, _ = sg.alert_sightings([a1], now=NOW)
+    assert next(v for v in uncased.values() if v["type"] == "sighting")["x_dxdfir"]["case_id"] == "exec-1"
+
+
+def test_matched_observables():
+    assert sg.matched_observable("destination.ip", "2001:db8::1")["type"] == "ipv6-addr"
+    assert sg.matched_observable("process.hash.md5", MD5)["hashes"] == {"MD5": MD5}
+    assert sg.matched_observable("dns.question.name", "Evil.Example.")["value"] == "evil.example"
+    assert sg.matched_observable("url.full", "https://evil.example/x")["type"] == "url"
+    assert sg.matched_observable("registry.key", "HKLM\\x") is None      # sighted without an observable
+    assert sg.matched_observable("source.ip", "PC1") is None            # not an address: nothing invented
+    assert objects.domain_name("") is None and objects.url(" ") is None
+    assert objects.domain_name("evil.example")["id"] == "domain-name--" + str(uuid.uuid5(SCO_NS, '{"value":"evil.example"}'))
+
+
+def test_run_sightings_pushes_through_the_stubbed_transport(tmp_path):
+    alerts = tmp_path / "alerts.json"
+    alerts.write_text(json.dumps({"took": 1, "hits": {"total": {"value": 1}, "hits": [
+        {"_index": ".alerts-security.alerts-default", "_id": "al-1", "_source": _alert()}]}}))
+    out = tmp_path / "exchange" / "sightings.json"
+    rec = RecordingTransport()
+    cfg = config.StixConfig(case_id="CASE-9", out=str(out), push=True, opencti_url="https://opencti.example.test",
+                            opencti_token="tok-123", opencti_connector_id="conn-1")
+    summary, bundle = sg.run_sightings(cfg, [str(alerts)], transport=rec, now=NOW)
+    assert summary["ok"] and summary["push"]["ok"] and summary["sightings"]["sightings"] == 1
+    assert json.loads(out.read_text()) == bundle and summary["validation"]["errors"] == []
+    url, headers, body, _timeout = rec.calls[0]
+    assert url == "https://opencti.example.test/graphql" and headers["Authorization"] == "Bearer tok-123"
+    payload = json.loads(body)
+    assert "stixBundlePush" in payload["query"] and payload["variables"]["connectorId"] == "conn-1"
+    pushed = json.loads(payload["variables"]["bundle"])
+    assert pushed == bundle
+    assert next(x for x in pushed["objects"] if x["type"] == "sighting")["sighting_of_ref"] == IND_IP
+    assert "tok-123" not in json.dumps(summary)
+    # a refused push is not ok; alerts without an enrichment, or no alerts at all, are refused up front
+    summary, _ = sg.run_sightings(cfg, [str(alerts)], transport=RecordingTransport(status=403, text=""), now=NOW)
+    assert not summary["ok"] and "token" in summary["push"]["message"]
+    plain = tmp_path / "plain.json"
+    plain.write_text(json.dumps([{"event": {"id": "x"}}]))
+    with pytest.raises(ValueError, match="enrichment"):
+        sg.run_sightings(config.StixConfig(), [str(plain)], now=NOW)
+    empty = tmp_path / "empty.json"
+    empty.write_text("")
+    with pytest.raises(ValueError, match="no alerts"):
+        sg.run_sightings(config.StixConfig(), [str(empty)], now=NOW)
+
+
+# ---- the pull verb + config + CLI -------------------------------------------
+def test_run_pull_from_bundle_and_via_client(tmp_path):
+    bundle_path = tmp_path / "indicators.json"
+    bundle_path.write_text(json.dumps({"type": "bundle", "id": "bundle--" + str(uuid.uuid4()), "objects": BUNDLE_OBJECTS}))
+    out = tmp_path / "copy" / "cti.ndjson"
+    summary, lines = ind.run_pull(config.StixConfig(cti_index="cti-case17"), from_bundle=str(bundle_path),
+                                  out=str(out), now=NOW)
+    assert summary["ok"] and summary["copy"]["docs"] == 4 and summary["index"] == "cti-case17"
+    written = out.read_text().splitlines()
+    assert written == lines and json.loads(written[0]) == {"index": {"_index": "cti-case17", "_id": IND_IP}}
+    # via the client: the transport is the stub, the pulled bundle is kept, the summary counts the pull
+    rec = RecordingTransport(responses=[_page([_node(IND_IP, "[ipv4-addr:value = '203.0.113.9']")], None, False)])
+    cfg = config.StixConfig(opencti_url="https://x.test", opencti_token="t")
+    keep = tmp_path / "pulled.json"
+    summary, lines = ind.run_pull(cfg, bundle_out=str(keep), transport=rec, now=NOW)
+    assert summary["ok"] and summary["pull"]["indicators"] == 1 and summary["copy"]["docs"] == 1 and len(lines) == 2
+    assert export.validate_bundle(json.loads(keep.read_text())) == ([], [])
+    assert summary["validation"]["errors"] == [] and summary["config"]["opencti_token"] == "***"
+    # a refused pull: not ok, nothing written
+    never = tmp_path / "never.ndjson"
+    summary, lines = ind.run_pull(cfg, out=str(never), transport=RecordingTransport(status=401, text=""), now=NOW)
+    assert not summary["ok"] and lines == [] and not never.exists()
+
+
+def test_config_cti_index_layers(tmp_path):
+    f = tmp_path / "stix.yml"
+    f.write_text("cti:\n  index: cti-file\n")
+    assert config.load_config(str(f), env={}).cti_index == "cti-file"
+    assert config.load_config(str(f), env={"DXDFIR_CTI_INDEX": "cti-env"}).cti_index == "cti-env"
+    assert config.load_config(str(f), env={"DXDFIR_CTI_INDEX": "cti-env"}, cti_index="cti-flag").cti_index == "cti-flag"
+    assert config.load_config(env={}).cti_index == "cti-opencti"
+
+
+def test_cli_stix_pull_and_sightings(tmp_path, monkeypatch):
+    runner = CliRunner()
+    for var in ("DXDFIR_OPENCTI_URL", "DXDFIR_OPENCTI_TOKEN", "DXDFIR_CTI_INDEX"):
+        monkeypatch.delenv(var, raising=False)
+    bundle_path = tmp_path / "indicators.json"
+    bundle_path.write_text(json.dumps({"type": "bundle", "id": "bundle--" + str(uuid.uuid4()), "objects": BUNDLE_OBJECTS}))
+    out = tmp_path / "cti.ndjson"
+    r = runner.invoke(cli.app, ["stix", "pull", "--from-bundle", str(bundle_path), "--out", str(out), "--index", "cti-case7"])
+    assert r.exit_code == 0, r.output
+    assert json.loads(out.read_text().splitlines()[0])["index"]["_index"] == "cti-case7"
+    summary = json.loads(r.stdout)
+    assert summary["copy"]["docs"] == 4 and summary["out"] == str(out)
+    # without --out the bulk lines are stdout; without endpoint/token (and no bundle) it is exit 2
+    r = runner.invoke(cli.app, ["stix", "pull", "--from-bundle", str(bundle_path)])
+    assert r.exit_code == 0, r.output
+    assert json.loads(r.stdout.splitlines()[0]) == {"index": {"_index": "cti-opencti", "_id": IND_IP}}
+    assert runner.invoke(cli.app, ["stix", "pull"]).exit_code == 2
+    # a live-shaped pull goes through the (stubbed) transport with endpoint/token/index from the environment
+    rec = RecordingTransport(responses=[_page([_node(IND_IP, "[ipv4-addr:value = '203.0.113.9']")], None, False)])
+    monkeypatch.setattr(opencti, "UrllibTransport", lambda: rec)
+    monkeypatch.setenv("DXDFIR_OPENCTI_URL", "https://env.test")
+    monkeypatch.setenv("DXDFIR_OPENCTI_TOKEN", "env-token")
+    monkeypatch.setenv("DXDFIR_CTI_INDEX", "cti-env")
+    r = runner.invoke(cli.app, ["stix", "pull", "--out", str(out), "--since", "2026-08-01T00:00:00Z"])
+    assert r.exit_code == 0, r.output
+    assert rec.calls[0][0] == "https://env.test/graphql" and rec.calls[0][1]["Authorization"] == "Bearer env-token"
+    assert json.loads(rec.calls[0][2])["variables"]["filters"]["filters"][0]["values"] == ["2026-08-01T00:00:00.000Z"]
+    assert json.loads(out.read_text().splitlines()[0])["index"]["_index"] == "cti-env"
+    assert "env-token" not in r.output
+    # a refused pull is exit 1; a bad --since is exit 2
+    monkeypatch.setattr(opencti, "UrllibTransport", lambda: RecordingTransport(status=403, text=""))
+    assert runner.invoke(cli.app, ["stix", "pull"]).exit_code == 1
+    assert runner.invoke(cli.app, ["stix", "pull", "--since", "yesterday"]).exit_code == 2
+    # sightings: alerts -> bundle on disk, --push through the transport
+    alerts = tmp_path / "alerts.jsonl"
+    alerts.write_text(json.dumps(_alert()) + "\n")
+    sightings_out = tmp_path / "sightings.json"
+    pushed = RecordingTransport()
+    monkeypatch.setattr(opencti, "UrllibTransport", lambda: pushed)
+    r = runner.invoke(cli.app, ["stix", "sightings", "--alerts", str(alerts), "--out", str(sightings_out),
+                                "--case", "CASE-7", "--push"])
+    assert r.exit_code == 0, r.output
+    bundle = json.loads(sightings_out.read_text())
+    assert export.validate_bundle(bundle)[0] == []
+    assert next(x for x in bundle["objects"] if x["type"] == "sighting")["sighting_of_ref"] == IND_IP
+    assert json.loads(json.loads(pushed.calls[0][2])["variables"]["bundle"]) == bundle
+    assert json.loads(r.stdout)["push"]["ok"] and "env-token" not in r.output
+    # no alerts given, or alerts without an enrichment: exit 2
+    assert runner.invoke(cli.app, ["stix", "sightings"]).exit_code == 2
+    plain = tmp_path / "plain.jsonl"
+    plain.write_text(json.dumps({"event": {"id": "x"}}) + "\n")
+    assert runner.invoke(cli.app, ["stix", "sightings", "--alerts", str(plain)]).exit_code == 2
+
+
+# ---- the indicator-match rule contract -------------------------------------
+@pytest.fixture(scope="module")
+def cti_contract():
+    return rl.load_cti_contract()
+
+
+def test_indicator_match_rule_validates_against_the_cti_template(cti_contract):
+    rule, template = cti_contract
+    rl.validate_indicator_match(rule, template)
+    assert rule["id"] == "cti-indicator-match" and rule["type"] == "threat_match" and rule["risk_score"] == 73
+    assert rule["threat_index"] == ["cti-*"] and rule["threat_indicator_path"] == "threat.indicator"
+    assert rule["language"] == rule["threat_language"] == "kuery"
+    assert set(rule["index"]) == {"logs-dfir.*-*", "logs-car.*-*"}      # every Byakugan evidence stream
+    assert rule["evidence"]["stamped_by"] == "engine" and rule["evidence"]["shape"] == "line"
+    assert set(rl.ROUND_TRIP_FIELDS) <= set(rule["evidence"]["fields"])  # what the sightings push reads
+    assert template == ind.load_template()                              # one template, both sides
+
+
+def test_indicator_match_targets_are_fields_the_copy_fills(cti_contract):
+    rule, template = cti_contract
+    mapping = ind.load_pattern_mapping()
+    values = {e["value"] for g in rule["threat_mapping"] for e in g["entries"]}
+    assert values <= mapping.ecs_fields                 # every match target is one a STIX comparison lands in
+    assert {"threat.indicator.ip", "threat.indicator.file.hash.sha256", "threat.indicator.url.domain"} <= values
+    fields = {e["field"] for g in rule["threat_mapping"] for e in g["entries"]}
+    assert {"source.ip", "destination.ip", "file.hash.sha256", "dns.question.name"} <= fields
+    tf = ind.template_fields(template)                  # the threat_query reads mapped fields
+    assert tf["stix.revoked"] == "boolean" and tf["stix.valid_until"] == "date"
+    assert "stix.revoked" in rule["threat_query"] and "stix.valid_until" in rule["threat_query"]
+
+
+def test_indicator_match_rule_is_beside_the_registry_pinned_set(cti_contract):
+    rule, _template = cti_contract
+    assert rule["id"] not in {r["id"] for r in rl.list_rules()}
+    assert rl.main([]) == 0             # the loader's CLI validates the contract alongside the rule set
+
+
+@pytest.mark.parametrize("patch", [
+    {"type": "query"},
+    {"language": "esql"},
+    {"threat_language": "kql"},
+    {"query": "FROM logs-dfir.*-* | WHERE a == 1"},                    # ES|QL is not a Kibana language
+    {"query": "source.ip:* and (x"},
+    {"query": "tostring(a) == 1"},                                     # a Kusto left-over
+    {"status": "stub"},
+    {"todo": {"query": "x", "blockers": ["y"]}},
+    {"severity": "info"},
+    {"index": ["cti-*"]},
+    {"threat_index": []},
+    {"threat_index": ["logs-*"]},                                      # not what the template covers
+    {"threat_indicator_path": "threat.feed.name"},                     # a leaf, not an object
+    {"threat_indicator_path": "threat.enrichments"},                   # not mapped
+    {"threat_mapping": []},
+    {"threat_mapping": [{"entries": []}]},
+    {"threat_mapping": [{"entries": [{"field": "source.ip", "type": "mapping", "value": "source.ip"}]}]},
+    {"threat_mapping": [{"entries": [{"field": "source.ip", "type": "mapping", "value": "threat.indicator.nope"}]}]},
+    {"threat_mapping": [{"entries": [{"field": "source.ip", "type": "lookup", "value": "threat.indicator.ip"}]}]},
+    {"threat_mapping": [{"entries": [{"field": "source.ip", "type": "mapping", "value": "threat.indicator.ip"}]}] * 2},
+    {"items_per_search": 0},
+    {"evidence": {"shape": "line", "stamped_by": "engine", "fields": ["rule.id"]}},
+    {"evidence": {"shape": "line", "stamped_by": "query",
+                  "fields": ["threat.enrichments.matched.atomic", "threat.enrichments.indicator.id"]}},
+    {"evidence": {"shape": "line", "stamped_by": "engine", "fields": ["kibana.alert.rule.rule_id"]}},
+    {"car_join": {"key": "guid", "via": "direct"}},
+    {"attack": ["T1"]},
+])
+def test_validate_indicator_match_rejects_drift(cti_contract, patch):
+    rule, template = (copy.deepcopy(c) for c in cti_contract)
+    with pytest.raises(ValueError):
+        rl.validate_indicator_match({**rule, **patch}, template)
+
+
+def test_validate_indicator_match_without_template_skips_only_the_cross_checks(cti_contract):
+    rule, _template = cti_contract
+    loose = {**copy.deepcopy(rule), "threat_index": ["cti-anything-*"],
+             "threat_mapping": [{"entries": [{"field": "a.b", "type": "mapping", "value": "threat.indicator.nope"}]}]}
+    rl.validate_indicator_match(loose)                       # no template: nothing to cross-check against
+    with pytest.raises(ValueError, match="not mapped"):
+        rl.validate_indicator_match(loose, ind.load_template())
+    with pytest.raises(ValueError, match="threat_index"):
+        rl.validate_indicator_match({**copy.deepcopy(rule), "threat_index": ["logs-*"]}, ind.load_template())
+
+
+def test_existing_rule_set_and_car_contract_still_validate():
+    rules = rl.list_rules()
+    rl.validate(rules)
+    rl.validate_car_detections(*rl.load_car_detections())
+    # the engine-prefix relaxation is opt-in: a plain rule's engine-stamped fields stay kibana.alert.* only
+    eql = next(r for r in rules if r["language"] == "eql")
+    with pytest.raises(ValueError, match="kibana.alert"):
+        rl.validate([{**eql, "evidence": {"shape": "line", "stamped_by": "engine",
+                                          "fields": ["threat.enrichments.matched.atomic"]}}])


### PR DESCRIPTION
OpenCTI stays an **exchange interface**; the detection engine is Elastic's own (D5). This wires the CTI direction around Elastic's **indicator match** — everything authored and structurally tested behind the existing stubbed `Transport`: no live OpenCTI, no Elasticsearch, no network, no secrets.

## What
- **Pull** — `OpenCTIClient.pull_indicators()` pages the platform's STIX 2.1 indicators (plus the markings / creator identities they reference) into one bundle; `--since` makes it incremental. Push and pull share one GraphQL error path (existing tests pin the push behaviour unchanged).
- **Copy (`cti-*`)** — `stix/cti/indicators.py` lifts the `=` comparisons out of each STIX pattern and lands the values under ECS `threat.indicator.*` per `pattern-mapping.yml`; `cti.index-template.json` is the strict `cti-*` template (`_id` = STIX id, so a re-pull upserts). Output is `_bulk` NDJSON. YARA/Sigma patterns, CIDRs, and unmapped observables are skipped and counted.
- **Match** — `detect/rules/cti/cti-indicator-match.yml`: the `threat_match` rule contract over `logs-dfir.*-*` / `logs-car.*-*` against `cti-*` (`threat_indicator_path: threat.indicator`). It lives beside the registry-pinned rule set (the `car-detections/` precedent), so the `test_rules` invariant that top-level rules == the Kusto registry stays intact; `rules_loader.validate_indicator_match()` checks it against the template.
- **Sightings back** — `stix/cti/sightings.py` turns indicator-match alerts (`threat.enrichments[]`) into STIX sightings whose `sighting_of_ref` is the platform's own indicator id, the matched value as the spec's SCO, host as `where_sighted_refs`; collapsed by (indicator, host, value) and pushed through the same client.
- CLI: `dxdfir stix pull` / `dxdfir stix sightings`; config `cti.index` / `DXDFIR_CTI_INDEX`.

## Tests / checks
- `tests/test_cti.py` (new): stubbed pull → valid STIX bundle → `cti-*` docs (every written field is template-mapped); alert → sighting pushed (endpoint, bearer header, payload asserted); template/mapping well-formed and agreeing; the rule validates and drift is rejected; CLI exit codes. Existing rules and tests unchanged.
- `pytest test_stix_export + test_rules + test_detect + test_cti` → **142 passed**; `./tests/run-checks.sh` → **72 passed, 0 failed** (ansible-lint production profile clean over 219 files — the new data YAML needed no exclude); `ruff` clean. Verified locally.
- Note: `test_carcheck.py::test_union_equals_sum_detects_fabrication` fails on `dev` already (a `_Checker` method missing in the Kusto/carcheck area) — pre-existing, unrelated, out of scope, and not part of the CI gate.

## Deferred (by decision)
Live exercise against OpenCTI / Elasticsearch in the operator's environment; `PUT _index_template/cti` and the Kibana rule import are the deploy step's job. The OpenCTI GraphQL query targets the 6.x schema shape (with a fallback reader for `edges`-shaped fields).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu)_