### PR TITLE
stix: address Copilot review on the merged CTI wiring (#109 follow-up)

### DIFF
--- a/python/get_sybers_dfir/stix/cli.py
+++ b/python/get_sybers_dfir/stix/cli.py
@@ -4,8 +4,8 @@
     dxdfir stix pull --out cti.ndjson [--since 2026-01-01T00:00:00Z]        # OpenCTI -> cti-* copy
     dxdfir stix sightings --alerts alerts.json --out sightings.json [--push]  # matches -> OpenCTI
 
-Exit codes: 0 done (and pushed, if asked); 1 the bundle failed validation, the
-push was refused, or the pull was; 2 bad input / missing configuration.
+Exit codes: 0 done (and pushed, if asked); 1 the bundle failed validation or a
+push or pull was refused; 2 bad input / missing configuration.
 """
 from __future__ import annotations
 

--- a/python/get_sybers_dfir/stix/cti/indicators.py
+++ b/python/get_sybers_dfir/stix/cti/indicators.py
@@ -49,7 +49,7 @@ _SPEC_TLP_NAMES = {mid: level.upper() for level, mid in o.TLP_MARKING_IDS.items(
 _INDICATOR_ID_RE = re.compile(r"^indicator--[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 _FIELD_RE = re.compile(r"^[@a-z][a-z0-9_]*(?:\.[A-Za-z0-9_]+)*$")
 _SCO_TYPE_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
-_INDEX_RE = re.compile(r"^cti-[a-z0-9_.*-]*$")       # a cti-* pattern or a concrete cti- name
+_INDEX_RE = re.compile(r"^cti-[a-z0-9_.*-]+$")       # a cti-* pattern or a concrete cti- name (>=1 char after "cti-")
 _ES_TYPES = {"ip": ("ip",), "integer": ("long", "integer", "short"), "string": ("keyword", "wildcard", "text")}
 
 # One STIX comparison expression: an object path (type:property, property

--- a/python/get_sybers_dfir/stix/opencti.py
+++ b/python/get_sybers_dfir/stix/opencti.py
@@ -330,6 +330,10 @@ class OpenCTIClient:
         given), paged, as one STIX 2.1 bundle with the markings and identities
         they reference. ``max_pages`` is a safety valve — the result says when
         it stopped the pull short."""
+        if page_size <= 0:
+            raise ValueError(f"page_size must be a positive integer, got {page_size!r}")
+        if max_pages is not None and max_pages <= 0:
+            raise ValueError(f"max_pages must be a positive integer or None, got {max_pages!r}")
         objects: dict[str, dict] = {}
         after: str | None = None
         pages = skipped = count = status = 0

--- a/python/tests/test_cti.py
+++ b/python/tests/test_cti.py
@@ -117,6 +117,10 @@ def test_validate_pattern_mapping_and_template_reject_drift():
     bad["index_patterns"] = ["logs-*"]
     with pytest.raises(ValueError, match="cti-"):
         ind.validate_template(bad, m)
+    bad = copy.deepcopy(t)
+    bad["index_patterns"] = ["cti-"]              # an empty dataset after "cti-" is not a valid index
+    with pytest.raises(ValueError, match="cti-"):
+        ind.validate_template(bad, m)
 
 
 # ---- the pattern reader ----------------------------------------------------
@@ -155,7 +159,7 @@ def test_indicators_become_cti_docs_with_threat_indicator_fields():
     assert h["type"] == "file" and h["file"]["hash"] == {"sha256": SHA256, "md5": MD5} and h["confidence"] == "Medium"
     assert by_id[IND_HASH]["stix"]["valid_until"] == "2027-01-01T00:00:00.000Z"
     d = by_id[IND_DOMAIN]["threat"]["indicator"]
-    assert d["url"] == {"domain": "evil.example"} and d["confidence"] == "None"    # the != comparison is no atomic
+    assert d["url"] == {"domain": "evil.example"} and d["confidence"] == "None"    # the != comparison is not atomic
     assert d["marking"] == {"tlp": "AMBER+STRICT", "tlp_version": "2.0"}         # resolved through its marking object
     u = by_id[IND_URL]
     assert u["threat"]["indicator"]["url"] == {"original": "https://evil.example/p?q=1"} and u["stix"]["revoked"] is True
@@ -289,6 +293,11 @@ def test_pull_indicators_reports_refusals_and_max_pages():
     page = _page([_node(IND_IP, "[ipv4-addr:value = '1.1.1.1']")], "c", True)
     capped = pull(page, page, page, max_pages=2)
     assert capped.ok and capped.pages == 2 and "max_pages" in capped.message and capped.indicators == 1
+    # non-positive paging is rejected up front, before any request
+    with pytest.raises(ValueError, match="page_size"):
+        pull(page_size=0)
+    with pytest.raises(ValueError, match="max_pages"):
+        pull(max_pages=0)
     # an empty platform is an empty (valid) result; a bad --since is refused before any request
     empty = pull(_page([], None, False))
     assert empty.ok and empty.indicators == 0 and empty.bundle["objects"] == []


### PR DESCRIPTION
Copilot's review on **#109** posted just after it merged, so these four land as a follow-up on `dev`.

- **`indicators._INDEX_RE`** — required at least one character after `cti-` (`*` → `+`), so an empty `cti-` index name/pattern is rejected at validation instead of failing later at runtime.
- **`opencti.pull_indicators()`** — reject non-positive `page_size` / `max_pages` up front with a clear `ValueError` (the CLI maps it to exit 2), rather than confusing OpenCTI GraphQL failures or odd loop behaviour.
- **`cli.py`** — fixed the truncated exit-code clause in the help docstring.
- **`test_cti.py`** — comment typo.

Two regression tests pin the real fixes: an empty `cti-` template pattern is rejected, and `page_size` / `max_pages` of `0` raise before any request.

## Checks
`pytest test_cti + test_stix_export + test_rules + test_detect` → **142 passed**; `./tests/run-checks.sh` → **72 passed, 0 failed**; `ruff` clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgwAWnyG2ARaZyYuo5Mnqu)_