### PR TITLE
Pin Python deps with a lockfile the installers consume

### DIFF
--- a/python/constraints.txt
+++ b/python/constraints.txt
@@ -1,0 +1,44 @@
+# Python dependency lock for the get_sybers_dfir CLI and the vendored
+# PIIAT-MitreCar engine it runs in-process.
+#
+# pyproject.toml carries the ">=" floors (what the code needs); THIS file pins the
+# exact, tested resolution so a fresh `pip install` is reproducible and an
+# unattended upstream release cannot shift a dependency under the pipeline
+# (build-car, ansible-core, the docker SDK, PyYAML, ...). It is the single source
+# of truth for Python versions — no version literals live in the shell installers,
+# they only reference this file.
+#
+# Consumed as a pip constraints file (`pip install ... -c python/constraints.txt`)
+# by BOTH scripts/setup-environment.sh (online) and scripts/package-offline.sh
+# (the offline wheel bundle), so both resolve identical versions. The Ansible
+# COLLECTIONS are pinned separately in
+# ansible/collections/get_sybers.dfir/requirements.yml.
+#
+# Regenerate after a deliberate dependency bump, then restore this header:
+#   python3 -m venv /tmp/lock && /tmp/lock/bin/pip install ./python \
+#     && /tmp/lock/bin/pip freeze --exclude-editable > python/constraints.txt
+#
+# Generated 2026-09-03, Python 3.13, get-sybers-dfir 0.6.0.
+
+annotated-doc==0.0.5
+ansible-core==2.21.3
+certifi==2026.7.22
+cffi==2.1.1
+charset-normalizer==3.5.1
+cryptography==50.0.1
+docker==7.2.0
+idna==3.19
+Jinja2==3.1.6
+markdown-it-py==4.2.0
+MarkupSafe==3.0.3
+mdurl==0.1.2
+packaging==26.3
+pycparser==3.0
+Pygments==2.21.0
+PyYAML==6.0.3
+requests==2.34.2
+resolvelib==1.2.1
+rich==15.0.0
+shellingham==1.5.4
+typer==0.27.2
+urllib3==2.7.0

--- a/scripts/package-offline.sh
+++ b/scripts/package-offline.sh
@@ -87,7 +87,9 @@ git -C "$REPO" archive --format=tar HEAD -o "$STAGE/repo.tar" \
 echo "🐍 Building the dxdfir CLI and downloading Python dependencies as wheels ..."
 # `pip wheel` BUILDS the local project into a wheel AND resolves every
 # dependency into wheels — the project itself is what `pip download` omits.
-$PIP wheel --wheel-dir "$STAGE/wheels" "$REPO/python" >/dev/null \
+# --constraint pins them to python/constraints.txt, the SAME lock
+# setup-environment.sh uses, so the offline bundle carries the exact tested versions.
+$PIP wheel --wheel-dir "$STAGE/wheels" --constraint "$REPO/python/constraints.txt" "$REPO/python" >/dev/null \
     || die "pip wheel of the CLI failed."
 # bootstrap wheels so the offline venv can upgrade its own pip
 $PIP download --dest "$STAGE/wheels" pip setuptools wheel >/dev/null 2>&1 || true

--- a/scripts/setup-environment.sh
+++ b/scripts/setup-environment.sh
@@ -292,8 +292,14 @@ DXDFIR_VENV="${DXDFIR_VENV:-/opt/dxdfir/venv}"
 echo "🐍 Installing the dxdfir CLI into $DXDFIR_VENV ..."
 $SUDO python3 -m venv "$DXDFIR_VENV" || die "Failed to create the CLI venv (need python3-venv)."
 $SUDO "$DXDFIR_VENV/bin/pip" install --quiet --upgrade pip || die "pip upgrade in the CLI venv failed."
+# --constraint pins the exact, tested dependency versions from python/constraints.txt
+# (pyproject carries the ">=" floors; the lock is the single source of truth this
+# installer AND scripts/package-offline.sh consume). Without it a fresh install pulls
+# whatever ansible-core / docker-SDK / PyYAML is newest and can shift the pipeline
+# under itself; with it there are no version literals to drift in this script.
 $SUDO "$DXDFIR_VENV/bin/pip" install --quiet --editable "$REPO_ROOT_DIR/python" \
-    || die "Failed to install the dxdfir CLI (and its ansible-core dependency)."
+    --constraint "$REPO_ROOT_DIR/python/constraints.txt" \
+    || die "Failed to install the dxdfir CLI (and its pinned dependencies)."
 $SUDO ln -sf "$DXDFIR_VENV/bin/dxdfir" /usr/local/bin/dxdfir
 echo "✅ dxdfir installed: $(/usr/local/bin/dxdfir --version 2>/dev/null || echo '/usr/local/bin/dxdfir')"
 


### PR DESCRIPTION
## What

Pins the Python side so a fresh install is reproducible — `ansible-core` and every DX dep were `>=` floors with no lockfile (the Ansible *collections* were the only exact pins).

- **`python/constraints.txt`** — the exact, tested resolution (Python 3.13, 0.6.0) as a single source of truth. Regeneration documented in its header.
- Consumed via `pip install -c python/constraints.txt` in both installers: `scripts/setup-environment.sh` (online, editable install) and `scripts/package-offline.sh` (offline wheel bundle).
- **No version literals in the shell scripts** — they only reference the lock, so nothing there can drift.

## Verified
`pip install --editable python/ -c python/constraints.txt` in a clean venv resolves to the locked versions (`ansible-core 2.21.3`, `typer 0.27.2`, `requests 2.34.2`, `docker 7.2.0`, `PyYAML 6.0.3`) and `dxdfir build-car` exits 0.

Supersedes #117 (auto-closed when #116's head branch was deleted on merge); this branch is cut fresh from `dev` so it carries only the pin lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
