### PR TITLE
Evidence collections + magic-byte raw/ auto-sorter (dxdfir collection, process all)

### DIFF
--- a/data_store/README.md
+++ b/data_store/README.md
@@ -43,6 +43,18 @@ data_store/
 
 **1. Place raw evidence** in the matching `raw/` subdirectory above.
 
+*Or auto-sort a mixed drop.* Create a collection and let `dxdfir` file a pile of
+mixed evidence into its lane subdirs by **magic bytes** (content, not extension —
+a mislabelled `.raw` E01 still lands in `disk_images/`; a header-less `.raw` with
+no signature is left in the dropzone for you to place by hand):
+
+```bash
+dxdfir collection create --name case-a   # -> data_store/raw/collections/case-a/
+#   ...drop mixed files into data_store/raw/sort/...
+dxdfir collection sort case-a            # magic-first sort into the lane subdirs
+dxdfir process all case-a                # run every lane over just this collection
+```
+
 **2. Process it.** The `dxdfir` CLI is the front-end (see
 [How It Runs](/README.md#how-it-runs)):
 

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import typer
 
 from . import __version__
+from . import collection as _collection
 from .stix.cli import app as stix_app
 
 app = typer.Typer(
@@ -53,6 +54,7 @@ class Source(str, enum.Enum):
     plaso = "plaso"
     zimmerman = "zimmerman"
     signatures = "signatures"
+    all = "all"  # every evidence lane (see `dxdfir process all [<collection>]`)
 
 
 class Pipeline(str, enum.Enum):
@@ -121,9 +123,35 @@ def _ansible_playbook() -> str:
 
 
 # --------------------------------------------------------------------------- commands
+def _process_lane(ap: str, repo: Path, name: str, pipeline: Pipeline, force: bool,
+                  extra_vars: list[str], scope_vars: list[str]) -> None:
+    """Drive one lane's process role (preflight → process → verify). ``scope_vars``
+    are extra ``KEY=VALUE`` input-dir overrides — how a collection narrows a lane."""
+    playbook = repo / _COLLECTION / "playbooks" / f"dfir-process-{name}.yml"
+    if not playbook.is_file():
+        typer.secho(f"no playbook for source '{name}': {playbook}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    cmd = [
+        ap, "-i", "localhost,", "-c", "local", str(playbook),
+        "-e", f"dfir_{name}_pipeline={pipeline.value}",
+        "-e", f"dfir_{name}_force={'true' if force else 'false'}",
+    ]
+    for kv in scope_vars:      # collection scope first, so an explicit --extra-var can still override
+        cmd += ["-e", kv]
+    for kv in extra_vars:
+        cmd += ["-e", kv]
+    # resolve the role without installing the collection
+    env = {"ANSIBLE_ROLES_PATH": str(repo / _COLLECTION / "roles")}
+    scoped = "  (collection-scoped)" if scope_vars else ""
+    typer.secho(f"processing {name} → {pipeline.value}{scoped}", fg=typer.colors.GREEN)
+    _run(cmd, cwd=repo, env=env)
+
+
 @app.command()
 def process(
-    source: Source = typer.Argument(..., help="Which evidence source to process."),
+    source: Source = typer.Argument(..., help="Evidence source to process, or 'all' for every lane."),
+    collection: str = typer.Argument(
+        None, help="Scope to a collection (data_store/raw/collections/<name>)."),
     pipeline: Pipeline = typer.Option(Pipeline.elastic, "--pipeline", "-p", help="Backend to target."),
     force: bool = typer.Option(False, "--force", help="Reprocess inputs that already have output."),
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
@@ -131,25 +159,46 @@ def process(
         None, "--extra-var", "-e", help="Extra Ansible var KEY=VALUE (repeatable)."
     ),
 ) -> None:
-    """Process one evidence source by driving its role (preflight → process → verify)."""
+    """Process one evidence source — or 'all' lanes — driving each role (preflight → process → verify).
+
+    With a COLLECTION, each lane is scoped to that collection's subdir under
+    data_store/raw/collections/<name>/. `dxdfir process all <collection>` runs
+    every lane that has evidence staged in the collection.
+    """
     _ap = _ansible_playbook()
     repo = _repo_root(repo_root)
-    name = source.value
-    playbook = repo / _COLLECTION / "playbooks" / f"dfir-process-{name}.yml"
-    if not playbook.is_file():
-        typer.secho(f"no playbook for source '{name}': {playbook}", fg=typer.colors.RED, err=True)
-        raise typer.Exit(2)
-    cmd = [
-        _ap, "-i", "localhost,", "-c", "local", str(playbook),
-        "-e", f"dfir_{name}_pipeline={pipeline.value}",
-        "-e", f"dfir_{name}_force={'true' if force else 'false'}",
-    ]
-    for kv in extra_var or []:
-        cmd += ["-e", kv]
-    # resolve the role without installing the collection
-    env = {"ANSIBLE_ROLES_PATH": str(repo / _COLLECTION / "roles")}
-    typer.secho(f"processing {name} → {pipeline.value}", fg=typer.colors.GREEN)
-    _run(cmd, cwd=repo, env=env)
+
+    # A collection scopes each lane's input dir(s), and tells us which lanes have evidence.
+    scope: dict[str, list[str]] = {}
+    counts: dict[str, int] = {}
+    if collection:
+        if collection not in _collection.list_collections(repo):
+            typer.secho(
+                f"no such collection '{collection}'. Create it: "
+                f"dxdfir collection create --name {collection}",
+                fg=typer.colors.RED, err=True)
+            raise typer.Exit(2)
+        for lane_name, var, d, n in _collection.lane_inputs(repo, collection):
+            scope.setdefault(lane_name, []).append(f"{var}={d}")
+            counts[lane_name] = counts.get(lane_name, 0) + n
+
+    if source is Source.all:
+        lanes = [lane.name for lane in _collection.LANES]     # the five evidence lanes
+        if collection:
+            lanes = [ln for ln in lanes if counts.get(ln, 0) > 0]
+            if not lanes:
+                typer.secho(
+                    f"collection '{collection}' has no evidence — drop files in "
+                    f"data_store/raw/sort/ then: dxdfir collection sort {collection}",
+                    fg=typer.colors.YELLOW)
+                return
+        typer.secho(f"process all → {', '.join(lanes)}"
+                    + (f"  (collection '{collection}')" if collection else ""), bold=True)
+    else:
+        lanes = [source.value]
+
+    for ln in lanes:
+        _process_lane(_ap, repo, ln, pipeline, force, extra_var or [], scope.get(ln, []))
 
 
 @app.command()
@@ -299,8 +348,8 @@ def list_sources(
     typer.secho(f"Evidence under {raw.relative_to(repo)}/", bold=True)
     for src in Source:
         name = src.value
-        if name == "signatures":
-            continue  # spans the other lanes' inputs; reported separately below
+        if name in ("signatures", "all"):
+            continue  # signatures spans the other lanes (reported below); 'all' is not a real lane
         subs, exts = _EVIDENCE[name]
         count = 0
         missing = []
@@ -317,6 +366,94 @@ def list_sources(
     typer.echo(f"  {'signatures':<13} {'—':>5}          scans pcaps / files / disk images / evtx (the lanes above)")
     typer.echo("")
     typer.echo("Process one with:  dxdfir process <source>   (see  dxdfir process -h)")
+
+
+# --------------------------------------------------------------------- collections
+collection_app = typer.Typer(
+    help="Group raw evidence into collections and auto-sort the raw/sort dropzone.",
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+app.add_typer(collection_app, name="collection")
+
+
+@collection_app.command("create")
+def collection_create(
+    name: str = typer.Option(..., "--name", "-n", help="Collection name (letters/digits then . _ -)."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Create a collection folder (its lane subdirs) under data_store/raw/collections/."""
+    repo = _repo_root(repo_root)
+    try:
+        root = _collection.create(repo, name)
+    except ValueError as e:
+        typer.secho(str(e), fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    typer.secho(f"✅ collection '{name}' ready at {root.relative_to(repo)}/", fg=typer.colors.GREEN)
+    typer.echo(f"   drop evidence in data_store/raw/sort/, then: dxdfir collection sort {name}")
+
+
+@collection_app.command("list")
+def collection_list(
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """List collections and how much evidence each holds, per lane."""
+    repo = _repo_root(repo_root)
+    cols = _collection.list_collections(repo)
+    if not cols:
+        typer.echo("No collections yet. Create one:  dxdfir collection create --name <name>")
+        return
+    for c in cols:
+        counts: dict[str, int] = {}
+        for lane_name, var, d, n in _collection.lane_inputs(repo, c):
+            counts[lane_name] = counts.get(lane_name, 0) + n
+        total = sum(counts.values())
+        detail = ", ".join(f"{ln}:{counts[ln]}" for ln in counts if counts[ln]) or "empty"
+        colour = typer.colors.GREEN if total else typer.colors.BRIGHT_BLACK
+        typer.echo(f"  {c:<22} {typer.style(f'{total:>4}', fg=colour)} file(s)  [{detail}]")
+
+
+@collection_app.command("sort")
+def collection_sort(
+    name: str = typer.Argument(None, help="Target collection (defaults to the only one, if unambiguous)."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show what would move; move nothing."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Sort the data_store/raw/sort dropzone into a collection's lane subdirs by file type.
+
+    Each file is classified by extension (the same lane/extension table `dxdfir list`
+    uses). A file whose type is ambiguous (`.raw` is a memory OR a disk image) or
+    unknown is left in the dropzone and reported — never guessed.
+    """
+    repo = _repo_root(repo_root)
+    cols = _collection.list_collections(repo)
+    if name is None:
+        if len(cols) == 1:
+            name = cols[0]
+        elif not cols:
+            typer.secho("No collections. Create one first:  dxdfir collection create --name <name>",
+                        fg=typer.colors.RED, err=True)
+            raise typer.Exit(2)
+        else:
+            typer.secho(f"Several collections ({', '.join(cols)}) — name one:  dxdfir collection sort <name>",
+                        fg=typer.colors.RED, err=True)
+            raise typer.Exit(2)
+    try:
+        res = _collection.sort_into(repo, name, dry_run=dry_run)
+    except ValueError as e:
+        typer.secho(str(e), fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    verb = "would move" if dry_run else "moved"
+    if res.moved:
+        typer.secho(f"✅ {verb} {res.moved_count} file(s) into collection '{name}':", fg=typer.colors.GREEN)
+        for sub in sorted(res.moved):
+            typer.echo(f"   {sub}/  ← {', '.join(res.moved[sub])}")
+    else:
+        typer.echo(f"Nothing to sort into '{name}' (dropzone: data_store/raw/sort/).")
+    if res.skipped:
+        typer.secho(f"⚠️  left in the dropzone ({len(res.skipped)} — place by hand):", fg=typer.colors.YELLOW)
+        for fn, why in res.skipped:
+            typer.echo(f"   {fn}  ({why})")
 
 
 def _version_cb(value: bool) -> None:

--- a/python/get_sybers_dfir/collection.py
+++ b/python/get_sybers_dfir/collection.py
@@ -1,0 +1,219 @@
+"""Evidence collections and the ``data_store/raw`` auto-sorter for the dxdfir CLI.
+
+A *collection* is a named case folder under
+``data_store/raw/collections/<name>/`` holding the same per-lane subdirs the
+processing roles read from (``pcaps/``, ``logs/winevt/``, ``memory/``,
+``disk_images/``, ``VM_files/``).
+
+Drop mixed evidence into the dropzone ``data_store/raw/sort/`` and
+``dxdfir collection sort <name>`` files each item into that collection's matching
+lane subdir. Classification is **not** reinvented here — it delegates to the
+processors' own magic-byte detectors (:func:`zeek.is_pcap`,
+:func:`plaso.detect_format` / :func:`plaso.ext_format`,
+:func:`volatility.is_memory_image`), so the sorter and the pipeline always agree
+on what a file is. **Content (magic bytes) wins over extension**, so an E01
+mislabelled ``.raw`` files as a disk image by its real header, not its name.
+
+``dxdfir process all <name>`` then drives every lane over just that collection,
+each role scoped to the collection's subdir via its input-dir Ansible var.
+
+Forensic-safe: a header-less file two lanes both claim by extension (``.raw`` is a
+memory image AND a raw disk image) or that none recognise is never guessed — it
+stays in the dropzone and is reported, for the operator to place by hand.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Lane:
+    """One processing lane: the ``raw/`` subdirs it reads and the Ansible
+    input-dir var(s) that point there (parallel to ``subdirs``) — the hook a
+    collection uses to scope ``dxdfir process`` to itself. Detection is the
+    processors' job (see :func:`classify`); this only says where a lane reads."""
+
+    name: str
+    subdirs: tuple[str, ...]
+    input_vars: tuple[str, ...]
+
+
+# Mirrors each dfir_<lane> role's input-dir defaults (defaults/main.yml).
+LANES: tuple[Lane, ...] = (
+    Lane("zeek", ("pcaps",), ("dfir_zeek_pcap_dir",)),
+    Lane("evtx", ("logs/winevt",), ("dfir_evtx_evtx_dir",)),
+    Lane("volatility", ("memory",), ("dfir_volatility_memory_dir",)),
+    Lane("plaso", ("disk_images", "VM_files"),
+         ("dfir_plaso_input_dir", "dfir_plaso_vm_dir")),
+    Lane("zimmerman", ("disk_images", "VM_files"),
+         ("dfir_zimmerman_input_dir", "dfir_zimmerman_vm_dir")),
+)
+
+# The lane subdirs a collection materialises (order = display order).
+LANE_SUBDIRS: tuple[str, ...] = ("pcaps", "logs/winevt", "memory", "disk_images", "VM_files")
+
+# How a plaso image format (from detect_format / ext_format) maps to a raw/ subdir.
+_DISK_FORMATS = ("ewf1", "ewf2", "ewf-cont", "qcow2", "aff", "raw")
+_VM_FORMATS = ("vmdk", "vmdk-extent", "vhd", "vhdx")
+
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_COLLECTIONS_REL = ("data_store", "raw", "collections")
+_DROPZONE_REL = ("data_store", "raw", "sort")
+_MARKER = ".collection"
+
+
+# --------------------------------------------------------------- paths / naming
+def collections_root(repo: Path) -> Path:
+    return repo.joinpath(*_COLLECTIONS_REL)
+
+
+def dropzone(repo: Path) -> Path:
+    return repo.joinpath(*_DROPZONE_REL)
+
+
+def collection_dir(repo: Path, name: str) -> Path:
+    return collections_root(repo) / name
+
+
+def valid_name(name: str) -> bool:
+    return name not in (".", "..") and bool(_NAME_RE.match(name))
+
+
+def list_collections(repo: Path) -> list[str]:
+    """Names of collections (a dir under collections/ carrying the marker)."""
+    root = collections_root(repo)
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir()
+                  if p.is_dir() and (p / _MARKER).exists())
+
+
+def create(repo: Path, name: str) -> Path:
+    """Create a collection — its lane subdirs and marker — and ensure the shared
+    dropzone exists. Idempotent. Raises ValueError on a bad name."""
+    if not valid_name(name):
+        raise ValueError(
+            f"invalid collection name {name!r} — use letters/digits then . _ -")
+    root = collection_dir(repo, name)
+    for sub in LANE_SUBDIRS:
+        (root / sub).mkdir(parents=True, exist_ok=True)
+    (root / _MARKER).write_text(f"name: {name}\n", encoding="utf-8")
+    dropzone(repo).mkdir(parents=True, exist_ok=True)
+    return root
+
+
+# --------------------------------------------------------------- classification
+def _content_subdir(path: Path) -> str | None:
+    """The lane subdir from CONTENT (magic bytes) alone — the definitive signal,
+    reusing the processors' own magic checks. None when nothing matches by magic."""
+    from . import plaso, zeek  # lazy import: keep `dxdfir` startup light
+    p = str(path)
+    try:
+        with open(p, "rb") as fh:
+            head4 = fh.read(4).hex()
+    except OSError:
+        head4 = ""
+    if head4 in zeek._PCAP_MAGIC:            # zeek's authoritative pcap magic set
+        return "pcaps"
+    cfmt = plaso.detect_format(p)            # plaso's image magic (EWF/VMDK/VHDX/QCOW2)
+    if cfmt in _DISK_FORMATS:
+        return "disk_images"
+    if cfmt in _VM_FORMATS:
+        return "VM_files"
+    return None
+
+
+def _ext_subdirs(path: Path) -> set[str]:
+    """Lane subdirs claiming this file by NAME/extension — the fallback used only
+    when no magic matched. Reuses the processors' own extension logic."""
+    from . import plaso, volatility, zeek  # lazy import
+    claims: set[str] = set()
+    if zeek.is_pcap(str(path)):                 # .pcap/.pcapng/.cap (magic already missed)
+        claims.add("pcaps")
+    efmt = plaso.ext_format(str(path))
+    if efmt in _DISK_FORMATS:
+        claims.add("disk_images")
+    elif efmt in _VM_FORMATS:
+        claims.add("VM_files")
+    if volatility.is_memory_image(path.name):   # memory-dump extensions
+        claims.add("memory")
+    if path.name.lower().endswith(".evtx"):     # Windows event log
+        claims.add("logs/winevt")
+    return claims
+
+
+def classify(path: Path) -> tuple[str | None, str]:
+    """Where a file sorts to, magic-first via the processors' detectors.
+
+    ``(subdir, "ok")`` — a single lane owns it; ``(None, "ambiguous:a,b")`` —
+    several lanes claim it by extension with no magic to break the tie (a
+    header-less ``.raw`` is a memory OR a disk image); ``(None, "unknown")`` —
+    nothing recognises it. Content beats extension, so a mislabelled image is
+    filed by its real type.
+    """
+    magic = _content_subdir(path)
+    if magic:
+        return magic, "ok"
+    claims = _ext_subdirs(path)
+    if not claims:
+        return None, "unknown"
+    if len(claims) > 1:
+        return None, "ambiguous:" + ",".join(sorted(claims))
+    return next(iter(claims)), "ok"
+
+
+# --------------------------------------------------------------- sort / inspect
+@dataclass
+class SortResult:
+    moved: dict[str, list[str]] = field(default_factory=dict)      # subdir -> filenames
+    skipped: list[tuple[str, str]] = field(default_factory=list)   # (filename, reason)
+
+    @property
+    def moved_count(self) -> int:
+        return sum(len(v) for v in self.moved.values())
+
+
+def sort_into(repo: Path, name: str, *, dry_run: bool = False) -> SortResult:
+    """Classify each file directly in the dropzone and move it into the named
+    collection's matching lane subdir. Ambiguous/unknown files stay and are
+    reported. Sub-directories and dotfiles in the dropzone are ignored."""
+    if name not in list_collections(repo):
+        raise ValueError(
+            f"no such collection {name!r} — create it first: "
+            f"dxdfir collection create --name {name}")
+    dz = dropzone(repo)
+    dz.mkdir(parents=True, exist_ok=True)
+    root = collection_dir(repo, name)
+    res = SortResult()
+    for p in sorted(dz.iterdir()):
+        if p.is_dir() or p.name.startswith("."):
+            continue
+        subdir, reason = classify(p)
+        if subdir is None:
+            res.skipped.append((p.name, reason))
+            continue
+        dest = root / subdir / p.name
+        if dest.exists():
+            res.skipped.append((p.name, f"already in {subdir}/"))
+            continue
+        if not dry_run:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(p), str(dest))
+        res.moved.setdefault(subdir, []).append(p.name)
+    return res
+
+
+def lane_inputs(repo: Path, name: str) -> list[tuple[str, str, Path, int]]:
+    """For ``process all``: one ``(lane, input_var, dir, file_count)`` per lane
+    input, scoped to the collection."""
+    root = collection_dir(repo, name)
+    out: list[tuple[str, str, Path, int]] = []
+    for lane in LANES:
+        for var, sub in zip(lane.input_vars, lane.subdirs):
+            d = root / sub
+            n = sum(1 for f in d.rglob("*") if f.is_file()) if d.is_dir() else 0
+            out.append((lane.name, var, d, n))
+    return out

--- a/python/tests/test_collection.py
+++ b/python/tests/test_collection.py
@@ -1,0 +1,101 @@
+"""Unit tests for get_sybers_dfir.collection — the raw/ auto-sorter.
+
+Classification delegates to the processors' own magic-byte detectors, so these
+tests assert the delegation: content (magic) beats extension, a header-less
+``.raw`` is ambiguous, and create/sort file evidence into the right lane subdirs.
+No docker/ansible — pure filesystem.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from get_sybers_dfir import collection
+
+# EWF/E01 header "EVF\x09\x0d\x0a\xff\x00" + fields_start + segment 1 (uint16 LE).
+_EWF_MAGIC = b"\x45\x56\x46\x09\x0d\x0a\xff\x00\x01\x01\x00"
+_PCAP_MAGIC = b"\xa1\xb2\xc3\xd4"
+
+
+def _write(p: Path, data: bytes = b"") -> Path:
+    p.write_bytes(data)
+    return p
+
+
+def test_classify_magic_beats_extension(tmp_path):
+    # An E01 mislabelled .raw must file as a disk image by its header, not its name.
+    f = _write(tmp_path / "image.raw", _EWF_MAGIC + b"padding")
+    assert collection.classify(f) == ("disk_images", "ok")
+
+
+def test_classify_pcap_magic_over_odd_extension(tmp_path):
+    f = _write(tmp_path / "capture.dat", _PCAP_MAGIC + b"rest")
+    assert collection.classify(f) == ("pcaps", "ok")
+
+
+def test_classify_headerless_raw_is_ambiguous(tmp_path):
+    subdir, reason = collection.classify(_write(tmp_path / "dump.raw", b"no magic here"))
+    assert subdir is None
+    assert reason == "ambiguous:disk_images,memory"
+
+
+def test_classify_memory_extension(tmp_path):
+    assert collection.classify(_write(tmp_path / "ram.mem"))[0] == "memory"
+
+
+def test_classify_evtx_extension(tmp_path):
+    assert collection.classify(_write(tmp_path / "Security.evtx"))[0] == "logs/winevt"
+
+
+def test_classify_unknown(tmp_path):
+    assert collection.classify(_write(tmp_path / "notes.txt", b"hello")) == (None, "unknown")
+
+
+def test_create_makes_lane_subdirs_and_marker(tmp_path):
+    root = collection.create(tmp_path, "case-a")
+    assert (root / ".collection").is_file()
+    for sub in collection.LANE_SUBDIRS:
+        assert (root / sub).is_dir()
+    assert collection.list_collections(tmp_path) == ["case-a"]
+    assert collection.dropzone(tmp_path).is_dir()
+
+
+def test_create_rejects_bad_name(tmp_path):
+    with pytest.raises(ValueError):
+        collection.create(tmp_path, "../escape")
+
+
+def test_sort_routes_and_leaves_ambiguous(tmp_path):
+    collection.create(tmp_path, "case-a")
+    dz = collection.dropzone(tmp_path)
+    _write(dz / "image.raw", _EWF_MAGIC)     # -> disk_images (magic)
+    _write(dz / "capture.dat", _PCAP_MAGIC)  # -> pcaps (magic)
+    _write(dz / "ram.mem")                   # -> memory (ext)
+    _write(dz / "Security.evtx")             # -> logs/winevt (ext)
+    _write(dz / "dump.raw", b"no magic")     # -> ambiguous, stays
+    _write(dz / "notes.txt", b"x")           # -> unknown, stays
+    res = collection.sort_into(tmp_path, "case-a")
+    root = collection.collection_dir(tmp_path, "case-a")
+    assert (root / "disk_images" / "image.raw").is_file()
+    assert (root / "pcaps" / "capture.dat").is_file()
+    assert (root / "memory" / "ram.mem").is_file()
+    assert (root / "logs" / "winevt" / "Security.evtx").is_file()
+    assert res.moved_count == 4
+    assert (dz / "dump.raw").is_file() and (dz / "notes.txt").is_file()
+    skipped = {n: why for n, why in res.skipped}
+    assert skipped["dump.raw"].startswith("ambiguous")
+    assert skipped["notes.txt"] == "unknown"
+
+
+def test_sort_is_idempotent_on_second_run(tmp_path):
+    collection.create(tmp_path, "case-a")
+    _write(collection.dropzone(tmp_path) / "capture.dat", _PCAP_MAGIC)
+    assert collection.sort_into(tmp_path, "case-a").moved_count == 1
+    # nothing left to move; a re-run moves nothing and does not error
+    assert collection.sort_into(tmp_path, "case-a").moved_count == 0
+
+
+def test_sort_unknown_collection_raises(tmp_path):
+    with pytest.raises(ValueError):
+        collection.sort_into(tmp_path, "nope")


### PR DESCRIPTION
## What

Evidence **collections** + a **magic-byte auto-sorter** for `data_store/raw`, and a `process all` verb — the requested workflow:

```bash
dxdfir collection create --name case-a   # data_store/raw/collections/case-a/
#   ...drop mixed evidence into data_store/raw/sort/...
dxdfir collection sort case-a            # file each item into the right lane subdir
dxdfir process all case-a                # run every lane over just this collection
```

## Classification is reused, not reinvented
`collection sort` delegates to the processors' **own magic-byte detectors** — `zeek.is_pcap` (`_PCAP_MAGIC`), `plaso.detect_format`/`ext_format` (EWF/VMDK/VHDX/QCOW2 magic), `volatility.is_memory_image` — so the sorter and the pipeline agree on what a file is. **Content beats extension:** an E01 mislabelled `.raw` files to `disk_images/` by its header, not its name. Forensic-safe: a header-less `.raw` (memory OR disk, no signature) or an unrecognised file is never guessed — it stays in the dropzone and is reported for manual placement.

## process all
`dxdfir process all [<collection>]` runs every evidence lane; with a collection it scopes each role to the collection's subdir via its input-dir var (`dfir_zeek_pcap_dir`, `dfir_plaso_input_dir`, …) and skips lanes with no evidence. Backward-compatible: `dxdfir process <lane>` is unchanged.

## Tested
- `python/tests/test_collection.py` — 11 tests (magic-beats-extension proof, ambiguous `.raw`, unknown, create/sort/idempotency). Green; existing `test_cli.py` still green.
- Verified live via the installed CLI: a crafted EWF-magic `.raw` → `disk_images/`, a pcap-magic `.dat` → `pcaps/`, a header-less `.raw` left in the dropzone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
