### PR TITLE
Collections: register hand-staged folders + per-file SHA-1 manifest + log

### DIFF
--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -157,15 +157,16 @@ def _resolve_collection(repo: Path, name: str, *, no_register: bool = False) -> 
 
 
 def _hash_and_report(repo: Path, name: str) -> None:
-    """SHA-1 the collection's evidence, persist the manifest, print the rollup."""
+    """SHA-256 + SHA-1 the collection's evidence, persist the manifest, print the rollups."""
     n = len(_collection.evidence_files(_collection.collection_dir(repo, name)))
     if n == 0:
         typer.echo("  (no evidence files to hash yet)")
         return
     typer.secho(f"🔒 hashing {n} evidence file(s) …", fg=typer.colors.BRIGHT_BLACK)
-    rollup, count = _collection.write_manifest(repo, name)
-    typer.secho(f"   collection SHA-1: {rollup}  ({count} files → .collection.sha1)",
-                fg=typer.colors.GREEN)
+    rollups, count = _collection.write_manifest(repo, name)
+    typer.secho(f"   SHA-256: {rollups['sha256']}", fg=typer.colors.GREEN)
+    typer.secho(f"   SHA-1:   {rollups['sha1']}  ({count} files → .collection.hashes)",
+                fg=typer.colors.BRIGHT_BLACK)
 
 
 def _process_lane(ap: str, repo: Path, name: str, pipeline: Pipeline, force: bool,
@@ -245,7 +246,7 @@ def process(
         _collection.log_event(
             repo, collection, "processed", lanes=lanes, pipeline=pipeline.value,
             files={ln: counts.get(ln, 0) for ln in lanes},
-            collection_sha1=_collection.manifest_rollup(repo, collection))
+            collection_sha256=_collection.manifest_rollup(repo, collection))
 
 
 @app.command()
@@ -459,7 +460,7 @@ def collection_list(
         total = sum(counts.values())
         detail = ", ".join(f"{ln}:{counts[ln]}" for ln in counts if counts[ln]) or "empty"
         roll = _collection.manifest_rollup(repo, c)
-        sha = f"  sha1:{roll[:12]}…" if roll else ""
+        sha = f"  sha256:{roll[:12]}…" if roll else ""
         colour = typer.colors.GREEN if total else typer.colors.BRIGHT_BLACK
         tagged = f"  {typer.style(tag, fg=tag_colour)}" if tag else ""
         typer.echo(f"  {c:<22} {typer.style(f'{total:>4}', fg=colour)} file(s)  [{detail}]{sha}{tagged}")
@@ -495,11 +496,11 @@ def collection_hash(
     name: str = typer.Argument(..., help="Collection to hash."),
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
 ) -> None:
-    """SHA-1 every evidence file and record the collection's rollup SHA-1.
+    """SHA-256 + SHA-1 every evidence file and record the collection's rollup hashes.
 
-    Writes data_store/raw/collections/<name>/.collection.sha1 — a per-file manifest
-    plus the collection SHA-1 (= SHA-1 of the sorted per-file hashes). As slow as
-    the evidence is large.
+    Writes data_store/raw/collections/<name>/.collection.hashes — a per-file
+    manifest plus the collection rollups (each = the hash of the sorted per-file
+    digests). SHA-256 is primary. As slow as the evidence is large.
     """
     repo = _repo_root(repo_root)
     if not _collection.collection_dir(repo, name).is_dir():

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -21,6 +21,7 @@ harness (``tests/run-checks.sh``).
 from __future__ import annotations
 
 import enum
+import json
 import os
 import shutil
 import subprocess
@@ -123,6 +124,50 @@ def _ansible_playbook() -> str:
 
 
 # --------------------------------------------------------------------------- commands
+def _resolve_collection(repo: Path, name: str, *, no_register: bool = False) -> None:
+    """Make a collection usable before it is sorted or processed. Registered -> ok.
+    A hand-staged (unregistered) folder -> offer to register it (prompt when
+    interactive, auto otherwise) so the run is recorded, unless --no-register.
+    Absent -> error out."""
+    if _collection.is_registered(repo, name):
+        return
+    if name in _collection.unregistered(repo):
+        if no_register:
+            typer.secho(f"⚠️  '{name}' is unregistered — proceeding untracked (no log).",
+                        fg=typer.colors.YELLOW)
+            return
+        do_register = True
+        if sys.stdin.isatty():
+            do_register = typer.confirm(
+                f"Detected unregistered collection '{name}'. Register it to keep a "
+                "processing record?", default=True)
+        else:
+            typer.secho(f"ℹ️  auto-registering detected collection '{name}' (non-interactive).",
+                        fg=typer.colors.BRIGHT_BLACK)
+        if do_register:
+            _collection.register(repo, name, source="detected")
+            typer.secho(f"✅ registered '{name}'.", fg=typer.colors.GREEN)
+        else:
+            typer.secho(f"⚠️  '{name}' left unregistered — this run won't be logged.",
+                        fg=typer.colors.YELLOW)
+        return
+    typer.secho(f"no such collection '{name}'. Create it: "
+                f"dxdfir collection create --name {name}", fg=typer.colors.RED, err=True)
+    raise typer.Exit(2)
+
+
+def _hash_and_report(repo: Path, name: str) -> None:
+    """SHA-1 the collection's evidence, persist the manifest, print the rollup."""
+    n = len(_collection.evidence_files(_collection.collection_dir(repo, name)))
+    if n == 0:
+        typer.echo("  (no evidence files to hash yet)")
+        return
+    typer.secho(f"🔒 hashing {n} evidence file(s) …", fg=typer.colors.BRIGHT_BLACK)
+    rollup, count = _collection.write_manifest(repo, name)
+    typer.secho(f"   collection SHA-1: {rollup}  ({count} files → .collection.sha1)",
+                fg=typer.colors.GREEN)
+
+
 def _process_lane(ap: str, repo: Path, name: str, pipeline: Pipeline, force: bool,
                   extra_vars: list[str], scope_vars: list[str]) -> None:
     """Drive one lane's process role (preflight → process → verify). ``scope_vars``
@@ -158,6 +203,8 @@ def process(
     extra_var: list[str] = typer.Option(
         None, "--extra-var", "-e", help="Extra Ansible var KEY=VALUE (repeatable)."
     ),
+    no_register: bool = typer.Option(
+        False, "--no-register", help="With a collection: process an unregistered one without registering/logging."),
 ) -> None:
     """Process one evidence source — or 'all' lanes — driving each role (preflight → process → verify).
 
@@ -172,12 +219,7 @@ def process(
     scope: dict[str, list[str]] = {}
     counts: dict[str, int] = {}
     if collection:
-        if collection not in _collection.list_collections(repo):
-            typer.secho(
-                f"no such collection '{collection}'. Create it: "
-                f"dxdfir collection create --name {collection}",
-                fg=typer.colors.RED, err=True)
-            raise typer.Exit(2)
+        _resolve_collection(repo, collection, no_register=no_register)
         for lane_name, var, d, n in _collection.lane_inputs(repo, collection):
             scope.setdefault(lane_name, []).append(f"{var}={d}")
             counts[lane_name] = counts.get(lane_name, 0) + n
@@ -199,6 +241,11 @@ def process(
 
     for ln in lanes:
         _process_lane(_ap, repo, ln, pipeline, force, extra_var or [], scope.get(ln, []))
+    if collection and _collection.is_registered(repo, collection):
+        _collection.log_event(
+            repo, collection, "processed", lanes=lanes, pipeline=pipeline.value,
+            files={ln: counts.get(ln, 0) for ln in lanes},
+            collection_sha1=_collection.manifest_rollup(repo, collection))
 
 
 @app.command()
@@ -397,47 +444,119 @@ def collection_create(
 def collection_list(
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
 ) -> None:
-    """List collections and how much evidence each holds, per lane."""
+    """List collections (registered and hand-staged) with counts and rollup SHA-1."""
     repo = _repo_root(repo_root)
-    cols = _collection.list_collections(repo)
-    if not cols:
+    registered = _collection.list_collections(repo)
+    unreg = _collection.unregistered(repo)
+    if not registered and not unreg:
         typer.echo("No collections yet. Create one:  dxdfir collection create --name <name>")
         return
-    for c in cols:
+
+    def _row(c: str, tag: str, tag_colour: str) -> None:
         counts: dict[str, int] = {}
         for lane_name, var, d, n in _collection.lane_inputs(repo, c):
             counts[lane_name] = counts.get(lane_name, 0) + n
         total = sum(counts.values())
         detail = ", ".join(f"{ln}:{counts[ln]}" for ln in counts if counts[ln]) or "empty"
+        roll = _collection.manifest_rollup(repo, c)
+        sha = f"  sha1:{roll[:12]}…" if roll else ""
         colour = typer.colors.GREEN if total else typer.colors.BRIGHT_BLACK
-        typer.echo(f"  {c:<22} {typer.style(f'{total:>4}', fg=colour)} file(s)  [{detail}]")
+        tagged = f"  {typer.style(tag, fg=tag_colour)}" if tag else ""
+        typer.echo(f"  {c:<22} {typer.style(f'{total:>4}', fg=colour)} file(s)  [{detail}]{sha}{tagged}")
+
+    for c in registered:
+        _row(c, "", typer.colors.GREEN)
+    for c in unreg:
+        _row(c, "unregistered", typer.colors.YELLOW)
+    if unreg:
+        typer.echo("\n  register a detected one:  dxdfir collection register <name>")
+
+
+@collection_app.command("register")
+def collection_register(
+    name: str = typer.Argument(..., help="A hand-staged folder under data_store/raw/collections/."),
+    do_hash: bool = typer.Option(True, "--hash/--no-hash", help="Also SHA-1 the evidence (manifest + rollup)."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Register a hand-staged collection so it is tracked and logged."""
+    repo = _repo_root(repo_root)
+    try:
+        _collection.register(repo, name, source="manual")
+    except ValueError as e:
+        typer.secho(str(e), fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    typer.secho(f"✅ registered '{name}' — now tracked and logged.", fg=typer.colors.GREEN)
+    if do_hash:
+        _hash_and_report(repo, name)
+
+
+@collection_app.command("hash")
+def collection_hash(
+    name: str = typer.Argument(..., help="Collection to hash."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """SHA-1 every evidence file and record the collection's rollup SHA-1.
+
+    Writes data_store/raw/collections/<name>/.collection.sha1 — a per-file manifest
+    plus the collection SHA-1 (= SHA-1 of the sorted per-file hashes). As slow as
+    the evidence is large.
+    """
+    repo = _repo_root(repo_root)
+    if not _collection.collection_dir(repo, name).is_dir():
+        typer.secho(f"no such collection '{name}'.", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    _hash_and_report(repo, name)
+
+
+@collection_app.command("log")
+def collection_log(
+    name: str = typer.Argument(..., help="Collection whose log to show."),
+    repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
+) -> None:
+    """Show a collection's history (created / registered / sorted / hashed / processed)."""
+    repo = _repo_root(repo_root)
+    events = _collection.read_log(repo, name)
+    if not events:
+        typer.echo(f"No log for '{name}' (unregistered, or nothing recorded yet).")
+        return
+    typer.secho(f"Log for collection '{name}':", bold=True)
+    for e in events:
+        ts, ev = e.get("ts", "?"), e.get("event", "?")
+        rest = {k: v for k, v in e.items() if k not in ("ts", "event")}
+        extra = "  " + json.dumps(rest) if rest else ""
+        typer.echo(f"  {ts}  {typer.style(ev, fg=typer.colors.CYAN)}{extra}")
 
 
 @collection_app.command("sort")
 def collection_sort(
     name: str = typer.Argument(None, help="Target collection (defaults to the only one, if unambiguous)."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would move; move nothing."),
+    no_register: bool = typer.Option(False, "--no-register", help="Sort an unregistered collection without registering it."),
+    no_hash: bool = typer.Option(False, "--no-hash", help="Skip the SHA-1 manifest refresh after sorting."),
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
 ) -> None:
     """Sort the data_store/raw/sort dropzone into a collection's lane subdirs by file type.
 
-    Each file is classified by extension (the same lane/extension table `dxdfir list`
-    uses). A file whose type is ambiguous (`.raw` is a memory OR a disk image) or
-    unknown is left in the dropzone and reported — never guessed.
+    Classification delegates to the processors' magic-byte detectors, so CONTENT
+    beats extension (a mislabelled `.raw` E01 lands in disk_images/); an ambiguous
+    (`.raw` = memory OR disk) or unknown file is left in the dropzone, never guessed.
+    A registered collection gets its SHA-1 manifest refreshed afterwards.
     """
     repo = _repo_root(repo_root)
-    cols = _collection.list_collections(repo)
+    known = _collection.list_collections(repo) + _collection.unregistered(repo)
     if name is None:
-        if len(cols) == 1:
-            name = cols[0]
-        elif not cols:
+        if len(known) == 1:
+            name = known[0]
+        elif not known:
             typer.secho("No collections. Create one first:  dxdfir collection create --name <name>",
                         fg=typer.colors.RED, err=True)
             raise typer.Exit(2)
         else:
-            typer.secho(f"Several collections ({', '.join(cols)}) — name one:  dxdfir collection sort <name>",
+            typer.secho(f"Several collections ({', '.join(known)}) — name one:  dxdfir collection sort <name>",
                         fg=typer.colors.RED, err=True)
             raise typer.Exit(2)
+    if not dry_run:
+        _resolve_collection(repo, name, no_register=no_register)
     try:
         res = _collection.sort_into(repo, name, dry_run=dry_run)
     except ValueError as e:
@@ -454,6 +573,8 @@ def collection_sort(
         typer.secho(f"⚠️  left in the dropzone ({len(res.skipped)} — place by hand):", fg=typer.colors.YELLOW)
         for fn, why in res.skipped:
             typer.echo(f"   {fn}  ({why})")
+    if not dry_run and res.moved and not no_hash and _collection.is_registered(repo, name):
+        _hash_and_report(repo, name)
 
 
 def _version_cb(value: bool) -> None:

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -124,11 +124,21 @@ def _ansible_playbook() -> str:
 
 
 # --------------------------------------------------------------------------- commands
+def _valid_or_exit(name: str) -> None:
+    """Reject an invalid collection name (traversal / absolute / . ..) with a clean
+    CLI error before it is ever joined into a filesystem path."""
+    if not _collection.valid_name(name):
+        typer.secho(f"invalid collection name {name!r} — use letters/digits then . _ -",
+                    fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+
+
 def _resolve_collection(repo: Path, name: str, *, no_register: bool = False) -> None:
     """Make a collection usable before it is sorted or processed. Registered -> ok.
     A hand-staged (unregistered) folder -> offer to register it (prompt when
     interactive, auto otherwise) so the run is recorded, unless --no-register.
     Absent -> error out."""
+    _valid_or_exit(name)
     if _collection.is_registered(repo, name):
         return
     if name in _collection.unregistered(repo):
@@ -503,6 +513,7 @@ def collection_hash(
     digests). SHA-256 is primary. As slow as the evidence is large.
     """
     repo = _repo_root(repo_root)
+    _valid_or_exit(name)
     if not _collection.collection_dir(repo, name).is_dir():
         typer.secho(f"no such collection '{name}'.", fg=typer.colors.RED, err=True)
         raise typer.Exit(2)
@@ -516,6 +527,7 @@ def collection_log(
 ) -> None:
     """Show a collection's history (created / registered / sorted / hashed / processed)."""
     repo = _repo_root(repo_root)
+    _valid_or_exit(name)
     events = _collection.read_log(repo, name)
     if not events:
         typer.echo(f"No log for '{name}' (unregistered, or nothing recorded yet).")

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -445,7 +445,7 @@ def collection_create(
 def collection_list(
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
 ) -> None:
-    """List collections (registered and hand-staged) with counts and rollup SHA-1."""
+    """List collections (registered and hand-staged) with counts and rollup SHA-256."""
     repo = _repo_root(repo_root)
     registered = _collection.list_collections(repo)
     unreg = _collection.unregistered(repo)
@@ -476,7 +476,7 @@ def collection_list(
 @collection_app.command("register")
 def collection_register(
     name: str = typer.Argument(..., help="A hand-staged folder under data_store/raw/collections/."),
-    do_hash: bool = typer.Option(True, "--hash/--no-hash", help="Also SHA-1 the evidence (manifest + rollup)."),
+    do_hash: bool = typer.Option(True, "--hash/--no-hash", help="Also hash the evidence (SHA-256 + SHA-1 manifest + rollup)."),
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
 ) -> None:
     """Register a hand-staged collection so it is tracked and logged."""
@@ -533,7 +533,7 @@ def collection_sort(
     name: str = typer.Argument(None, help="Target collection (defaults to the only one, if unambiguous)."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would move; move nothing."),
     no_register: bool = typer.Option(False, "--no-register", help="Sort an unregistered collection without registering it."),
-    no_hash: bool = typer.Option(False, "--no-hash", help="Skip the SHA-1 manifest refresh after sorting."),
+    no_hash: bool = typer.Option(False, "--no-hash", help="Skip the hash manifest refresh after sorting."),
     repo_root: Path = typer.Option(None, "--repo-root", help="DX_DFIR repo (auto-detected otherwise)."),
 ) -> None:
     """Sort the data_store/raw/sort dropzone into a collection's lane subdirs by file type.
@@ -541,7 +541,7 @@ def collection_sort(
     Classification delegates to the processors' magic-byte detectors, so CONTENT
     beats extension (a mislabelled `.raw` E01 lands in disk_images/); an ambiguous
     (`.raw` = memory OR disk) or unknown file is left in the dropzone, never guessed.
-    A registered collection gets its SHA-1 manifest refreshed afterwards.
+    A registered collection gets its hash manifest refreshed afterwards.
     """
     repo = _repo_root(repo_root)
     known = _collection.list_collections(repo) + _collection.unregistered(repo)

--- a/python/get_sybers_dfir/collection.py
+++ b/python/get_sybers_dfir/collection.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 from dataclasses import dataclass, field
@@ -83,6 +84,11 @@ def dropzone(repo: Path) -> Path:
 
 
 def collection_dir(repo: Path, name: str) -> Path:
+    """The collection's directory. Validates ``name`` at this single choke point,
+    so no caller can build a path outside collections/ (no traversal, no absolute
+    or ``.``/``..`` segments). Raises ValueError on a bad name."""
+    if not valid_name(name):
+        raise ValueError(f"invalid collection name {name!r} — use letters/digits then . _ -")
     return collections_root(repo) / name
 
 
@@ -165,12 +171,26 @@ def _hash_file(path: Path) -> tuple[str, str]:
     return h1.hexdigest(), h256.hexdigest()
 
 
+def _walk_files(root: Path):
+    """Regular, non-symlink files under ``root`` WITHOUT following symlinked dirs —
+    a symlink loop can't hang it and a symlink can't pull in files outside the
+    collection (integrity + no traversal)."""
+    for dirpath, _dirs, filenames in os.walk(root, followlinks=False):
+        base = Path(dirpath)
+        for fn in filenames:
+            p = base / fn
+            if p.is_symlink() or not p.is_file():
+                continue
+            yield p
+
+
 def evidence_files(root: Path) -> list[Path]:
     """Every evidence file under a collection, excluding ONLY the collection's own
     control files (.collection, .collection.log, .collection.hashes). Dot-prefixed
-    EVIDENCE (.bash_history, .ssh/…) is included — it is real forensic data."""
+    EVIDENCE (.bash_history, .ssh/…) is included — it is real forensic data.
+    Symlinks are skipped and symlinked directories are not followed."""
     control = {root / _MARKER, root / _LOG, root / _MANIFEST}
-    return sorted(p for p in root.rglob("*") if p.is_file() and p not in control)
+    return sorted(p for p in _walk_files(root) if p not in control)
 
 
 def hash_collection(repo: Path, name: str) -> tuple[list[tuple[str, str, str]], dict[str, str]]:
@@ -182,6 +202,8 @@ def hash_collection(repo: Path, name: str) -> tuple[list[tuple[str, str, str]], 
     whenever any file's content changes. SHA-256 is the primary integrity hash
     (forensic strength); SHA-1 is kept alongside it."""
     root = collection_dir(repo, name)
+    if not root.is_dir():
+        raise ValueError(f"no such collection {name!r} to hash")
     per_file: list[tuple[str, str, str]] = []
     for p in evidence_files(root):
         s1, s256 = _hash_file(p)
@@ -238,12 +260,15 @@ def create(repo: Path, name: str) -> Path:
         raise ValueError(
             f"invalid collection name {name!r} — use letters/digits then . _ -")
     root = collection_dir(repo, name)
-    new = not (root / _MARKER).exists()
+    dir_existed = root.is_dir()
+    had_marker = (root / _MARKER).exists()
     for sub in LANE_SUBDIRS:
         (root / sub).mkdir(parents=True, exist_ok=True)
-    if new:                       # write the marker (and its registered_at) ONCE — idempotent
+    if not had_marker:            # write the marker (and its registered_at) ONCE — idempotent
         _write_marker(root, name)
-        log_event(repo, name, "created")
+        # a folder that already existed (hand-staged) is a REGISTRATION, not a creation
+        log_event(repo, name, "registered" if dir_existed else "created",
+                  **({"source": "create"} if dir_existed else {}))
     dropzone(repo).mkdir(parents=True, exist_ok=True)
     return root
 
@@ -377,6 +402,6 @@ def lane_inputs(repo: Path, name: str) -> list[tuple[str, str, Path, int]]:
     for lane in LANES:
         for var, sub in zip(lane.input_vars, lane.subdirs):
             d = root / sub
-            n = sum(1 for f in d.rglob("*") if f.is_file()) if d.is_dir() else 0
+            n = sum(1 for _ in _walk_files(d)) if d.is_dir() else 0
             out.append((lane.name, var, d, n))
     return out

--- a/python/get_sybers_dfir/collection.py
+++ b/python/get_sybers_dfir/collection.py
@@ -5,7 +5,7 @@ A *collection* is a named case folder under
 processing roles read from (``pcaps/``, ``logs/winevt/``, ``memory/``,
 ``disk_images/``, ``VM_files/``). A registered collection carries a
 ``.collection`` marker and a ``.collection.log`` — an append-only record of what
-was created, registered, sorted and processed, so a case keeps its own history.
+was created, registered, sorted, hashed and processed, so a case keeps its history.
 
 Two ways in:
 

--- a/python/get_sybers_dfir/collection.py
+++ b/python/get_sybers_dfir/collection.py
@@ -3,29 +3,35 @@
 A *collection* is a named case folder under
 ``data_store/raw/collections/<name>/`` holding the same per-lane subdirs the
 processing roles read from (``pcaps/``, ``logs/winevt/``, ``memory/``,
-``disk_images/``, ``VM_files/``).
+``disk_images/``, ``VM_files/``). A registered collection carries a
+``.collection`` marker and a ``.collection.log`` — an append-only record of what
+was created, registered, sorted and processed, so a case keeps its own history.
 
-Drop mixed evidence into the dropzone ``data_store/raw/sort/`` and
-``dxdfir collection sort <name>`` files each item into that collection's matching
-lane subdir. Classification is **not** reinvented here — it delegates to the
-processors' own magic-byte detectors (:func:`zeek.is_pcap`,
-:func:`plaso.detect_format` / :func:`plaso.ext_format`,
-:func:`volatility.is_memory_image`), so the sorter and the pipeline always agree
-on what a file is. **Content (magic bytes) wins over extension**, so an E01
-mislabelled ``.raw`` files as a disk image by its real header, not its name.
+Two ways in:
 
-``dxdfir process all <name>`` then drives every lane over just that collection,
-each role scoped to the collection's subdir via its input-dir Ansible var.
+* ``dxdfir collection create`` + drop into ``data_store/raw/sort/`` +
+  ``dxdfir collection sort`` — the tool files each item into the right lane
+  subdir. Classification is **not** reinvented: it delegates to the processors'
+  own magic-byte detectors (:func:`zeek.is_pcap`, :func:`plaso.detect_format` /
+  :func:`plaso.ext_format`, :func:`volatility.is_memory_image`), so **content
+  beats extension** — an E01 mislabelled ``.raw`` files as a disk image by its
+  header, not its name.
+* Stage the lane subdirs by hand. Such a folder is an *unregistered* collection
+  (no marker); the CLI detects it and offers to register it so the run is logged
+  (see :func:`unregistered` / :func:`register`).
 
-Forensic-safe: a header-less file two lanes both claim by extension (``.raw`` is a
-memory image AND a raw disk image) or that none recognise is never guessed — it
+Forensic-safe: a header-less file two lanes both claim by extension (``.raw`` is
+a memory image AND a raw disk image) or that none recognise is never guessed — it
 stays in the dropzone and is reported, for the operator to place by hand.
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import shutil
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -63,6 +69,8 @@ _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _COLLECTIONS_REL = ("data_store", "raw", "collections")
 _DROPZONE_REL = ("data_store", "raw", "sort")
 _MARKER = ".collection"
+_LOG = ".collection.log"
+_MANIFEST = ".collection.sha1"
 
 
 # --------------------------------------------------------------- paths / naming
@@ -82,13 +90,129 @@ def valid_name(name: str) -> bool:
     return name not in (".", "..") and bool(_NAME_RE.match(name))
 
 
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --------------------------------------------------------------- registry / log
+def is_registered(repo: Path, name: str) -> bool:
+    """True when the collection carries the ``.collection`` marker."""
+    return (collection_dir(repo, name) / _MARKER).is_file()
+
+
 def list_collections(repo: Path) -> list[str]:
-    """Names of collections (a dir under collections/ carrying the marker)."""
+    """Registered collections (a dir under collections/ carrying the marker)."""
     root = collections_root(repo)
     if not root.is_dir():
         return []
     return sorted(p.name for p in root.iterdir()
                   if p.is_dir() and (p / _MARKER).exists())
+
+
+def _has_evidence(d: Path) -> bool:
+    return any(p.is_file() and not p.name.startswith(".") for p in d.rglob("*"))
+
+
+def unregistered(repo: Path) -> list[str]:
+    """collections/ subdirs that hold evidence but carry NO marker — a case an
+    operator staged by hand instead of via ``collection create`` + ``sort``."""
+    root = collections_root(repo)
+    if not root.is_dir():
+        return []
+    return sorted(p.name for p in root.iterdir()
+                  if p.is_dir() and not (p / _MARKER).exists()
+                  and valid_name(p.name) and _has_evidence(p))
+
+
+def _write_marker(root: Path, name: str) -> None:
+    (root / _MARKER).write_text(f"name: {name}\nregistered_at: {_now()}\n", encoding="utf-8")
+
+
+def log_event(repo: Path, name: str, event: str, **detail) -> None:
+    """Append one JSONL record ({ts, event, ...detail}) to the collection log."""
+    root = collection_dir(repo, name)
+    root.mkdir(parents=True, exist_ok=True)
+    rec = {"ts": _now(), "event": event, **detail}
+    with open(root / _LOG, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec, sort_keys=False) + "\n")
+
+
+def read_log(repo: Path, name: str) -> list[dict]:
+    """The collection's log events, oldest first (``[]`` if none)."""
+    p = collection_dir(repo, name) / _LOG
+    if not p.is_file():
+        return []
+    out: list[dict] = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+# --------------------------------------------------------------- integrity (SHA-1)
+def _sha1_file(path: Path) -> str:
+    h = hashlib.sha1()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def evidence_files(root: Path) -> list[Path]:
+    """Every evidence file under a collection (its lane subdirs), excluding the
+    collection's own dotfiles (.collection, .collection.log, .collection.sha1)."""
+    return sorted(p for p in root.rglob("*")
+                  if p.is_file() and not p.name.startswith("."))
+
+
+def hash_collection(repo: Path, name: str) -> tuple[list[tuple[str, str]], str]:
+    """``([(relpath, sha1)], collection_sha1)``. Every evidence file is SHA-1'd;
+    the collection's SHA-1 is the SHA-1 of every file's SHA-1 hex string sorted
+    alphabetically and concatenated — order-independent, and it changes whenever
+    any file's content changes."""
+    root = collection_dir(repo, name)
+    per_file = [(str(p.relative_to(root)), _sha1_file(p)) for p in evidence_files(root)]
+    per_file.sort(key=lambda t: t[0])                    # manifest ordered by path
+    rollup = hashlib.sha1(
+        "".join(sorted(sha1 for _rel, sha1 in per_file)).encode("ascii")).hexdigest()
+    return per_file, rollup
+
+
+def write_manifest(repo: Path, name: str) -> tuple[str, int]:
+    """(Re)compute the collection's SHA-1 manifest, persist it to
+    ``.collection.sha1`` and log a 'hashed' event (when registered). Returns
+    ``(collection_sha1, file_count)``. Note: hashes every evidence file, so it is
+    as slow as the evidence is large."""
+    root = collection_dir(repo, name)
+    root.mkdir(parents=True, exist_ok=True)
+    per_file, rollup = hash_collection(repo, name)
+    header = (f"# DX_DFIR collection manifest (SHA-1)\n"
+              f"# collection: {name}\n"
+              f"# collection_sha1: {rollup}\n"
+              f"# files: {len(per_file)}\n"
+              f"# generated: {_now()}\n")
+    body = "".join(f"{sha1}  {rel}\n" for rel, sha1 in per_file)
+    (root / _MANIFEST).write_text(header + body, encoding="utf-8")
+    if is_registered(repo, name):
+        log_event(repo, name, "hashed", collection_sha1=rollup, files=len(per_file))
+    return rollup, len(per_file)
+
+
+def manifest_rollup(repo: Path, name: str) -> str | None:
+    """The stored collection SHA-1 from the manifest header, or None if never
+    hashed. Cheap — reads the header, does not re-hash."""
+    p = collection_dir(repo, name) / _MANIFEST
+    if not p.is_file():
+        return None
+    for line in p.read_text(encoding="utf-8").splitlines():
+        if line.startswith("# collection_sha1:"):
+            return line.split(":", 1)[1].strip() or None
+    return None
 
 
 def create(repo: Path, name: str) -> Path:
@@ -98,9 +222,29 @@ def create(repo: Path, name: str) -> Path:
         raise ValueError(
             f"invalid collection name {name!r} — use letters/digits then . _ -")
     root = collection_dir(repo, name)
+    new = not (root / _MARKER).exists()
     for sub in LANE_SUBDIRS:
         (root / sub).mkdir(parents=True, exist_ok=True)
-    (root / _MARKER).write_text(f"name: {name}\n", encoding="utf-8")
+    _write_marker(root, name)
+    dropzone(repo).mkdir(parents=True, exist_ok=True)
+    if new:
+        log_event(repo, name, "created")
+    return root
+
+
+def register(repo: Path, name: str, *, source: str = "detected") -> Path:
+    """Register an EXISTING (hand-staged) collection dir: write the marker and log
+    it. Does not create lane subdirs. Raises ValueError if the dir is absent or
+    the name is invalid. Idempotent (a registered collection is left as-is)."""
+    if not valid_name(name):
+        raise ValueError(
+            f"invalid collection name {name!r} — use letters/digits then . _ -")
+    root = collection_dir(repo, name)
+    if not root.is_dir():
+        raise ValueError(f"no collection folder to register at {root}")
+    if not (root / _MARKER).exists():
+        _write_marker(root, name)
+        log_event(repo, name, "registered", source=source)
     dropzone(repo).mkdir(parents=True, exist_ok=True)
     return root
 
@@ -178,15 +322,16 @@ class SortResult:
 
 def sort_into(repo: Path, name: str, *, dry_run: bool = False) -> SortResult:
     """Classify each file directly in the dropzone and move it into the named
-    collection's matching lane subdir. Ambiguous/unknown files stay and are
-    reported. Sub-directories and dotfiles in the dropzone are ignored."""
-    if name not in list_collections(repo):
+    collection's matching lane subdir. Works on any existing collection dir
+    (registered or not); logs the move only when the collection is registered.
+    Ambiguous/unknown files stay and are reported; dirs/dotfiles are ignored."""
+    root = collection_dir(repo, name)
+    if not root.is_dir():
         raise ValueError(
             f"no such collection {name!r} — create it first: "
             f"dxdfir collection create --name {name}")
     dz = dropzone(repo)
     dz.mkdir(parents=True, exist_ok=True)
-    root = collection_dir(repo, name)
     res = SortResult()
     for p in sorted(dz.iterdir()):
         if p.is_dir() or p.name.startswith("."):
@@ -203,6 +348,8 @@ def sort_into(repo: Path, name: str, *, dry_run: bool = False) -> SortResult:
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(p), str(dest))
         res.moved.setdefault(subdir, []).append(p.name)
+    if not dry_run and res.moved_count and is_registered(repo, name):
+        log_event(repo, name, "sorted", moved=res.moved_count, skipped=len(res.skipped))
     return res
 
 

--- a/python/get_sybers_dfir/collection.py
+++ b/python/get_sybers_dfir/collection.py
@@ -70,7 +70,7 @@ _COLLECTIONS_REL = ("data_store", "raw", "collections")
 _DROPZONE_REL = ("data_store", "raw", "sort")
 _MARKER = ".collection"
 _LOG = ".collection.log"
-_MANIFEST = ".collection.sha1"
+_MANIFEST = ".collection.hashes"
 
 
 # --------------------------------------------------------------- paths / naming
@@ -110,7 +110,7 @@ def list_collections(repo: Path) -> list[str]:
 
 
 def _has_evidence(d: Path) -> bool:
-    return any(p.is_file() and not p.name.startswith(".") for p in d.rglob("*"))
+    return bool(evidence_files(d))
 
 
 def unregistered(repo: Path) -> list[str]:
@@ -154,63 +154,79 @@ def read_log(repo: Path, name: str) -> list[dict]:
     return out
 
 
-# --------------------------------------------------------------- integrity (SHA-1)
-def _sha1_file(path: Path) -> str:
-    h = hashlib.sha1()
+# ------------------------------------------------- integrity (SHA-256 + SHA-1)
+def _hash_file(path: Path) -> tuple[str, str]:
+    """(sha1, sha256) of a file, computed in a single read pass."""
+    h1, h256 = hashlib.sha1(), hashlib.sha256()
     with open(path, "rb") as fh:
         for chunk in iter(lambda: fh.read(1 << 20), b""):
-            h.update(chunk)
-    return h.hexdigest()
+            h1.update(chunk)
+            h256.update(chunk)
+    return h1.hexdigest(), h256.hexdigest()
 
 
 def evidence_files(root: Path) -> list[Path]:
-    """Every evidence file under a collection (its lane subdirs), excluding the
-    collection's own dotfiles (.collection, .collection.log, .collection.sha1)."""
-    return sorted(p for p in root.rglob("*")
-                  if p.is_file() and not p.name.startswith("."))
+    """Every evidence file under a collection, excluding ONLY the collection's own
+    control files (.collection, .collection.log, .collection.hashes). Dot-prefixed
+    EVIDENCE (.bash_history, .ssh/…) is included — it is real forensic data."""
+    control = {root / _MARKER, root / _LOG, root / _MANIFEST}
+    return sorted(p for p in root.rglob("*") if p.is_file() and p not in control)
 
 
-def hash_collection(repo: Path, name: str) -> tuple[list[tuple[str, str]], str]:
-    """``([(relpath, sha1)], collection_sha1)``. Every evidence file is SHA-1'd;
-    the collection's SHA-1 is the SHA-1 of every file's SHA-1 hex string sorted
-    alphabetically and concatenated — order-independent, and it changes whenever
-    any file's content changes."""
+def hash_collection(repo: Path, name: str) -> tuple[list[tuple[str, str, str]], dict[str, str]]:
+    """``([(relpath, sha1, sha256)], {"sha1": rollup, "sha256": rollup})``.
+
+    Every evidence file is SHA-256'd AND SHA-1'd (one read pass); each collection
+    rollup is the hash — in that algorithm — of every file's hex digest sorted
+    alphabetically and concatenated, so it is order-independent and changes
+    whenever any file's content changes. SHA-256 is the primary integrity hash
+    (forensic strength); SHA-1 is kept alongside it."""
     root = collection_dir(repo, name)
-    per_file = [(str(p.relative_to(root)), _sha1_file(p)) for p in evidence_files(root)]
+    per_file: list[tuple[str, str, str]] = []
+    for p in evidence_files(root):
+        s1, s256 = _hash_file(p)
+        per_file.append((str(p.relative_to(root)), s1, s256))
     per_file.sort(key=lambda t: t[0])                    # manifest ordered by path
-    rollup = hashlib.sha1(
-        "".join(sorted(sha1 for _rel, sha1 in per_file)).encode("ascii")).hexdigest()
-    return per_file, rollup
+    rollups = {
+        "sha1": hashlib.sha1(
+            "".join(sorted(t[1] for t in per_file)).encode("ascii")).hexdigest(),
+        "sha256": hashlib.sha256(
+            "".join(sorted(t[2] for t in per_file)).encode("ascii")).hexdigest(),
+    }
+    return per_file, rollups
 
 
-def write_manifest(repo: Path, name: str) -> tuple[str, int]:
-    """(Re)compute the collection's SHA-1 manifest, persist it to
-    ``.collection.sha1`` and log a 'hashed' event (when registered). Returns
-    ``(collection_sha1, file_count)``. Note: hashes every evidence file, so it is
-    as slow as the evidence is large."""
+def write_manifest(repo: Path, name: str) -> tuple[dict[str, str], int]:
+    """(Re)compute the collection's hash manifest, persist it to
+    ``.collection.hashes`` and log a 'hashed' event (when registered). Returns
+    ``({"sha1", "sha256"}, file_count)``. Hashes every evidence file, so it is as
+    slow as the evidence is large."""
     root = collection_dir(repo, name)
     root.mkdir(parents=True, exist_ok=True)
-    per_file, rollup = hash_collection(repo, name)
-    header = (f"# DX_DFIR collection manifest (SHA-1)\n"
+    per_file, rollups = hash_collection(repo, name)
+    header = (f"# DX_DFIR collection manifest\n"
               f"# collection: {name}\n"
-              f"# collection_sha1: {rollup}\n"
+              f"# collection_sha256: {rollups['sha256']}\n"
+              f"# collection_sha1: {rollups['sha1']}\n"
               f"# files: {len(per_file)}\n"
-              f"# generated: {_now()}\n")
-    body = "".join(f"{sha1}  {rel}\n" for rel, sha1 in per_file)
+              f"# generated: {_now()}\n"
+              f"# columns: sha256  sha1  path\n")
+    body = "".join(f"{s256}  {s1}  {rel}\n" for rel, s1, s256 in per_file)
     (root / _MANIFEST).write_text(header + body, encoding="utf-8")
     if is_registered(repo, name):
-        log_event(repo, name, "hashed", collection_sha1=rollup, files=len(per_file))
-    return rollup, len(per_file)
+        log_event(repo, name, "hashed", collection_sha256=rollups["sha256"],
+                  collection_sha1=rollups["sha1"], files=len(per_file))
+    return rollups, len(per_file)
 
 
 def manifest_rollup(repo: Path, name: str) -> str | None:
-    """The stored collection SHA-1 from the manifest header, or None if never
-    hashed. Cheap — reads the header, does not re-hash."""
+    """The stored collection SHA-256 (primary rollup) from the manifest header, or
+    None if never hashed. Cheap — reads the header, does not re-hash."""
     p = collection_dir(repo, name) / _MANIFEST
     if not p.is_file():
         return None
     for line in p.read_text(encoding="utf-8").splitlines():
-        if line.startswith("# collection_sha1:"):
+        if line.startswith("# collection_sha256:"):
             return line.split(":", 1)[1].strip() or None
     return None
 
@@ -225,10 +241,10 @@ def create(repo: Path, name: str) -> Path:
     new = not (root / _MARKER).exists()
     for sub in LANE_SUBDIRS:
         (root / sub).mkdir(parents=True, exist_ok=True)
-    _write_marker(root, name)
-    dropzone(repo).mkdir(parents=True, exist_ok=True)
-    if new:
+    if new:                       # write the marker (and its registered_at) ONCE — idempotent
+        _write_marker(root, name)
         log_event(repo, name, "created")
+    dropzone(repo).mkdir(parents=True, exist_ok=True)
     return root
 
 

--- a/python/tests/test_collection.py
+++ b/python/tests/test_collection.py
@@ -184,3 +184,43 @@ def test_unregistered_detects_dot_only_evidence(tmp_path):
     (root / "disk_images").mkdir(parents=True)
     _write(root / "disk_images" / ".bash_history", b"cmd")   # only dot-prefixed evidence
     assert collection.unregistered(tmp_path) == ["hand"]     # detected (was missed before)
+
+
+# --- security: name validation + symlink safety -----------------------------
+@pytest.mark.parametrize("bad", ["../escape", "..", ".", "/abs", "a/b", "with space", ""])
+def test_collection_dir_rejects_bad_names(tmp_path, bad):
+    with pytest.raises(ValueError):
+        collection.collection_dir(tmp_path, bad)
+
+
+def test_sort_and_hash_reject_traversal(tmp_path):
+    with pytest.raises(ValueError):
+        collection.sort_into(tmp_path, "../escape")
+    with pytest.raises(ValueError):
+        collection.hash_collection(tmp_path, "../escape")
+
+
+def test_hash_absent_collection_raises(tmp_path):
+    with pytest.raises(ValueError):
+        collection.hash_collection(tmp_path, "nope")
+
+
+def test_symlinks_not_followed_in_evidence(tmp_path):
+    collection.create(tmp_path, "case")
+    root = collection.collection_dir(tmp_path, "case")
+    _write(root / "pcaps" / "real.pcap", _PCAP_MAGIC)
+    outside = _write(tmp_path / "outside.bin", b"secret")           # a file OUTSIDE the collection
+    (root / "pcaps" / "link.pcap").symlink_to(outside)             # symlink to it
+    outdir = tmp_path / "outdir"; outdir.mkdir(); _write(outdir / "loot.bin", b"x")
+    (root / "memory" / "linkdir").symlink_to(outdir, target_is_directory=True)
+    files = [rel for rel, _s1, _s256 in collection.hash_collection(tmp_path, "case")[0]]
+    assert files == ["pcaps/real.pcap"]                            # symlink + symlinked dir skipped
+
+
+def test_create_on_existing_folder_logs_registered(tmp_path):
+    root = collection.collection_dir(tmp_path, "hand")
+    (root / "pcaps").mkdir(parents=True)
+    _write(root / "pcaps" / "c.pcap", _PCAP_MAGIC)                 # hand-staged, no marker
+    collection.create(tmp_path, "hand")
+    events = [e["event"] for e in collection.read_log(tmp_path, "hand")]
+    assert "registered" in events and "created" not in events     # registration, not creation

--- a/python/tests/test_collection.py
+++ b/python/tests/test_collection.py
@@ -7,6 +7,7 @@ No docker/ansible — pure filesystem.
 """
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -99,3 +100,63 @@ def test_sort_is_idempotent_on_second_run(tmp_path):
 def test_sort_unknown_collection_raises(tmp_path):
     with pytest.raises(ValueError):
         collection.sort_into(tmp_path, "nope")
+
+
+# --- registration of hand-staged (unregistered) collections ------------------
+def test_unregistered_detection(tmp_path):
+    root = collection.collection_dir(tmp_path, "hand")
+    (root / "pcaps").mkdir(parents=True)
+    _write(root / "pcaps" / "c.pcap", _PCAP_MAGIC)
+    assert collection.unregistered(tmp_path) == ["hand"]
+    assert collection.list_collections(tmp_path) == []
+    assert not collection.is_registered(tmp_path, "hand")
+
+
+def test_register_marks_and_logs(tmp_path):
+    root = collection.collection_dir(tmp_path, "hand")
+    (root / "pcaps").mkdir(parents=True)
+    _write(root / "pcaps" / "c.pcap", _PCAP_MAGIC)
+    collection.register(tmp_path, "hand")
+    assert collection.is_registered(tmp_path, "hand")
+    assert collection.unregistered(tmp_path) == []
+    assert "registered" in [e["event"] for e in collection.read_log(tmp_path, "hand")]
+
+
+def test_register_missing_dir_raises(tmp_path):
+    with pytest.raises(ValueError):
+        collection.register(tmp_path, "nope")
+
+
+# --- integrity: per-file SHA-1 + collection rollup ---------------------------
+def test_hash_collection_is_deterministic_and_content_addressed(tmp_path):
+    collection.create(tmp_path, "case")
+    root = collection.collection_dir(tmp_path, "case")
+    _write(root / "pcaps" / "a.pcap", b"AAA")
+    _write(root / "memory" / "b.mem", b"BBB")
+    per_file, roll1 = collection.hash_collection(tmp_path, "case")
+    assert dict(per_file)["pcaps/a.pcap"] == hashlib.sha1(b"AAA").hexdigest()
+    # rollup == sha1 of the per-file sha1 strings, alphabetical, concatenated
+    expected = hashlib.sha1("".join(sorted(h for _r, h in per_file)).encode()).hexdigest()
+    assert roll1 == expected
+    assert collection.hash_collection(tmp_path, "case")[1] == roll1        # deterministic
+    _write(root / "memory" / "b.mem", b"CHANGED")
+    assert collection.hash_collection(tmp_path, "case")[1] != roll1        # content-addressed
+
+
+def test_write_manifest_persists_and_logs(tmp_path):
+    collection.create(tmp_path, "case")
+    root = collection.collection_dir(tmp_path, "case")
+    _write(root / "pcaps" / "a.pcap", b"AAA")
+    rollup, count = collection.write_manifest(tmp_path, "case")
+    assert count == 1 and collection.manifest_rollup(tmp_path, "case") == rollup
+    manifest = (root / ".collection.sha1").read_text()
+    assert "pcaps/a.pcap" in manifest and hashlib.sha1(b"AAA").hexdigest() in manifest
+    assert "hashed" in [e["event"] for e in collection.read_log(tmp_path, "case")]
+
+
+def test_manifest_excludes_own_dotfiles(tmp_path):
+    collection.create(tmp_path, "case")
+    _write(collection.collection_dir(tmp_path, "case") / "pcaps" / "a.pcap", b"AAA")
+    collection.write_manifest(tmp_path, "case")           # writes .collection.sha1
+    files = [r for r, _h in collection.hash_collection(tmp_path, "case")[0]]
+    assert files == ["pcaps/a.pcap"]                       # markers/log/manifest not hashed

--- a/python/tests/test_collection.py
+++ b/python/tests/test_collection.py
@@ -134,10 +134,13 @@ def test_hash_collection_is_deterministic_and_content_addressed(tmp_path):
     _write(root / "pcaps" / "a.pcap", b"AAA")
     _write(root / "memory" / "b.mem", b"BBB")
     per_file, roll1 = collection.hash_collection(tmp_path, "case")
-    assert dict(per_file)["pcaps/a.pcap"] == hashlib.sha1(b"AAA").hexdigest()
-    # rollup == sha1 of the per-file sha1 strings, alphabetical, concatenated
-    expected = hashlib.sha1("".join(sorted(h for _r, h in per_file)).encode()).hexdigest()
-    assert roll1 == expected
+    rec = {rel: (s1, s256) for rel, s1, s256 in per_file}
+    assert rec["pcaps/a.pcap"] == (hashlib.sha1(b"AAA").hexdigest(), hashlib.sha256(b"AAA").hexdigest())
+    # each rollup == hash (in that algo) of the sorted per-file digests, concatenated
+    assert roll1["sha1"] == hashlib.sha1(
+        "".join(sorted(s1 for _r, s1, _s in per_file)).encode()).hexdigest()
+    assert roll1["sha256"] == hashlib.sha256(
+        "".join(sorted(s256 for _r, _s, s256 in per_file)).encode()).hexdigest()
     assert collection.hash_collection(tmp_path, "case")[1] == roll1        # deterministic
     _write(root / "memory" / "b.mem", b"CHANGED")
     assert collection.hash_collection(tmp_path, "case")[1] != roll1        # content-addressed
@@ -147,16 +150,37 @@ def test_write_manifest_persists_and_logs(tmp_path):
     collection.create(tmp_path, "case")
     root = collection.collection_dir(tmp_path, "case")
     _write(root / "pcaps" / "a.pcap", b"AAA")
-    rollup, count = collection.write_manifest(tmp_path, "case")
-    assert count == 1 and collection.manifest_rollup(tmp_path, "case") == rollup
-    manifest = (root / ".collection.sha1").read_text()
-    assert "pcaps/a.pcap" in manifest and hashlib.sha1(b"AAA").hexdigest() in manifest
+    rollups, count = collection.write_manifest(tmp_path, "case")
+    assert count == 1 and collection.manifest_rollup(tmp_path, "case") == rollups["sha256"]
+    manifest = (root / ".collection.hashes").read_text()
+    assert "pcaps/a.pcap" in manifest
+    assert hashlib.sha256(b"AAA").hexdigest() in manifest      # SHA-256 recorded
+    assert hashlib.sha1(b"AAA").hexdigest() in manifest        # SHA-1 kept too
     assert "hashed" in [e["event"] for e in collection.read_log(tmp_path, "case")]
 
 
-def test_manifest_excludes_own_dotfiles(tmp_path):
+def test_manifest_includes_dot_evidence_excludes_control(tmp_path):
     collection.create(tmp_path, "case")
-    _write(collection.collection_dir(tmp_path, "case") / "pcaps" / "a.pcap", b"AAA")
-    collection.write_manifest(tmp_path, "case")           # writes .collection.sha1
-    files = [r for r, _h in collection.hash_collection(tmp_path, "case")[0]]
-    assert files == ["pcaps/a.pcap"]                       # markers/log/manifest not hashed
+    root = collection.collection_dir(tmp_path, "case")
+    _write(root / "disk_images" / ".bash_history", b"whoami\n")   # dot-prefixed EVIDENCE
+    _write(root / "pcaps" / "a.pcap", b"AAA")
+    collection.write_manifest(tmp_path, "case")                   # writes .collection.hashes
+    files = [rel for rel, _s1, _s256 in collection.hash_collection(tmp_path, "case")[0]]
+    assert "disk_images/.bash_history" in files                   # real dot-evidence IS hashed
+    assert "pcaps/a.pcap" in files
+    assert not any(f.startswith(".collection") for f in files)    # control files are NOT
+
+
+def test_create_is_idempotent_marker_stable(tmp_path):
+    root = collection.create(tmp_path, "case")
+    marker = (root / ".collection").read_text()
+    collection.create(tmp_path, "case")                    # a second create must not rewrite it
+    assert (root / ".collection").read_text() == marker    # registered_at preserved
+    assert [e["event"] for e in collection.read_log(tmp_path, "case")].count("created") == 1
+
+
+def test_unregistered_detects_dot_only_evidence(tmp_path):
+    root = collection.collection_dir(tmp_path, "hand")
+    (root / "disk_images").mkdir(parents=True)
+    _write(root / "disk_images" / ".bash_history", b"cmd")   # only dot-prefixed evidence
+    assert collection.unregistered(tmp_path) == ["hand"]     # detected (was missed before)


### PR DESCRIPTION
## What — follow-up to #119

Three additions to the collection feature:

### 1. Register hand-staged collections
A folder under `data_store/raw/collections/` that holds evidence but has no `.collection` marker (staged by hand instead of via `sort`) is now an **unregistered** collection. `dxdfir collection sort` / `process all` **prompt to register** it (auto in non-interactive runs; `--no-register` to skip); `dxdfir collection register <name>` does it explicitly — so a case processed without the sort feature still gets on record.

### 2. Per-collection log
`.collection.log` (JSONL) records `created / registered / sorted / hashed / processed` with timestamps. `dxdfir collection log <name>` shows the history; `dxdfir collection list` now also lists hand-staged collections and each rollup SHA-256.

### 3. Integrity — SHA-256 + SHA-1
Every evidence file is hashed (**SHA-256** primary + **SHA-1**) in one read pass; each **collection rollup = hash of the sorted per-file digests concatenated** (order-independent; changes if any file changes) — written to `.collection.hashes` (per-file `sha256  sha1  path` manifest + both rollups). `dxdfir collection hash <name>` computes it; `sort`/`register` refresh it; `process all` records the rollup. Dot-prefixed forensic evidence (`.bash_history`, `.ssh/…`) IS hashed; only the collection's own control files are excluded.

## Tested
`test_collection.py` (30 pass with `test_cli.py`): magic-first classification, registration/detection incl. dot-only evidence, deterministic + content-addressed dual rollup, manifest, marker idempotency. Verified live end-to-end.

Addresses the earlier Copilot review (idempotent `create`, dot-evidence inclusion, SHA-256) and the follow-up doc-consistency comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
