### PR TITLE
stix: reference main (not dev) in exported STIX URLs

### DIFF
--- a/python/get_sybers_dfir/stix/export.py
+++ b/python/get_sybers_dfir/stix/export.py
@@ -117,7 +117,9 @@ UNCASED = "uncased"
 # The package's own rules-as-code (detect/rules): the default rules directory.
 PACKAGE_RULES_DIR = os.path.normpath(os.path.join(
     os.path.dirname(os.path.abspath(__file__)), os.pardir, "detect", "rules"))
-RULE_URL = "https://github.com/Get-Sybers/DX_DFIR/blob/dev/python/get_sybers_dfir/detect/rules/{id}.yml"
+# Released STIX references the stable released branch (main), not dev (WIP), so
+# exported artifacts don't point consumers at a moving target.
+RULE_URL = "https://github.com/Get-Sybers/DX_DFIR/blob/main/python/get_sybers_dfir/detect/rules/{id}.yml"
 # STIX 2.1 pattern-type-ov (§10.19). The rules' own languages are trust-group
 # values beyond it (BP §8.1) — documented in stix/README.md, versioned by
 # ``pattern_version`` (the Elastic stack the rule is known to run on).

--- a/python/get_sybers_dfir/stix/extension/dxdfir-extension.schema.json
+++ b/python/get_sybers_dfir/stix/extension/dxdfir-extension.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/Get-Sybers/DX_DFIR/dev/python/get_sybers_dfir/stix/extension/dxdfir-extension.schema.json",
+  "$id": "https://raw.githubusercontent.com/Get-Sybers/DX_DFIR/main/python/get_sybers_dfir/stix/extension/dxdfir-extension.schema.json",
   "title": "DX_DFIR detection exchange — STIX 2.1 property extension",
   "description": "The properties the DX_DFIR (Byakugan) detection exchange adds to the STIX 2.1 objects it produces, under extensions[\"extension-definition--0a37fc5b-cf2b-5ae9-84aa-933110a32190\"] (extension_type property-extension, STIX 2.1 §7.3). On an indicator: the detection rule's id, severity and status. On a sighting: the case, run, CAR-object and Elastic alert pointers, the evidence source, and — for an indicator-match sighting — the feed, the matched field / value and the matched indicator's descriptors. On a relationship: whether a rule author declared it or it was derived from evidence. Version 1.0.0.",
   "type": "object",

--- a/python/get_sybers_dfir/stix/objects.py
+++ b/python/get_sybers_dfir/stix/objects.py
@@ -78,9 +78,11 @@ EXTENSION_VERSION = "1.0.0"
 EXTENSION_CREATED = "2026-09-03T00:00:00.000Z"
 EXTENSION_MODIFIED = "2026-09-03T00:00:00.000Z"
 EXTENSION_NAME = "DX_DFIR detection exchange"
-EXTENSION_SCHEMA_URL = ("https://raw.githubusercontent.com/Get-Sybers/DX_DFIR/dev/python/"
+# Released STIX references the stable released branch (main), not dev (WIP), so
+# consumers of the extension schema/docs don't chase a moving target.
+EXTENSION_SCHEMA_URL = ("https://raw.githubusercontent.com/Get-Sybers/DX_DFIR/main/python/"
                         "get_sybers_dfir/stix/extension/dxdfir-extension.schema.json")
-EXTENSION_DOC_URL = "https://github.com/Get-Sybers/DX_DFIR/blob/dev/python/get_sybers_dfir/stix/README.md"
+EXTENSION_DOC_URL = "https://github.com/Get-Sybers/DX_DFIR/blob/main/python/get_sybers_dfir/stix/README.md"
 
 RELATIONSHIP_CLASS_DECLARED = "declared"
 RELATIONSHIP_CLASS_DERIVED = "derived"


### PR DESCRIPTION
Addresses the Copilot review on #123: the STIX export hard-coded `dev`-branch URLs, which drift as `dev` takes on WIP.

Repointed at `main` (the stable released branch — Copilot's suggested ref):
- `export.py` `RULE_URL`
- `objects.py` `EXTENSION_SCHEMA_URL` / `EXTENSION_DOC_URL`
- `stix/extension/dxdfir-extension.schema.json` `$id`

The `v0.6.0` tag can't serve as the ref — it predates these files (points at `a53acce` / #99). Tests reference the URLs via the constants (and assert `$id == EXTENSION_SCHEMA_URL`), so they follow the change: **78 STIX tests pass** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)