### PR TITLE
fix: hardened tool containers read locked-down evidence (+ honest evtx empty/failed)

### DIFF
--- a/python/get_sybers_dfir/container.py
+++ b/python/get_sybers_dfir/container.py
@@ -23,9 +23,14 @@ compromised tool) does not need an on-image shell:
                                  The single exception is Volatility ISF symbol
                                  fetch (``network=True``), an explicit opt-in.
 
-Pure list builders so every argv stays unit-testable.
+The confinement flags stay pure list builders; run() additionally reads the
+group owning each read-only (evidence) mount and --group-add's it, so a
+locked-down evidence tree is readable by the image's non-root uid off defaults —
+no per-run --user/--group knobs threaded through processing.
 """
 from __future__ import annotations
+
+import os
 
 # Base confinement applied to every tool container.
 HARDENING_FLAGS = [
@@ -51,6 +56,33 @@ def run_flags(network: bool = False, tmpfs: tuple = ()) -> list[str]:
     return flags
 
 
+def _mount_group_ids(mounts) -> list[str]:
+    """Supplementary gids the container needs to READ its read-only mounts.
+
+    Evidence is bind-mounted read-only and owned by whatever group staged it
+    (data_store is root:docker 750 on a locked-down host). The tool runs as the
+    image's baked non-root uid, which is not in that group, so it cannot traverse
+    the evidence unless granted it. Return the distinct gid of each read-only
+    mount's host source for --group-add, so reading evidence works off the mount
+    with nothing to configure per run. Read-write (output) mounts are skipped —
+    the caller makes those world-writable — as are the root group and any source
+    that can't be stat'd (keeps placeholder-path unit tests and absent mounts
+    harmless).
+    """
+    gids: list[str] = []
+    for spec in mounts:
+        parts = spec.split(":")
+        if len(parts) < 3 or parts[-1] != "ro":
+            continue
+        try:
+            gid = str(os.stat(parts[0]).st_gid)
+        except OSError:
+            continue
+        if gid not in gids and gid != "0":
+            gids.append(gid)
+    return gids
+
+
 def run(image, after_image=(), *, mounts=(), network=False, tmpfs=(),
         workdir=None) -> list[str]:
     """``docker run`` argv for a minimal hardened dfir/* image.
@@ -64,6 +96,12 @@ def run(image, after_image=(), *, mounts=(), network=False, tmpfs=(),
     (read-write) and reads mounted evidence (read-only).
     """
     argv = ["docker", "run", "--rm", *run_flags(network, tmpfs)]
+    # Grant the container the group that owns each read-only (evidence) mount, so
+    # the image's baked non-root uid can read locked-down evidence (data_store is
+    # root:docker 750 on a hardened host) without running as root. Automatic, off
+    # the mounts — no per-run --user/--group knobs threaded through processing.
+    for gid in _mount_group_ids(mounts):
+        argv += ["--group-add", gid]
     if workdir:
         argv += ["-w", workdir]
     for mount in mounts:

--- a/python/get_sybers_dfir/evtx.py
+++ b/python/get_sybers_dfir/evtx.py
@@ -135,8 +135,14 @@ def evtxecmd_argv(evtx_file, dest_dir, json_out, xml_out, image, *,
 
 def _run_evtxecmd(evtx_file, dest_dir, json_out, xml_out, image, *,
                   evtxecmd_dir=None, dll_rel=None):
-    """One EvtxECmd container run over one log, JSON + XML into dest_dir."""
-    subprocess.run(
+    """One EvtxECmd container run over one log, JSON + XML into dest_dir.
+
+    Returns the CompletedProcess so the caller can tell a genuinely empty log
+    (EvtxECmd opened it and printed a record tally) from an input it could not
+    read at all (missing, or permission-denied under the hardened uid) — EvtxECmd
+    exits 0 on both, but only prints a tally when it actually opened the log.
+    """
+    return subprocess.run(
         evtxecmd_argv(evtx_file, dest_dir, json_out, xml_out, image,
                       evtxecmd_dir=evtxecmd_dir, dll_rel=dll_rel),
         # EvtxECmd is chatty (version banner + per-record "time went backwards"
@@ -251,8 +257,8 @@ def process(evtx_dir, out_dir, evtxecmd_dir=None, image=None, force=False) -> di
         except OSError:
             pass
         try:
-            _run_evtxecmd(evtx, dest_dir, json_out, xml_out, image,
-                          evtxecmd_dir=evtxecmd_dir, dll_rel=dll_rel)
+            proc = _run_evtxecmd(evtx, dest_dir, json_out, xml_out, image,
+                                 evtxecmd_dir=evtxecmd_dir, dll_rel=dll_rel)
         except subprocess.CalledProcessError:
             for p in (json_path, os.path.join(dest_dir, xml_out)):
                 if os.path.exists(p):
@@ -263,15 +269,28 @@ def process(evtx_dir, out_dir, evtxecmd_dir=None, image=None, force=False) -> di
         if _has_records(json_path):
             summary["processed"] += 1
             summary["results"].append({"log": rel, "output": os.path.join(host, json_out)})
-        else:
-            # EvtxECmd exits 0 on an empty log and writes a BOM-only file — drop it
-            # so it is neither picked up downstream as an ill-formed input nor
-            # miscounted as processed. This is expected, not a failure.
-            for p in (json_path, os.path.join(dest_dir, xml_out)):
-                if os.path.exists(p):
-                    os.remove(p)
+            continue
+        # No records written. EvtxECmd exits 0 both when a log is genuinely EMPTY
+        # (it opened the log and printed a record tally) AND when it could not READ
+        # the input at all — a missing file, or a permission-denied it prints as
+        # "... does not exist! Exiting". Only the first is benign. EvtxECmd prints a
+        # "records found" tally once it has actually opened a log, so its ABSENCE
+        # means the log was never read: count that as a failure and surface
+        # EvtxECmd's own reason, not a silent "empty" that would hide an unreadable
+        # evidence tree.
+        for p in (json_path, os.path.join(dest_dir, xml_out)):
+            if os.path.exists(p):
+                os.remove(p)
+        out = (proc.stdout or b"") + (proc.stderr or b"")
+        if b"records found" in out.lower():
             summary["empty"] += 1
             summary["results"].append({"log": rel, "empty": True})
+        else:
+            tail = out.decode("utf-8", "replace").strip().splitlines()
+            why = tail[-1].strip() if tail else "no output and no record tally"
+            summary["failed"] += 1
+            summary["results"].append(
+                {"log": rel, "error": f"EvtxECmd did not read the log: {why}"})
     return summary
 
 

--- a/python/tests/test_evtx.py
+++ b/python/tests/test_evtx.py
@@ -1,6 +1,7 @@
 import json
 """Unit tests for the pure logic of the evtx processor (no docker/EvtxECmd needed)."""
 import os
+import subprocess
 
 from get_sybers_dfir import evtx
 
@@ -158,9 +159,12 @@ def test_process_counts_empty_log_apart_from_failed(tmp_path, monkeypatch):
     (evtx_dir / "Empty.evtx").write_bytes(b"x")
 
     def fake_run(evtx_file, dest_dir, json_out, xml_out, image, **kw):
-        # simulate EvtxECmd on an empty log: exits 0, writes a BOM-only file
+        # simulate EvtxECmd on an empty log: exits 0, writes a BOM-only file, and
+        # reports it OPENED the log (a records-found tally of 0)
         with open(os.path.join(dest_dir, json_out), "wb") as f:
             f.write(b"\xef\xbb\xbf")
+        return subprocess.CompletedProcess(
+            [], 0, stdout=b"Total event log records found: 0", stderr=b"")
 
     monkeypatch.setattr(evtx, "_run_evtxecmd", fake_run)
     s = evtx.process(str(evtx_dir), str(tmp_path / "out"), image="dfir/evtxecmd:latest")
@@ -169,6 +173,25 @@ def test_process_counts_empty_log_apart_from_failed(tmp_path, monkeypatch):
     assert s["processed"] == 0
     # the BOM-only artefact is dropped so it never reaches ingest
     assert not (tmp_path / "out" / "unspecified_host" / "Empty_EvtxECmd_Output.json").exists()
+
+
+def test_process_counts_unreadable_log_as_failed(tmp_path, monkeypatch):
+    evtx_dir = tmp_path / "in"
+    evtx_dir.mkdir()
+    (evtx_dir / "Locked.evtx").write_bytes(b"x")
+
+    def fake_run(evtx_file, dest_dir, json_out, xml_out, image, **kw):
+        # EvtxECmd that could not READ the input: exits 0, writes no output, and
+        # prints "does not exist" — it never reports a records-found tally.
+        return subprocess.CompletedProcess(
+            [], 0, stdout=b"/input/Locked.evtx does not exist! Exiting", stderr=b"")
+
+    monkeypatch.setattr(evtx, "_run_evtxecmd", fake_run)
+    s = evtx.process(str(evtx_dir), str(tmp_path / "out"), image="dfir/evtxecmd:latest")
+    assert s["failed"] == 1        # a log EvtxECmd could not read is a failure...
+    assert s["empty"] == 0         # ...not a benign empty
+    assert s["processed"] == 0
+    assert "did not read" in s["results"][0]["error"]
 
 
 def test_process_bundled_mode_needs_no_dll(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes the runtime half of the hardened-container work — tool containers now read locked-down evidence, off defaults, with no per-run knobs.

**Problem** — the hardened images run as uid 2000, not in the group owning the evidence (`data_store` is `750 root:docker` on a locked-down host). Every lane silently produced nothing; EvtxECmd printed `… does not exist! Exiting` on inputs it couldn't traverse, and the processor scored that as a benign "empty".

**Fix**
- `container.run` auto-`--group-add`s the group of each read-only (evidence) mount → the container reads the evidence without running as root, nothing to configure per run. The uid stays the image's baked `USER` (single-sourced at build via `dfir_runtime_uid`, #127).
- `evtx.process()` now tells a genuinely empty log (EvtxECmd opened it, printed a record tally) from one it couldn't read (no tally / "does not exist") — the latter is counted failed and surfaced, not masked as empty.

**Verified** — 343 unit tests pass; a real `dxdfir process evtx` over the 7 sysmon-attack-samples logs extracts 47 records across 7 EvtxECmd JSON files (was 0, silently "empty").

🤖 Generated with [Claude Code](https://claude.com/claude-code)