### PR TITLE
fix: address Copilot review on the restructure (uid single-source + doc drift)

### DIFF
--- a/ansible/collections/get_sybers.dfir/roles/dfir_images/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_images/defaults/main.yml
@@ -10,7 +10,9 @@ dfir_images_repo_root: "{{ role_path }}/../../../../.."
 # the build contract, so the build and the runtime share one uid. (dfir/volatility
 # is built from the third_party/piiat-mem submodule — Get-Sybers/PIIAT-Mem#2.)
 dfir_images_uid: "{{ dfir_runtime_uid | default(2000) }}"
-dfir_images_gid: "{{ dfir_runtime_gid | default(2000) }}"
+# gid follows the uid unless explicitly set, so setting only dfir_runtime_uid
+# still yields a matched USER <uid>:<uid>, never <uid>:2000.
+dfir_images_gid: "{{ dfir_runtime_gid | default(dfir_runtime_uid | default(2000)) }}"
 
 # The docker/ build context — every Dockerfile COPYs the shared ansible
 # hardening playbook (docker/hardening/harden.yml) from here.

--- a/ansible/collections/get_sybers.dfir/roles/dfir_images/tasks/build.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_images/tasks/build.yml
@@ -16,10 +16,12 @@
       # its context+dockerfile (e.g. volatility builds from the PIIAT-Mem submodule).
       path: "{{ (dfir_images_build_overrides[dfir_images_name] | default({})).context | default(dfir_images_context, true) }}"
       dockerfile: "{{ (dfir_images_build_overrides[dfir_images_name] | default({})).dockerfile | default(dfir_images_name ~ '/Dockerfile', true) }}"
-      # Every build gets the single-source run-as uid/gid; parameterized builds
-      # (the shared eztool/Dockerfile) merge their tool selector on top.
-      args: "{{ {'DFIR_UID': dfir_images_uid | string, 'DFIR_GID': dfir_images_gid | string}
-                | combine((dfir_images_build_overrides[dfir_images_name] | default({})).args | default({})) }}"
+      # Every build gets the single-source run-as uid/gid, and it WINS over any
+      # per-image override args (e.g. the shared eztool/Dockerfile's tool selector):
+      # the override is the base, the uid/gid are combined on top so they can't be
+      # replaced.
+      args: "{{ ((dfir_images_build_overrides[dfir_images_name] | default({})).args | default({}))
+                | combine({'DFIR_UID': dfir_images_uid | string, 'DFIR_GID': dfir_images_gid | string}) }}"
 
 - name: "images-build | inspect dfir/{{ dfir_images_name }}"
   community.docker.docker_image_info:

--- a/ansible/collections/get_sybers.dfir/roles/dfir_images/tasks/build.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_images/tasks/build.yml
@@ -35,8 +35,8 @@
       - dfir_images_inspect.images[0].Config.User == (dfir_images_uid | string) ~ ':' ~ (dfir_images_gid | string)
       - (dfir_images_inspect.images[0].Config.Labels or {})['com.get-sybers.hardened'] | default('') == 'true'
     fail_msg: >-
-      dfir/{{ dfir_images_name }} fails the static contract (USER 2000:2000 +
-      com.get-sybers.hardened label).
+      dfir/{{ dfir_images_name }} fails the static contract (USER
+      {{ dfir_images_uid }}:{{ dfir_images_gid }} + com.get-sybers.hardened label).
     quiet: true
 
 # Filesystem scan without needing a shell in the image: export the image as a

--- a/ansible/collections/get_sybers.dfir/roles/dfir_lane/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_lane/meta/argument_specs.yml
@@ -21,7 +21,7 @@ argument_specs:
         description: "Short lane token used in task names and diagnostics (e.g. evtx)."
       dfir_lane_module:
         type: str
-        required: false
+        required: true
         description: "Python module the preflight import-checks (e.g. get_sybers_dfir.evtx)."
       dfir_lane_python_path:
         type: str
@@ -42,8 +42,7 @@ argument_specs:
       dfir_lane_argv:
         type: list
         elements: str
-        required: false
-        default: []
+        required: true
         description: "The processor command argv — the one genuinely per-lane piece."
       dfir_lane_verify_dir:
         type: str

--- a/ansible/collections/get_sybers.dfir/roles/dfir_lane/tasks/process.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_lane/tasks/process.yml
@@ -8,9 +8,10 @@
 #
 # The calling lane supplies: dfir_lane_argv (the processor command — the one
 # genuinely per-lane piece), dfir_lane_python_path, the output dir + glob to
-# verify (dfir_lane_verify_dir / dfir_lane_verify_glob), and any extra gate
-# assertions (dfir_lane_gate) evaluated against the run's JSON summary
-# (dfir_lane_run.stdout) and the on-disk verification (dfir_lane_verify).
+# verify (dfir_lane_verify_dir / dfir_lane_verify_glob), and an optional
+# lane-specific output gate (dfir_lane_gate_extra) — a task file that asserts on
+# the run's JSON summary (dfir_lane_run.stdout) and the verification
+# (dfir_lane_verify).
 - name: "process | run, verify and gate | {{ dfir_lane_name }}"
   block:
     - name: "process | run the processor | {{ dfir_lane_name }}"

--- a/docker/evtxecmd/Dockerfile
+++ b/docker/evtxecmd/Dockerfile
@@ -69,7 +69,7 @@ ARG DFIR_GID=2000
 USER ${DFIR_UID}:${DFIR_GID}
 ENTRYPOINT ["dotnet", "/opt/evtxecmd/EvtxECmd.dll"]
 LABEL org.opencontainers.image.title="dfir/evtxecmd" \
-      org.opencontainers.image.description="Minimal hardened EvtxECmd (.NET) for the DX_DFIR dfir_evtx role: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, runs as uid 2000." \
+      org.opencontainers.image.description="Minimal hardened EvtxECmd (.NET) for the DX_DFIR dfir_evtx role: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, runs as a fixed non-root uid (default 2000)." \
       org.opencontainers.image.source="https://github.com/EricZimmerman/evtx" \
       org.opencontainers.image.licenses="MIT" \
       com.get-sybers.evtxecmd.url="${EVTXECMD_URL}" \

--- a/docker/eztool/Dockerfile
+++ b/docker/eztool/Dockerfile
@@ -91,7 +91,7 @@ ARG DFIR_GID=2000
 USER ${DFIR_UID}:${DFIR_GID}
 ENTRYPOINT ["dotnet", "/opt/eztool/tool.dll"]
 LABEL org.opencontainers.image.title="dfir/eztool" \
-      org.opencontainers.image.description="Minimal hardened Eric Zimmerman tool (.NET) for the DX_DFIR pipeline: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, runs as uid 2000. Parameterized over EZTOOL." \
+      org.opencontainers.image.description="Minimal hardened Eric Zimmerman tool (.NET) for the DX_DFIR pipeline: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, runs as a fixed non-root uid (default 2000). Parameterized over EZTOOL." \
       org.opencontainers.image.licenses="MIT" \
       com.get-sybers.eztool="${EZTOOL}" \
       com.get-sybers.eztool.url="${EZTOOL_URL}" \

--- a/docker/hardening/harden.yml
+++ b/docker/hardening/harden.yml
@@ -12,7 +12,8 @@
 #   - sudo/su/pkexec and the account-manipulation setuid suite are REMOVED,
 #     and every remaining setuid/setgid bit is stripped
 #   - package managers and pip are removed (nothing installable at runtime)
-#   - the tool runs as the fixed unprivileged user (USER 2000:2000)
+#   - the tool runs as the fixed unprivileged user (USER harden_uid:harden_gid,
+#     default 2000:2000)
 #
 # Contract verified after every build by the dfir_images role (static image
 # config + a `docker export` scan proving the removed binaries are absent).

--- a/docker/plaso/Dockerfile
+++ b/docker/plaso/Dockerfile
@@ -47,5 +47,5 @@ ARG DFIR_UID=2000
 ARG DFIR_GID=2000
 USER ${DFIR_UID}:${DFIR_GID}
 LABEL org.opencontainers.image.title="dfir/plaso" \
-      org.opencontainers.image.description="Minimal hardened Plaso (pinned PyPI, libyal from source) for the DX_DFIR plaso/evtx-extraction lanes: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, runs as uid 2000 (python+sh irreducible; three entry tools, no single ENTRYPOINT)." \
+      org.opencontainers.image.description="Minimal hardened Plaso (pinned PyPI, libyal from source) for the DX_DFIR plaso/evtx-extraction lanes: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, runs as a fixed non-root uid (default 2000) (python+sh irreducible; three entry tools, no single ENTRYPOINT)." \
       com.get-sybers.hardened="true"

--- a/docker/suricata/Dockerfile
+++ b/docker/suricata/Dockerfile
@@ -31,5 +31,5 @@ ARG DFIR_GID=2000
 USER ${DFIR_UID}:${DFIR_GID}
 ENTRYPOINT ["suricata"]
 LABEL org.opencontainers.image.title="dfir/suricata" \
-      org.opencontainers.image.description="Minimal hardened Suricata (offline pcap replay) for the DX_DFIR signatures lane: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, runs as uid 2000." \
+      org.opencontainers.image.description="Minimal hardened Suricata (offline pcap replay) for the DX_DFIR signatures lane: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, runs as a fixed non-root uid (default 2000)." \
       com.get-sybers.hardened="true"

--- a/docker/yara/Dockerfile
+++ b/docker/yara/Dockerfile
@@ -34,5 +34,5 @@ ARG DFIR_GID=2000
 USER ${DFIR_UID}:${DFIR_GID}
 ENTRYPOINT ["/opt/dfir/scan-list.sh"]
 LABEL org.opencontainers.image.title="dfir/yara" \
-      org.opencontainers.image.description="Minimal hardened YARA for the DX_DFIR signatures lane: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no python, runs as uid 2000; sh kept only for the tool's own scan loop." \
+      org.opencontainers.image.description="Minimal hardened YARA for the DX_DFIR signatures lane: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no python, runs as a fixed non-root uid (default 2000); sh kept only for the tool's own scan loop." \
       com.get-sybers.hardened="true"

--- a/docker/zeek/Dockerfile
+++ b/docker/zeek/Dockerfile
@@ -40,5 +40,5 @@ ARG DFIR_GID=2000
 USER ${DFIR_UID}:${DFIR_GID}
 ENTRYPOINT ["zeek"]
 LABEL org.opencontainers.image.title="dfir/zeek" \
-      org.opencontainers.image.description="Minimal hardened Zeek LTS (offline pcap parsing) for the DX_DFIR zeek lane: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, no zkg/zeekctl, runs as uid 2000." \
+      org.opencontainers.image.description="Minimal hardened Zeek LTS (offline pcap parsing) for the DX_DFIR zeek lane: uid0 renamed+locked, no ansible/apt/pip/sudo/setuid, no shell, no python, no zkg/zeekctl, runs as a fixed non-root uid (default 2000)." \
       com.get-sybers.hardened="true"


### PR DESCRIPTION
Addresses the 7 Copilot line-comments on the restructure (#126/#127):

**Real bugs**
- `dfir_images` build args: `DFIR_UID`/`DFIR_GID` now win over any per-image override (combine order reversed) — an override can't silently replace the single-source uid.
- `dfir_images_gid` follows the uid unless explicitly set, so setting only `dfir_runtime_uid` yields `USER <uid>:<uid>`, not `<uid>:2000`.

**Doc / spec**
- `dfir_lane` `argument_specs`: `dfir_lane_module` + `dfir_lane_argv` marked required (they always are).
- Stale comments: `process.yml` (`dfir_lane_gate` → `dfir_lane_gate_extra`), `harden.yml` header, and the 6 Dockerfile OCI labels ("runs as a fixed non-root uid (default 2000)").

Verified: `ansible-lint` clean; a real `dxdfir process evtx` still extracts 7 files of records; gid-follows-uid + combine precedence render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)