### PR TITLE
fix(evtx): only a zero tally is empty — a non-zero tally with no output is a failure

### DIFF
--- a/python/get_sybers_dfir/evtx.py
+++ b/python/get_sybers_dfir/evtx.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -270,23 +271,33 @@ def process(evtx_dir, out_dir, evtxecmd_dir=None, image=None, force=False) -> di
             summary["processed"] += 1
             summary["results"].append({"log": rel, "output": os.path.join(host, json_out)})
             continue
-        # No records written. EvtxECmd exits 0 both when a log is genuinely EMPTY
-        # (it opened the log and printed a record tally) AND when it could not READ
-        # the input at all — a missing file, or a permission-denied it prints as
-        # "... does not exist! Exiting". Only the first is benign. EvtxECmd prints a
-        # "records found" tally once it has actually opened a log, so its ABSENCE
-        # means the log was never read: count that as a failure and surface
-        # EvtxECmd's own reason, not a silent "empty" that would hide an unreadable
-        # evidence tree.
+        # No records written. EvtxECmd exits 0 in three shapes here, and only one is
+        # benign, so we read its own "Total event log records found: <n>" tally:
+        #   n == 0 -> genuinely EMPTY: it opened the log and there was nothing. Benign.
+        #   n  > 0 -> it found records but wrote NONE to disk (an output/write error,
+        #             e.g. an unwritable dest) — a failure masquerading as empty.
+        #   no tally at all -> it never opened the log (missing file, or the
+        #             permission-denied it prints as "... does not exist! Exiting").
+        #             A failure; surface EvtxECmd's own reason.
+        # Matching on the tally (not merely the "records found" substring) keeps a
+        # non-zero-but-unwritten count from being hidden as a silent "empty".
         for p in (json_path, os.path.join(dest_dir, xml_out)):
             if os.path.exists(p):
                 os.remove(p)
         out = (proc.stdout or b"") + (proc.stderr or b"")
-        if b"records found" in out.lower():
+        text = out.decode("utf-8", "replace")
+        m = re.search(r"records found:\s*([\d,]+)", text, re.IGNORECASE)
+        tally = int(m.group(1).replace(",", "")) if m else None
+        if tally == 0:
             summary["empty"] += 1
             summary["results"].append({"log": rel, "empty": True})
+        elif tally is not None:
+            summary["failed"] += 1
+            summary["results"].append(
+                {"log": rel,
+                 "error": f"EvtxECmd reported {m.group(1)} records but wrote none"})
         else:
-            tail = out.decode("utf-8", "replace").strip().splitlines()
+            tail = text.strip().splitlines()
             why = tail[-1].strip() if tail else "no output and no record tally"
             summary["failed"] += 1
             summary["results"].append(

--- a/python/tests/test_evtx.py
+++ b/python/tests/test_evtx.py
@@ -194,6 +194,25 @@ def test_process_counts_unreadable_log_as_failed(tmp_path, monkeypatch):
     assert "did not read" in s["results"][0]["error"]
 
 
+def test_process_nonzero_tally_but_no_output_is_failed(tmp_path, monkeypatch):
+    evtx_dir = tmp_path / "in"
+    evtx_dir.mkdir()
+    (evtx_dir / "Security.evtx").write_bytes(b"x")
+
+    def fake_run(evtx_file, dest_dir, json_out, xml_out, image, **kw):
+        # EvtxECmd that OPENED the log and counted records but wrote none to disk
+        # (an output/write error): exits 0, reports a non-zero tally, no JSON on disk.
+        return subprocess.CompletedProcess(
+            [], 0, stdout=b"Total event log records found: 1,234", stderr=b"")
+
+    monkeypatch.setattr(evtx, "_run_evtxecmd", fake_run)
+    s = evtx.process(str(evtx_dir), str(tmp_path / "out"), image="dfir/evtxecmd:latest")
+    assert s["failed"] == 1        # records found but none written is a failure...
+    assert s["empty"] == 0         # ...not a benign empty
+    assert s["processed"] == 0
+    assert "1,234 records but wrote none" in s["results"][0]["error"]
+
+
 def test_process_bundled_mode_needs_no_dll(tmp_path, monkeypatch):
     evtx_dir = tmp_path / "in"
     evtx_dir.mkdir()


### PR DESCRIPTION
Addresses the Copilot inline review on #131 (`python/get_sybers_dfir/evtx.py`).

## Problem
In `process()`, the "no records written to disk" path treated **any** EvtxECmd output containing the substring `records found` as a benign **empty** log. If EvtxECmd opened the log and reported a **non-zero** tally but wrote nothing (an output/write error — e.g. an unwritable dest), that was silently misclassified as `empty`, hiding a real failure.

## Fix
Parse the actual `Total event log records found: <n>` tally instead of substring-matching:

| Case | Before | After |
|---|---|---|
| tally `0` | empty ✅ | empty ✅ |
| tally `> 0`, nothing on disk | **empty ❌** | **failed** — `"reported <n> records but wrote none"` ✅ |
| no tally at all | failed ✅ | failed ✅ (`"did not read the log: <reason>"`) |

## Tests
- New regression test `test_process_nonzero_tally_but_no_output_is_failed` (non-zero tally, no output → `failed`).
- Existing `empty(0)` and unreadable-log tests unchanged.
- **Full suite: 344 passed** (was 343).

This lands on `dev` as the source of truth; the release PR #131 will pick it up on its next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
