### PR TITLE
fix(cli): lane playbooks run python3 from the CLI's interpreter (fixes zimmerman preflight)

### DIFF
--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -198,6 +198,15 @@ def _process_lane(ap: str, repo: Path, name: str, pipeline: Pipeline, force: boo
         cmd += ["-e", kv]
     # resolve the role without installing the collection
     env = {"ANSIBLE_ROLES_PATH": str(repo / _COLLECTION / "roles")}
+    # The lane playbooks shell out to `python3` on the localhost connection — the
+    # preflight import-check, the image supply-chain guard, and each processor argv.
+    # Those need get_sybers_dfir AND its declared dependencies (PyYAML, the docker
+    # SDK, …), which live wherever THIS CLI is installed — not in whatever `python3`
+    # ansible would otherwise resolve from PATH (typically the bare system
+    # interpreter, which has the package on PYTHONPATH but none of its deps). Put
+    # this interpreter's own bin dir first on PATH so the playbook's `python3` is the
+    # one that carries the dependencies.
+    env["PATH"] = os.path.dirname(sys.executable) + os.pathsep + os.environ.get("PATH", "")
     scoped = "  (collection-scoped)" if scope_vars else ""
     typer.secho(f"processing {name} → {pipeline.value}{scoped}", fg=typer.colors.GREEN)
     _run(cmd, cwd=repo, env=env)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Unit tests for the dfir CLI (Typer CliRunner; subprocess mocked)."""
 import os
 import subprocess
+import sys
 from pathlib import Path
 from unittest import mock
 
@@ -61,6 +62,10 @@ def test_process_builds_playbook_command(tmp_path):
     # role path is exported so the collection resolves without install
     env = m.call_args.kwargs["env"]
     assert env["ANSIBLE_ROLES_PATH"] == str(repo / _COLLECTION / "roles")
+    # this interpreter's bin dir is FIRST on PATH, so the playbook's `python3`
+    # (preflight import-check, image guard, processor argv) is the env that carries
+    # the deps — not the bare system python ansible would otherwise resolve
+    assert env["PATH"].split(os.pathsep)[0] == os.path.dirname(sys.executable)
 
 
 def test_process_defaults_to_the_elastic_pipeline(tmp_path):


### PR DESCRIPTION
Found while running a full collection through every processor to exercise the next phase.

## Bug
The lane playbooks shell out to `python3` on the localhost connection — the preflight import-check (`dfir_lane/tasks/preflight.yml`), the hardened-image supply-chain guard, and each processor argv. Ansible resolves that `python3` from **PATH**, i.e. the bare **system** interpreter, which has `get_sybers_dfir` on `PYTHONPATH` but **none of its declared dependencies**.

So the zimmerman lane (whose `zimmerman.py` imports `yaml` at module load) dies at preflight:
```
ModuleNotFoundError: No module named 'yaml'
```
evtx/zeek/plaso only survived because they happen to be stdlib-only. CI never caught it because every role's `molecule.yml` pins `ansible_python_interpreter: {{ ansible_playbook_python }}` (the venv) — **production runs set nothing**.

## Fix
Prepend the CLI's own interpreter dir (`dirname(sys.executable)`) to `PATH` for the ansible subprocess in `_process_lane`, so the playbook's `python3` is the environment that carries the dependencies — the same one `dxdfir` itself runs from. One line, at the single point that spawns every lane.

## Verified
- Zimmerman preflight now passes (`import get_sybers_dfir.zimmerman` OK, zero yaml errors) and the lane runs its processor.
- Regression test added (`test_process_builds_playbook_command` now asserts the interpreter dir is first on `PATH`).
- Full suite: **344 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
