### PR TITLE
feat(zimmerman): skip non-Windows disk/VM items via the collection identity cue

### DIFF
--- a/ansible/collections/get_sybers.dfir/roles/dfir_zimmerman/defaults/main.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_zimmerman/defaults/main.yml
@@ -26,6 +26,13 @@ dfir_zimmerman_vss: false
 dfir_zimmerman_python_path: "{{ dfir_zimmerman_repo_root }}/python"
 dfir_zimmerman_force: false
 
+# Path to the collection's .collection.identity.json, set by the collection-scoped
+# `dxdfir process zimmerman <collection>` when the collection was identified. When
+# present, the processor skips disk/VM items whose identified os_family is
+# non-Windows (the EZ-Tools are Windows-only). Empty by default — no identity cue,
+# so every image is processed as before.
+dfir_zimmerman_identity: ""
+
 # The processor command argv, handed to the shared dfir_lane process step. This
 # is the one genuinely per-lane piece; the run/verify/gate skeleton is shared.
 dfir_zimmerman_argv: >-
@@ -34,5 +41,6 @@ dfir_zimmerman_argv: >-
   '--vm-dir', dfir_zimmerman_vm_dir,
   '--out-dir', dfir_zimmerman_out_dir,
   '--plaso-image', dfir_zimmerman_plaso_image]
+  + (['--identity', dfir_zimmerman_identity] if dfir_zimmerman_identity | length > 0 else [])
   + (['--vss'] if dfir_zimmerman_vss | bool else [])
   + (['--force'] if dfir_zimmerman_force | bool else []) }}

--- a/ansible/collections/get_sybers.dfir/roles/dfir_zimmerman/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_zimmerman/meta/argument_specs.yml
@@ -60,6 +60,15 @@ argument_specs:
         type: str
         required: false
         description: "PYTHONPATH to the get_sybers_dfir package (in-repo/dev runs)."
+      dfir_zimmerman_identity:
+        type: str
+        required: false
+        description: >-
+          Path to the collection's .collection.identity.json (set by the
+          collection-scoped `dxdfir process zimmerman <collection>` when the
+          collection was identified). When present, disk/VM items whose identified
+          os_family is present and not 'windows' are skipped — the EZ-Tools are
+          Windows-only. Empty by default (no identity cue; every image is processed).
       dfir_zimmerman_force:
         type: bool
         required: false

--- a/ansible/collections/get_sybers.dfir/roles/dfir_zimmerman/tasks/gate_extra.yml
+++ b/ansible/collections/get_sybers.dfir/roles/dfir_zimmerman/tasks/gate_extra.yml
@@ -1,18 +1,23 @@
 ---
 # zimmerman output gate, included at the end of dfir_lane's process block: some
-# host produced output, UNLESS there were no images or nothing but empties
-# (images == empty — a non-Windows image with no artefact set is NORMAL, not a
-# failure). Per-image failures are tolerated (dfir_lane_require_no_failures is
-# false for this lane), so this gates on output. A trusted literal assert —
-# dfir_lane_run + dfir_lane_verify are in scope from the shared process step.
+# host produced output, UNLESS every image present is accounted for as an empty or
+# a skip (images == empty + skipped). "empty" is a processed image with no artefact
+# set (a non-Windows image extracted nothing — NORMAL, not a failure); "skipped"
+# covers both an idempotent re-run (output already on disk, so the find above still
+# matches) and an identity skip (a disk identified as non-Windows — the wrong input
+# for the Windows-only EZ-Tools). Per-image failures are tolerated
+# (dfir_lane_require_no_failures is false for this lane), so this gates on output. A
+# trusted literal assert — dfir_lane_run + dfir_lane_verify are in scope from the
+# shared process step.
 - name: "zimmerman-process | assert output was produced for the images present"
   ansible.builtin.assert:
     that:
       - >-
         dfir_lane_verify.matched | int > 0 or
         ((dfir_lane_run.stdout | from_json).images | int ==
-         (dfir_lane_run.stdout | from_json).empty | int)
+         ((dfir_lane_run.stdout | from_json).empty | int
+          + (dfir_lane_run.stdout | from_json).skipped | int))
     fail_msg: >-
-      zimmerman produced no output at all though disk images were present
-      (every EZ-Tools container failed?).
+      zimmerman produced no output at all though processable (Windows) disk images
+      were present (every EZ-Tools container failed?).
     quiet: true

--- a/python/get_sybers_dfir/cli.py
+++ b/python/get_sybers_dfir/cli.py
@@ -264,6 +264,13 @@ def process(
         for lane_name, var, d, n in _collection.lane_inputs(repo, collection):
             scope.setdefault(lane_name, []).append(f"{var}={d}")
             counts[lane_name] = counts.get(lane_name, 0) + n
+        # If the collection was identified (.collection.identity.json present), cue
+        # the Windows-only zimmerman lane to skip non-Windows disk/VM images: pass
+        # the identity record's path as a scope var. The role adds --identity only
+        # when it is set, so an un-identified collection is unaffected.
+        identity = _collection.collection_dir(repo, collection) / _collection._IDENTITY
+        if identity.is_file() and "zimmerman" in scope:
+            scope["zimmerman"].append(f"dfir_zimmerman_identity={identity}")
 
     if source is Source.all:
         lanes = [lane.name for lane in _collection.LANES]     # the five evidence lanes

--- a/python/get_sybers_dfir/zimmerman.py
+++ b/python/get_sybers_dfir/zimmerman.py
@@ -40,6 +40,15 @@ its SQLite interop needs a writable unpack path the tool's own working directory
 provides, which the hardened read-only-rootfs base image does not; verifying that
 against a real ActivitiesCache.db is deferred to issue #88. See its docstring.
 
+Identity-aware (``--identity``): the EZ-Tools are Windows-only, so pointing this
+lane at a non-Windows disk is the wrong tool — it extracts nothing and today that
+surfaces as a loud failure. When a collection's ``.collection.identity.json`` is
+supplied, a disk/VM item whose identified ``os_family`` is present and NOT
+``windows`` (a Linux/macOS disk) is SKIPPED, not processed — a clean skip counted
+apart from failures. Absent identity, or an item with a null ``os_family``, is
+processed exactly as before (degrade gracefully). The collection-scoped
+``dxdfir process zimmerman <collection>`` passes the path automatically.
+
     python -m get_sybers_dfir.zimmerman --image-src RAW/disk_images --out-dir PROCESSED/zimmerman
 """
 from __future__ import annotations
@@ -243,6 +252,44 @@ def find_file(root: str, name: str) -> str | None:
     matches = [os.path.join(cur, f) for cur, _dirs, files in os.walk(root)
                for f in files if f.lower() == target]
     return sorted(matches)[0] if matches else None
+
+
+# ---- identity cue (skip non-Windows disk/VM items) --------------------------
+def load_identity_os(identity_path: str) -> dict[str, str]:
+    """Map each identified item's ABSOLUTE path -> its ``os_family`` from a
+    ``.collection.identity.json`` file (written by ``dxdfir collection identify``).
+
+    A record's ``path`` is collection-relative and the identity file sits at the
+    collection root, so the item's absolute path is ``<root>/<record path>``;
+    matching on the resolved absolute path is unambiguous (two same-named images in
+    different subdirs never collide). Best-effort: a missing / unreadable / malformed
+    file yields ``{}`` — no cue, so the lane processes every image exactly as it did
+    before identify existed. Records with a null ``os_family`` are omitted, so an
+    unidentified OS never causes a skip."""
+    try:
+        with open(identity_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    root = os.path.dirname(os.path.realpath(identity_path))
+    out: dict[str, str] = {}
+    for rec in data.get("items", []):
+        rel, fam = rec.get("path"), rec.get("os_family")
+        if rel and fam:
+            out[os.path.realpath(os.path.join(root, rel))] = fam
+    return out
+
+
+def identity_skip_reason(image: str, identity_os: dict[str, str]) -> str | None:
+    """Why the zimmerman lane should skip ``image`` per the identity cue, or None to
+    process it. The EZ-Tools are Windows-only, so a disk/VM item whose identified
+    ``os_family`` is present and not ``windows`` is the wrong tool's input and is
+    skipped (a clean skip, not a failure). An item absent from the map (no identity,
+    or a null ``os_family``) is processed — degrade gracefully."""
+    fam = identity_os.get(os.path.realpath(image))
+    if fam and fam != "windows":
+        return f"identity: os_family={fam} (EZ-Tools are Windows-only)"
+    return None
 
 
 # ---- per-tool container argv builders (pure — no I/O, no docker) ------------
@@ -513,12 +560,16 @@ def process_image(image, host_out_dir, *, plaso_image=PLASO_IMAGE, force=False,
     return result
 
 
-def process_source(image_src, out_dir, *, plaso_image=PLASO_IMAGE, force=False, vss=False) -> dict:
+def process_source(image_src, out_dir, *, plaso_image=PLASO_IMAGE, force=False, vss=False,
+                   identity_os=None) -> dict:
     """Process every disk image under ONE source (``image_src``: a file or a
-    directory of them) into ``out_dir/<host>/``."""
+    directory of them) into ``out_dir/<host>/``. ``identity_os`` maps an item's
+    absolute path to its identified ``os_family`` (from ``load_identity_os``); a
+    non-Windows disk/VM item is skipped whole (EZ-Tools are Windows-only)."""
     out_dir = os.path.realpath(out_dir)
     os.makedirs(out_dir, exist_ok=True)
     images = discover_images(image_src)
+    identity_os = identity_os or {}
 
     summary = {
         "source": os.path.realpath(image_src),
@@ -535,6 +586,16 @@ def process_source(image_src, out_dir, *, plaso_image=PLASO_IMAGE, force=False, 
     for img in images:
         host = host_name(img)
         host_dir = os.path.join(out_dir, host)
+        # Identity cue: a disk/VM item identified as non-Windows is the wrong input
+        # for the Windows-only EZ-Tools — skip it whole (a clean skip, not a
+        # failure) before paying for extraction. Unidentified items fall through.
+        skip_reason = identity_skip_reason(img, identity_os)
+        if skip_reason:
+            summary["skipped"] += 1
+            summary["results"].append(
+                {"image": img, "host": host, "host_dir": host_dir,
+                 "skipped": True, "skip_reason": skip_reason, "steps": {}})
+            continue
         res = process_image(img, host_dir, plaso_image=plaso_image, force=force, vss=vss)
         res["host"] = host
         if res.get("skipped"):
@@ -554,13 +615,15 @@ def process_source(image_src, out_dir, *, plaso_image=PLASO_IMAGE, force=False, 
 
 
 def process(input_dir, out_dir, *, vm_dir="", plaso_image=PLASO_IMAGE, force=False,
-           vss=False) -> dict:
+           vss=False, identity_os=None) -> dict:
     """Process disk images under ``input_dir`` and (if given) ``vm_dir`` into
     ``out_dir/<host>/`` — the same two-source shape as ``plaso.process``.
     ``vm_dir`` is optional and tolerated when absent/empty (a VM-export folder
     holds a plain ``.vmdk``, which ``discover_images`` finds like any other
     image; it does not get plaso.py's descriptor-vs-extent disambiguation, so
     keep VM exports to a single base/snapshot descriptor per folder for now).
+    ``identity_os`` (from ``load_identity_os``) cues the lane to skip non-Windows
+    disk/VM items; ``None`` means no cue — every image is processed as before.
     """
     sources = [os.path.realpath(input_dir)]
     if vm_dir and os.path.isdir(vm_dir):
@@ -569,7 +632,8 @@ def process(input_dir, out_dir, *, vm_dir="", plaso_image=PLASO_IMAGE, force=Fal
     summary = {"tool": "zimmerman", "out_dir": os.path.realpath(out_dir), "sources": [],
               "images": 0, "processed": 0, "skipped": 0, "empty": 0, "failed": 0}
     for src in sources:
-        s = process_source(src, out_dir, plaso_image=plaso_image, force=force, vss=vss)
+        s = process_source(src, out_dir, plaso_image=plaso_image, force=force, vss=vss,
+                           identity_os=identity_os)
         summary["sources"].append(s)
         for k in ("images", "processed", "skipped", "empty", "failed"):
             summary[k] += s.get(k, 0)
@@ -592,14 +656,20 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--plaso-image", default=PLASO_IMAGE,
                     help="container image providing image_export.py/log2timeline.py/psort.py "
                          "(default: %(default)s)")
+    ap.add_argument("--identity", default="",
+                    help="path to the collection's .collection.identity.json; when given, "
+                         "disk/VM items identified as non-Windows are skipped (the EZ-Tools "
+                         "are Windows-only). Absent/unidentified items are processed as usual.")
     ap.add_argument("--vss", action="store_true",
                     help="also extract from Volume Shadow Copies")
     ap.add_argument("--force", action="store_true",
                     help="reprocess hosts that already have output")
     args = ap.parse_args(argv)
 
+    identity_os = load_identity_os(args.identity) if args.identity else {}
     summary = process(args.input_dir, args.out_dir, vm_dir=args.vm_dir,
-                      plaso_image=args.plaso_image, force=args.force, vss=args.vss)
+                      plaso_image=args.plaso_image, force=args.force, vss=args.vss,
+                      identity_os=identity_os)
     json.dump(summary, sys.stdout)
     sys.stdout.write("\n")
     # Fail only when the run produced nothing AND nothing was already done — see

--- a/python/tests/test_zimmerman.py
+++ b/python/tests/test_zimmerman.py
@@ -3,6 +3,7 @@
 Every test here is offline: docker invocations are represented purely as argv
 lists (never executed) or, in the process_image tests, monkeypatched out.
 """
+import json
 import os
 import subprocess
 
@@ -391,6 +392,134 @@ def test_process_ignores_missing_vm_dir(tmp_path, monkeypatch):
     assert len(summary["sources"]) == 1
 
 
+# ---- identity cue: skip non-Windows disk/VM items (EZ-Tools are Windows-only) --
+def _write_identity(root, items) -> str:
+    """Write a .collection.identity.json under `root` from [(rel, os_family), ...].
+    Returns the file path. Mirrors identify.py's on-disk shape."""
+    records = [{"path": rel, "lane_subdir": rel.split("/", 1)[0], "os_family": fam,
+                "format": None, "filesystems": []} for rel, fam in items]
+    p = root / ".collection.identity.json"
+    p.write_text(json.dumps({"collection": "c", "generated": "x", "items": records}))
+    return str(p)
+
+
+def test_load_identity_os_maps_abs_path_to_os_family(tmp_path):
+    (tmp_path / "VM_files").mkdir()
+    (tmp_path / "disk_images").mkdir()
+    (tmp_path / "VM_files" / "lin.vmdk").write_bytes(b"x")
+    (tmp_path / "disk_images" / "win.e01").write_bytes(b"x")
+    (tmp_path / "VM_files" / "unknown.vmdk").write_bytes(b"x")
+    idf = _write_identity(tmp_path, [("VM_files/lin.vmdk", "linux"),
+                                     ("disk_images/win.e01", "windows"),
+                                     ("VM_files/unknown.vmdk", None)])
+    m = z.load_identity_os(idf)
+    assert m[os.path.realpath(str(tmp_path / "VM_files" / "lin.vmdk"))] == "linux"
+    assert m[os.path.realpath(str(tmp_path / "disk_images" / "win.e01"))] == "windows"
+    # a null os_family is omitted from the map — it never causes a skip
+    assert os.path.realpath(str(tmp_path / "VM_files" / "unknown.vmdk")) not in m
+
+
+def test_load_identity_os_missing_or_malformed_is_empty(tmp_path):
+    assert z.load_identity_os(str(tmp_path / "nope.json")) == {}
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ this is not json")
+    assert z.load_identity_os(str(bad)) == {}
+
+
+def test_identity_skip_reason_windows_only():
+    lin, win, mac = "/img/lin.vmdk", "/img/win.e01", "/img/mac.vmdk"
+    m = {os.path.realpath(lin): "linux", os.path.realpath(win): "windows",
+         os.path.realpath(mac): "macos"}
+    assert "linux" in (z.identity_skip_reason(lin, m) or "")     # non-Windows -> skip
+    assert "macos" in (z.identity_skip_reason(mac, m) or "")     # non-Windows -> skip
+    assert z.identity_skip_reason(win, m) is None                # Windows -> process
+    assert z.identity_skip_reason("/img/other.raw", m) is None   # unknown item -> process
+    assert z.identity_skip_reason(lin, {}) is None               # no identity -> process
+
+
+def _fake_process_image(seen):
+    """A process_image stand-in that records the images it was handed and never
+    touches a container (the real one runs the EZ-Tools via container.run)."""
+    def fake(image, host_out_dir, **kw):
+        seen.append(os.path.basename(image))
+        return {"skipped": False, "extracted_files": 1,
+                "steps": {"recmd": {"ran": True, "ok": True}}}
+    return fake
+
+
+def test_process_skips_linux_vmdk_by_identity(tmp_path, monkeypatch):
+    disk = tmp_path / "disk_images"
+    disk.mkdir()
+    (disk / "lin.vmdk").write_bytes(b"x")
+    identity_os = z.load_identity_os(_write_identity(tmp_path, [("disk_images/lin.vmdk", "linux")]))
+
+    def boom(*a, **k):
+        raise AssertionError("process_image (container run) must not run for an identity skip")
+
+    monkeypatch.setattr(z, "process_image", boom)
+    summary = z.process(str(disk), str(tmp_path / "out"), identity_os=identity_os)
+    assert summary["images"] == 1
+    assert summary["skipped"] == 1        # counted skipped …
+    assert summary["processed"] == 0
+    assert summary["failed"] == 0         # … NOT failed
+    res = summary["sources"][0]["results"][0]
+    assert res["skipped"] is True and "linux" in res["skip_reason"]
+
+
+def test_process_processes_windows_image_by_identity(tmp_path, monkeypatch):
+    disk = tmp_path / "disk_images"
+    disk.mkdir()
+    (disk / "win.e01").write_bytes(b"x")
+    identity_os = z.load_identity_os(_write_identity(tmp_path, [("disk_images/win.e01", "windows")]))
+    seen: list[str] = []
+    monkeypatch.setattr(z, "process_image", _fake_process_image(seen))
+    summary = z.process(str(disk), str(tmp_path / "out"), identity_os=identity_os)
+    assert summary["processed"] == 1 and summary["skipped"] == 0
+    assert seen == ["win.e01"]            # the Windows image reached the container path
+
+
+def test_process_no_identity_processes_everything(tmp_path, monkeypatch):
+    """No .collection.identity.json (identity_os is None) — behave exactly as before
+    identify existed: every image is processed, even a would-be-Linux .vmdk."""
+    disk = tmp_path / "disk_images"
+    disk.mkdir()
+    (disk / "lin.vmdk").write_bytes(b"x")
+    seen: list[str] = []
+    monkeypatch.setattr(z, "process_image", _fake_process_image(seen))
+    summary = z.process(str(disk), str(tmp_path / "out"))   # no identity_os
+    assert summary["processed"] == 1 and summary["skipped"] == 0
+    assert seen == ["lin.vmdk"]
+
+
+def test_process_null_os_family_is_processed(tmp_path, monkeypatch):
+    """An identity record with a NULL os_family degrades gracefully — processed."""
+    disk = tmp_path / "disk_images"
+    disk.mkdir()
+    (disk / "x.vmdk").write_bytes(b"x")
+    identity_os = z.load_identity_os(_write_identity(tmp_path, [("disk_images/x.vmdk", None)]))
+    assert identity_os == {}              # null omitted, so nothing to skip on
+    seen: list[str] = []
+    monkeypatch.setattr(z, "process_image", _fake_process_image(seen))
+    summary = z.process(str(disk), str(tmp_path / "out"), identity_os=identity_os)
+    assert seen == ["x.vmdk"]
+
+
+def test_process_mixed_windows_processed_linux_skipped(tmp_path, monkeypatch):
+    disk = tmp_path / "disk_images"
+    disk.mkdir()
+    (disk / "win.e01").write_bytes(b"x")
+    (disk / "lin.vmdk").write_bytes(b"x")
+    identity_os = z.load_identity_os(_write_identity(
+        tmp_path, [("disk_images/win.e01", "windows"), ("disk_images/lin.vmdk", "linux")]))
+    seen: list[str] = []
+    monkeypatch.setattr(z, "process_image", _fake_process_image(seen))
+    summary = z.process(str(disk), str(tmp_path / "out"), identity_os=identity_os)
+    assert summary["images"] == 2
+    assert summary["processed"] == 1
+    assert summary["skipped"] == 1
+    assert seen == ["win.e01"]            # only the Windows image reached the container path
+
+
 # ---- CLI entry point ---------------------------------------------------------
 def test_main_requires_input_dir():
     import pytest
@@ -409,3 +538,22 @@ def test_main_no_images_is_clean_exit(tmp_path, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert '"images": 0' in out
+
+
+def test_main_identity_skips_linux_and_exits_clean(tmp_path, capsys, monkeypatch):
+    """End-to-end through main(): --identity is loaded and threaded, a Linux .vmdk
+    is skipped (never reaches the container path), and an all-skipped run is a clean
+    exit (rc 0), not a failure."""
+    disk = tmp_path / "disk_images"
+    disk.mkdir()
+    (disk / "lin.vmdk").write_bytes(b"x")
+    idf = _write_identity(tmp_path, [("disk_images/lin.vmdk", "linux")])
+
+    def boom(*a, **k):
+        raise AssertionError("a skipped image must never reach process_image / container.run")
+
+    monkeypatch.setattr(z, "process_image", boom)
+    rc = z.main(["--input-dir", str(disk), "--out-dir", str(tmp_path / "out"), "--identity", idf])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["skipped"] == 1 and summary["processed"] == 0 and summary["failed"] == 0


### PR DESCRIPTION
## What & why

Sub-issue of epic #134. The zimmerman lane runs Eric Zimmerman's **Windows-only**
EZ-Tools. Pointing it at a non-Windows disk (e.g. the LS24 Linux vmdk) extracts
nothing, and today that surfaces as a **loud failure**. Now the lane acts on the
`.collection.identity.json` cue written by `dxdfir collection identify` (#135) and
**skips** a disk/VM item whose identified `os_family` is present and `!= "windows"`
— a clean SKIP, counted apart from failures.

Built entirely on the existing lane: the shared `dfir_lane` skeleton, the
`dfir_zimmerman` role, the collection-scoped `dxdfir process`, and the hardened
`container.run` path. **No new machinery, and the container boundary is untouched**
— every EZ-Tool / plaso invocation still runs through `container.run`; the cue only
decides whether an image *enters* that path.

## How the cue is threaded

1. `zimmerman.py` gains two pure, host-side helpers:
   - `load_identity_os(path)` — reads the identity JSON and maps each item's
     **absolute** path (`<collection root>/<record path>`) to its `os_family`.
     Absolute-path matching is unambiguous; a missing/malformed file or a null
     `os_family` yields no cue (process as before).
   - `identity_skip_reason(image, map)` — returns a reason to skip a non-Windows
     item, else `None`.
   These thread through `process()` / `process_source()` via a new optional
   `--identity <path>` arg. `process_image` and the argv builders are unchanged.
2. `cli.py` — the collection-scoped `process` adds
   `dfir_zimmerman_identity=<path>` to the zimmerman scope vars when the collection
   carries `.collection.identity.json`.
3. `dfir_zimmerman` role — new `dfir_zimmerman_identity` default (empty by default)
   wired into `dfir_zimmerman_argv` (adds `--identity` only when set) + an
   `argument_specs` entry.
4. `gate_extra.yml` — the output gate now passes when every image present is
   accounted for as an empty **or a skip** (`images == empty + skipped`), so an
   all-skipped run is clean rather than a "produced no output" failure. Genuine
   failures (a Windows image whose EZ-Tools all failed) still fail the gate. Jinja
   precedence verified.

## Graceful degradation (unchanged behaviour when there's no cue)

- No `.collection.identity.json` → every image processed, exactly as before.
- `os_family` is null (unidentified) → processed.
- Item not in the identity record → processed.
- `os_family == "windows"` → processed.
- `os_family` is `linux`/`macos` → skipped (counted `skipped`, not `failed`);
  `main()` returns 0 (clean) when a run is all-skips.

## Tests (container boundary mocked — no real tools run)

Added to `python/tests/test_zimmerman.py`:
- `load_identity_os` maps abs path → os_family; null omitted; missing/malformed → `{}`.
- `identity_skip_reason`: linux/macos skip, windows/unknown/no-identity process.
- `process`: linux vmdk ⇒ **skipped** (`process_image` asserted never called),
  counted `skipped` not `failed`; windows image ⇒ **processed**; no identity ⇒
  processes everything; null os_family ⇒ processed; mixed ⇒ only the Windows image
  reaches the container path.
- `main --identity`: end-to-end, all-skipped run exits `0`.

Full suite: **357 passed, 2 skipped** (the 2 skips are pre-existing uninitialised
submodules, unrelated).

## Plaso 0-event on the LS24 Linux vmdk — finding (documented, not fixed)

Timeboxed per the task. **Not reproducible in-repo**: `data_store/` is skeleton-only
(all `.gitkeep`) — the LS24 image and its plaso log live only in the runtime
environment, so there is nothing here to re-run or inspect.

- **No skip belongs in plaso.** Unlike the Windows-only zimmerman lane, plaso is a
  general-purpose timelining tool that legitimately parses Linux/macOS images
  (ext/xfs, syslog, utmp, filestat, …). It *should* attempt the Linux vmdk — the
  identity cue deliberately does **not** touch the plaso lane.
- **The ~0.17s / 0-event result is consistent with "correct 0 events", not a crash.**
  0.17s is far too fast for `log2timeline` to have walked a real multi-GB disk; it
  matches dfVFS opening the image and finding no filesystem to timeline within that
  window — a minimal/empty test disk, or a container/extent that didn't resolve to a
  mountable FS. A genuine populated Linux disk would take far longer and emit events.
- **Definitive diagnostic for the operator:** read that image's run log at
  `data_store/processed/log2timeline/logs/<name>.log` — dfVFS records the
  partitions/filesystems it detected. If it lists a readable ext/xfs filesystem yet
  0 events were emitted → a real plaso parsing gap worth a follow-up issue. If it
  lists no readable filesystem (or LS24 is a streamOptimized/extent vmdk that didn't
  resolve) → 0 events is expected and correct.
- **Out-of-scope observation (flagged, not changed):** `plaso.py` currently counts a
  *lone* 0-event image as `failed` (so `main()` returns rc 1), whereas the zimmerman
  lane distinguishes `empty` (processed, no artefacts) from `failed`. If LS24's
  0-event is confirmed as "legitimately nothing to timeline", plaso could get the
  same "empty is not a failure" treatment — but that is a separate behaviour change I
  did not make blind, without the image to validate against.

## What I validated vs. could not

- **Validated:** full pytest suite green (357 passed); the 9 new identity tests; the
  Jinja gate truth-table (all six scenarios incl. real-failure cases) and the argv
  template rendering with/without `--identity`; YAML parse of all three edited role
  files; `py_compile` of the changed modules.
- **Could not validate (no docker / no evidence in this env):** a live containerised
  end-to-end zimmerman run against a real Linux vmdk, and the plaso LS24 run itself
  (documented above instead).

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
