### PR TITLE
feat(signatures): stage detection rule sets via the lanes' own pinned fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ is `0`, anything may change without notice.
 
 ## [Unreleased]
 
+### Added
+- **Detection-rule staging** so the `signatures` lane actually detects out of the
+  box (the dependency dirs shipped with only a `.gitkeep`, so yara/suricata/hayabusa
+  ran clean but found nothing). Every lane's `--fetch` now provisions its rule set
+  into `data_store/dependencies/` — previously only YARA did: the yara lane's pinned
+  DetectRaptor ruleset, **ET Open** for suricata (downloaded and merged into the one
+  `suricata.rules` the lane loads with `-S`), and the **pinned Hayabusa release**
+  (native binary + its bundled Sigma rules, sha256-verified) for hayabusa
+  (`suricata.fetch` / `hayabusa.fetch`, mirroring `detectraptor`'s host-side
+  pinned-download discipline — the hardened `dfir/suricata` image deliberately
+  strips `suricata-update` and Hayabusa has no tool image, so neither can fetch
+  inside a container). New `python -m get_sybers_dfir.signatures --fetch-only`
+  provisions every lane's rules without running detection, driven by the new
+  `scripts/stage-detection-rules.sh`, which `scripts/setup-environment.sh` now runs
+  once so a freshly set-up host has rules staged. Downloaded rules stay gitignored.
+
 ### Removed
 - **The Kusto/ADX layer.** The Azure Data Explorer emulator was the analysis
   backend from 0.2.0; the Elastic-native path (`docker/elastic`, the ES|QL/EQL

--- a/docs/Signature-Rules.md
+++ b/docs/Signature-Rules.md
@@ -132,9 +132,13 @@ python3 -m get_sybers_dfir.signatures --only suricata \
     --output-dir data_store/processed/signatures --repo-root .
 ```
 
-To provision ET Open while online, run `suricata-update` (or download the ET Open
-tarball) into the directory yourself, then append your own rules to the one
-`suricata.rules` file.
+To provision ET Open while online, run the staging step — either
+`scripts/stage-detection-rules.sh`, `python3 -m get_sybers_dfir.signatures
+--fetch-only`, or a detection run with `--fetch` — which downloads ET Open and
+merges it into that one `suricata.rules` for you (the hardened `dfir/suricata`
+image strips `suricata-update`, so the fetch runs host-side, pinned, like the
+YARA/DetectRaptor fetch). Or drop your own `suricata.rules` in yourself; append
+any local rules to that single file.
 
 **Verify:** the lane reports the ruleset it chose (if it says it's using the
 image's bundled rules, your file wasn't found). Then check the per-PCAP EVE
@@ -240,3 +244,10 @@ extracted from a disk image via `--image-src`. Sigma rules live under
 `data_store/dependencies/hayabusa/rules/` (or `--hayabusa-rules`); detections are
 written to `<out-dir>/hayabusa/timeline.jsonl`. See
 [Scripts-Overview](/docs/scripts/Scripts-Overview.md#signature-detection-get_sybers_dfirsignatures).
+
+The Hayabusa binary and its bundled Sigma `rules/` are provisioned by the staging
+step — `scripts/stage-detection-rules.sh` (or `python3 -m
+get_sybers_dfir.signatures --fetch-only`, or a signatures run with `--fetch`)
+downloads the pinned, sha256-verified release into
+`data_store/dependencies/hayabusa/`. Drop your own binary/rules there to override
+(a binary already present suppresses the fetch).

--- a/python/get_sybers_dfir/signatures/__init__.py
+++ b/python/get_sybers_dfir/signatures/__init__.py
@@ -83,3 +83,56 @@ def process(output_dir: str, lanes=LANES, *, repo_root: str, fetch: bool = False
         "failed": failed,
         "results": results,
     }
+
+
+def provision(repo_root: str, lanes=LANES, *, force: bool = False,
+              config: dict | None = None) -> dict:
+    """Provision (fetch) each lane's rule set into data_store/dependencies/ and
+    return a summary — the staging step (``--fetch-only`` /
+    ``scripts/stage-detection-rules.sh``), WITHOUT running detection.
+
+    Drives each lane's OWN pinned fetch: the DetectRaptor YARA provisioner, ET
+    Open for suricata, and the pinned Hayabusa release (binary + bundled Sigma
+    rules) for hayabusa — the same fetch the lanes' ``--fetch`` runs. Idempotent
+    (a lane whose rules are already present is left untouched; operator YARA rules
+    suppress the DetectRaptor fetch exactly as the yara lane does) and non-fatal (a
+    lane that cannot be provisioned — offline, hash mismatch — records an error and
+    the rest continue).
+    """
+    from . import detectraptor, hayabusa, suricata, yara
+
+    ds = os.path.join(repo_root, "data_store", "dependencies")
+    cfg = config or {}
+
+    def _yara() -> dict:
+        rules_dir = cfg.get("yara", {}).get("rules_dir") or os.path.join(ds, "yara-rules")
+        if not force and yara._rule_files(rules_dir):
+            return {"tool": "detectraptor", "skipped": True,
+                    "reason": "operator YARA rules present"}
+        return detectraptor.fetch(rules_dir, force=force)
+
+    def _suricata() -> dict:
+        rules_dir = cfg.get("suricata", {}).get("rules_dir") or os.path.join(ds, "suricata-rules")
+        return suricata.fetch(rules_dir, force=force)
+
+    def _hayabusa() -> dict:
+        hb_dir = cfg.get("hayabusa", {}).get("hb_dir") or os.path.join(ds, "hayabusa")
+        return hayabusa.fetch(hb_dir, force=force)
+
+    runners = {"yara": _yara, "suricata": _suricata, "hayabusa": _hayabusa}
+    results, provisioned, failed = {}, 0, 0
+    for lane in lanes:
+        try:
+            results[lane] = runners[lane]()
+            provisioned += 1
+        except Exception as exc:  # noqa: BLE001 — offline/hash errors are non-fatal per lane
+            results[lane] = {"lane": lane, "error": str(exc)}
+            failed += 1
+    return {
+        "tool": "signatures-provision",
+        "dependencies_dir": ds,
+        "lanes": list(lanes),
+        "provisioned": provisioned,
+        "failed": failed,
+        "results": results,
+    }

--- a/python/get_sybers_dfir/signatures/__main__.py
+++ b/python/get_sybers_dfir/signatures/__main__.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import sys
 
-from . import LANES, process
+from . import LANES, process, provision
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -13,15 +13,21 @@ def main(argv: list[str] | None = None) -> int:
         prog="get_sybers_dfir.signatures",
         description="YARA / Suricata / Hayabusa detection lanes -> JSONL",
     )
-    ap.add_argument("--output-dir", required=True, help="base output dir (one <lane>/ per lane)")
+    ap.add_argument("--output-dir",
+                    help="base output dir (one <lane>/ per lane); required unless --fetch-only")
     ap.add_argument("--repo-root", required=True, help="repo root (lane input/dep defaults hang off it)")
     ap.add_argument("--only", action="append", choices=list(LANES),
                     help="run only this lane (repeatable); default all")
     ap.add_argument("--fetch", action="store_true",
-                    help="provision rules when online: the yara lane fetches the pinned "
-                         "DetectRaptor ruleset when it has no rules yet (see "
-                         "signatures/detectraptor.py); the other lanes still record a "
-                         "note when their deps are missing")
+                    help="provision each lane's rule set when online before detecting: the "
+                         "pinned DetectRaptor YARA ruleset, ET Open for suricata, and the "
+                         "pinned Hayabusa release (binary + Sigma rules) — each only when "
+                         "that lane has no rules yet (see signatures/detectraptor.py, "
+                         "suricata.fetch, hayabusa.fetch). Offline is a per-lane note.")
+    ap.add_argument("--fetch-only", action="store_true",
+                    help="provision each lane's rule set into data_store/dependencies/ and "
+                         "EXIT without running detection (the staging step; honors --only "
+                         "and --force). Backs scripts/stage-detection-rules.sh.")
     ap.add_argument("--force", action="store_true", help="regenerate outputs that already exist")
     # Hayabusa disk-image staging (shared with the evtx processor's stage).
     ap.add_argument("--stage-dir", help="where disk-image EVTX extractions land for the "
@@ -56,6 +62,19 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     lanes = tuple(args.only) if args.only else LANES
+
+    if args.fetch_only:
+        # Staging only: drive each lane's own pinned fetch and exit (no detection).
+        summary = provision(args.repo_root, lanes, force=args.force)
+        json.dump(summary, sys.stdout)
+        sys.stdout.write("\n")
+        # Non-zero only when EVERY requested lane failed (fully offline) and none
+        # was provisioned — staging is otherwise best-effort and idempotent.
+        return 1 if summary["failed"] and not summary["provisioned"] else 0
+
+    if not args.output_dir:
+        ap.error("--output-dir is required (unless --fetch-only)")
+
     config = {"suricata": {
         "home_net": args.home_net,
         "external_net": args.external_net,

--- a/python/get_sybers_dfir/signatures/hayabusa.py
+++ b/python/get_sybers_dfir/signatures/hayabusa.py
@@ -14,19 +14,43 @@ The evtx pipeline's inline enrichment (``get_sybers_dfir.evtx.run_hayabusa``)
 reuses ``scan_directory`` / ``find_binary`` / ``tag_detections`` here — one
 Hayabusa implementation either way.
 
-Native Rust binary (no official image); operator-supplied. ``--fetch`` is accepted
-for parity with the bash script but not yet implemented here.
+Native Rust binary (no official image), so — unlike Volatility's in-container ISF
+symbol fetch — there is no hardened tool container to fetch through; ``--fetch``
+(also :func:`fetch`) provisions the pinned upstream release, the hayabusa binary
+AND its bundled Sigma ``rules/`` tree, with the same pin + sha256 discipline as
+``detectraptor.py`` — a host-side stdlib download like the rest of this package.
 """
 from __future__ import annotations
 
 import glob
+import hashlib
+import io
 import json
 import os
+import platform
 import subprocess
 import tempfile
+import urllib.request
+import zipfile
 
 from .. import imageexport
 from . import list_images
+
+# Pinned upstream Hayabusa release: the native binary + its bundled Sigma rules/
+# tree, published per-arch as a zip on GitHub. Same discipline as detectraptor.py
+# — pin the version AND the sha256 of the downloaded zip, so a moved or tampered
+# asset is caught. To advance: bump _VERSION and paste the new digest(s) (a
+# mismatch raises with the digest it got). The zip unpacks FLAT: a hayabusa*
+# binary beside rules/ and config/ — exactly where find_binary() and the lane's
+# <bin-dir>/rules default look.
+_REPO = "Yamato-Security/hayabusa"
+_VERSION = "3.4.0"                    # the pin the retired signatures shell lane used
+# sha256 of hayabusa-<_VERSION>-lin-<arch>-gnu.zip, keyed by hayabusa's arch tag.
+# Only an arch we have verified is pinned; an unpinned arch still fetches (version
+# + HTTPS), just without the extra digest check.
+_ZIP_SHA256 = {
+    "x64": "c58860c9ad2bc00bec9935d6a5dc43060a37119bdff6c05177cc677257a3b946",
+}
 
 
 def tag_detections(text: str) -> list[dict]:
@@ -53,6 +77,82 @@ def find_binary(hb_dir: str) -> str | None:
         if os.path.isfile(cand) and os.access(cand, os.X_OK):
             return cand
     return None
+
+
+def _hb_asset(version: str) -> tuple[str, str]:
+    """(release asset filename, hayabusa arch tag) for this host. Pure."""
+    machine = platform.machine().lower()
+    arch = "aarch64" if machine in ("aarch64", "arm64") else "x64"
+    return f"hayabusa-{version}-lin-{arch}-gnu.zip", arch
+
+
+def _download_zip(url: str, want_sha256: str | None) -> bytes:
+    with urllib.request.urlopen(url, timeout=300) as resp:  # noqa: S310 — pinned https release URL
+        blob = resp.read()
+    if want_sha256:
+        got = hashlib.sha256(blob).hexdigest()
+        if got != want_sha256:
+            raise ValueError(
+                f"sha256 mismatch for {url}: expected {want_sha256}, got {got}")
+    return blob
+
+
+def _safe_extract(zf: zipfile.ZipFile, dest: str) -> None:
+    """``extractall`` with a zip-slip guard — no member may escape ``dest``."""
+    dest_abs = os.path.realpath(dest)
+    for member in zf.namelist():
+        target = os.path.realpath(os.path.join(dest, member))
+        if target != dest_abs and not target.startswith(dest_abs + os.sep):
+            raise ValueError(f"unsafe path in archive: {member!r}")
+    zf.extractall(dest)
+
+
+def fetch(hb_dir: str, *, version: str | None = None, force: bool = False) -> dict:
+    """Provision the pinned Hayabusa release under ``hb_dir``.
+
+    Downloads the per-arch release zip (in-memory), verifies its sha256 against the
+    pin when the arch is pinned, unpacks it (the hayabusa binary + its bundled
+    Sigma ``rules/`` tree) where :func:`find_binary` and the lane's
+    ``<bin-dir>/rules`` default look, and makes the binary executable. Skips when a
+    binary is already present (pass ``force=True`` to refresh). Returns a summary;
+    raises on hash mismatch.
+
+    Native binary, so — unlike Volatility's in-container symbol fetch — there is no
+    hardened tool image to fetch through; this is a host-side stdlib download, the
+    same pattern as :mod:`get_sybers_dfir.signatures.detectraptor`.
+    """
+    version = version or _VERSION
+    existing = find_binary(hb_dir)
+    if existing and not force:
+        return {"tool": "hayabusa", "binary": existing, "skipped": True}
+    asset, arch = _hb_asset(version)
+    url = f"https://github.com/{_REPO}/releases/download/v{version}/{asset}"
+    want = _ZIP_SHA256.get(arch) if version == _VERSION else None
+    blob = _download_zip(url, want)
+    os.makedirs(hb_dir, exist_ok=True)
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        _safe_extract(zf, hb_dir)
+    # The zip unpacks flat, so the binary is <hb_dir>/<asset without .zip>; fall
+    # back to a name search for a layout that differs across future versions.
+    # (find_binary() can't locate it yet — it requires +x, which we set below.)
+    binary = os.path.join(hb_dir, asset[:-4])
+    if not os.path.isfile(binary):
+        cands = [c for c in sorted(
+                     glob.glob(os.path.join(hb_dir, "**", "hayabusa*"), recursive=True))
+                 if os.path.isfile(c) and not c.endswith(".zip")
+                 and "." not in os.path.basename(c)]
+        binary = cands[0] if cands else None
+    if not binary:
+        raise RuntimeError(f"no hayabusa binary found after unpacking {asset}")
+    os.chmod(binary, 0o755)
+    return {"tool": "hayabusa", "binary": binary, "version": version, "asset": asset,
+            "rules_dir": os.path.join(os.path.dirname(binary), "rules"),
+            "verified": want is not None, "skipped": False}
+
+
+# Module-level alias so run() — which has a ``fetch`` bool parameter that would
+# shadow the name in its local scope — can still reach the provisioner.
+_fetch_release = fetch
 
 
 def _dir_has_evtx(d: str) -> bool:
@@ -125,8 +225,16 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
         return res
 
     hb_bin = hb_bin or find_binary(hb_dir)
+    if (not hb_bin or not os.access(hb_bin, os.X_OK)) and fetch:
+        # --fetch contract (mirrors the yara lane): provision the pinned Hayabusa
+        # release — binary + bundled Sigma rules — when absent. Offline/failed
+        # fetch is a note, not a failure.
+        try:
+            hb_bin = _fetch_release(hb_dir).get("binary") or find_binary(hb_dir)
+        except Exception as exc:  # noqa: BLE001 — network/hash errors surface as a note
+            res["note"] = f"hayabusa fetch failed: {exc}"
     if not hb_bin or not os.access(hb_bin, os.X_OK):
-        res["note"] = f"no hayabusa binary in {hb_dir} — supply one or --fetch"
+        res["note"] = res["note"] or f"no hayabusa binary in {hb_dir} — supply one or --fetch"
         return res
     rules_dir = rules_dir or os.path.join(os.path.dirname(hb_bin), "rules")
 

--- a/python/get_sybers_dfir/signatures/suricata.py
+++ b/python/get_sybers_dfir/signatures/suricata.py
@@ -23,15 +23,26 @@ capture, or ``[global]``). The flow:
 
 Tuning is rebuilt from scratch for EVERY capture — a value derived from (or
 configured for) one pcap is never carried into the next.
+
+Rules are operator-supplied under data_store/dependencies/suricata-rules (a single
+``suricata.rules``, loaded with ``-S``). ``--fetch`` (also :func:`fetch`)
+provisions the ET Open ruleset there when it is absent — a host-side pinned
+download merged into one ``suricata.rules``, the same discipline as
+``detectraptor.py``. The hardened dfir/suricata image deliberately strips
+``suricata-update`` and runs with no network, so ET Open cannot be fetched inside
+the tool container.
 """
 from __future__ import annotations
 
 import configparser
+import io
 import ipaddress
 import json
 import os
 import subprocess
+import tarfile
 import tempfile
+import urllib.request
 
 from .. import container
 from . import clean_name
@@ -490,6 +501,89 @@ def _suricata_pass(pcap, rules_dir, rules_file, image, sets):
     return ""
 
 
+# ---- ET Open rule provisioning (--fetch) -----------------------------------
+# The hardened dfir/suricata image strips suricata-update and runs with no
+# network, so ET Open is fetched HOST-SIDE (stdlib urllib) and merged into the one
+# suricata.rules the lane loads — the same discipline as detectraptor.py. ET Open
+# is rebuilt continuously upstream, so (unlike detectraptor's commit pin) the URL
+# is pinned rather than a content digest.
+_ET_OPEN_URL = "https://rules.emergingthreats.net/open/suricata/emerging.rules.tar.gz"
+
+
+def merge_et_rules(named_texts: list[tuple[str, str]]) -> tuple[str, dict]:
+    """Concatenate ET Open per-category ``.rules`` files into one suricata.rules
+    body. Pure — testable without network.
+
+    Files are emitted in name order (stable output), each under a marker comment;
+    rule text is kept verbatim (its comments included). ``rules`` counts active
+    (non-comment, non-blank) lines. The lane loads the result with ``suricata
+    -S``; ET's classification/reference ``.config`` files are not rules and are
+    not passed here (the image supplies its own)."""
+    chunks: list[str] = []
+    files = rules = 0
+    for name, text in sorted(named_texts):
+        files += 1
+        for line in text.splitlines():
+            s = line.strip()
+            if s and not s.startswith("#"):
+                rules += 1
+        chunks.append(f"# --- {name} ---\n{text.rstrip()}\n")
+    return ("\n".join(chunks), {"files": files, "rules": rules})
+
+
+def _download(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=300) as resp:  # noqa: S310 — pinned https URL
+        return resp.read()
+
+
+def fetch(rules_dir: str, *, url: str | None = None, force: bool = False) -> dict:
+    """Provision the ET Open ruleset as ``<rules_dir>/suricata.rules``.
+
+    Downloads the ET Open tarball (in-memory), merges its ``.rules`` members into
+    the single ``suricata.rules`` the lane loads with ``-S``, and writes it
+    atomically. Skips when ``suricata.rules`` already exists (pass ``force=True``
+    to refresh). Returns a summary; raises on a download/parse error.
+
+    Host-side stdlib download (like detectraptor.py): the hardened dfir/suricata
+    image strips suricata-update and runs with no network, so ET Open cannot be
+    fetched inside the tool container.
+    """
+    url = url or _ET_OPEN_URL
+    out = os.path.join(rules_dir, "suricata.rules")
+    if os.path.exists(out) and not force:
+        return {"tool": "suricata", "output": out, "skipped": True}
+    blob = _download(url)
+    named: list[tuple[str, str]] = []
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tf:
+        for m in tf.getmembers():
+            if m.isfile() and m.name.endswith(".rules"):
+                fh = tf.extractfile(m)   # read member bytes only — never extracted to disk
+                if fh is not None:
+                    named.append((os.path.basename(m.name),
+                                  fh.read().decode("utf-8", errors="replace")))
+    if not named:
+        raise RuntimeError(f"no .rules members in the ET Open archive at {url}")
+    body, stats = merge_et_rules(named)
+    header = (
+        "# Emerging Threats Open ruleset — fetched and merged by get_sybers_dfir.\n"
+        f"# Source: {url}\n"
+        f"# Merged {stats['files']} rule file(s); loaded with `suricata -S`.\n"
+        "# Provenance/licensing: THIRD_PARTY_NOTICES.md.\n\n"
+    )
+    os.makedirs(rules_dir, exist_ok=True)
+    tmp = out + ".part"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(header + body)
+    os.replace(tmp, out)
+    return {"tool": "suricata", "output": out, "skipped": False,
+            "files": stats["files"], "rules": stats["rules"]}
+
+
+# Module-level alias so run() — which has a ``fetch`` bool parameter that would
+# shadow the name in its local scope — can still reach the provisioner.
+_fetch_rules = fetch
+
+
 def run(*, output_dir, repo_root, fetch=False, force=False,
         pcap_dir=None, rules_dir=None, image=_SURICATA_IMAGE, keep_all=False,
         home_net=None, external_net=None, extra_sets=None, auto_home_net=False,
@@ -504,13 +598,24 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
     res = {"lane": "suricata", "produced": 0, "skipped": 0, "failed": 0, "note": None,
            "tuning": {}}
 
+    if fetch and not any("suricata.rules" in files
+                         for _c, _d, files in os.walk(rules_dir)):
+        # --fetch contract (mirrors the yara lane): provision ET Open into the one
+        # suricata.rules the lane loads, when absent. Offline/failed fetch is a
+        # note, not a failure.
+        try:
+            _fetch_rules(rules_dir)
+        except Exception as exc:  # noqa: BLE001 — network errors surface as a note
+            res["note"] = f"suricata rules fetch failed: {exc}"
+
     rules_file = None
     for cur, _dirs, files in os.walk(rules_dir):
         if "suricata.rules" in files:
             rules_file = os.path.join(cur, "suricata.rules")
             break
     if not rules_file:
-        res["note"] = "no suricata.rules — using the image's bundled rules"
+        msg = "no suricata.rules — using the image's bundled rules"
+        res["note"] = f"{res['note']}; {msg}" if res["note"] else msg
 
     pcaps = discover(pcap_dir)
     if not pcaps:

--- a/python/tests/test_signatures.py
+++ b/python/tests/test_signatures.py
@@ -658,3 +658,154 @@ def test_audit_flags_unexpected_and_missing(monkeypatch):
     assert not result["ok"]
     assert any("dfir/rogue" in v and "unexpected" in v for v in result["violations"])
     assert not any("sof-elk" in v for v in result["violations"])   # allow-listed
+
+
+# ---- rule provisioning: suricata ET Open merge (pure) ----------------------
+def test_merge_et_rules_concatenates_and_counts():
+    a = "# comment\nalert tcp any any -> any any (msg:\"a\"; sid:1;)\n\n"
+    b = "alert ip any any -> any any (msg:\"b\"; sid:2;)\n"
+    body, stats = suricata.merge_et_rules([("emerging-b.rules", b),
+                                           ("emerging-a.rules", a)])
+    assert stats == {"files": 2, "rules": 2}          # two active (non-comment) lines
+    # emitted in NAME order (a before b) with a marker per file, text verbatim
+    assert body.index("emerging-a.rules") < body.index("emerging-b.rules")
+    assert 'msg:"a"' in body and 'msg:"b"' in body and "# comment" in body
+
+
+def test_suricata_fetch_skips_when_rules_present(tmp_path):
+    (tmp_path / "suricata.rules").write_text("alert ip any any -> any any (sid:1;)\n")
+    res = suricata.fetch(str(tmp_path))               # would need network otherwise
+    assert res["skipped"] is True
+    assert res["output"] == str(tmp_path / "suricata.rules")
+
+
+def test_suricata_run_fetches_when_absent(tmp_path, monkeypatch):
+    """run(fetch=True) drives the ET Open provisioner when no suricata.rules exists."""
+    repo = tmp_path
+    (repo / "data_store").mkdir()
+    rules = tmp_path / "rules"; rules.mkdir()
+    called = {}
+
+    def fake_fetch(rules_dir, **kw):
+        called["dir"] = rules_dir
+        (rules / "suricata.rules").write_text("alert ip any any -> any any (sid:1;)\n")
+        return {"tool": "suricata", "output": str(rules / "suricata.rules"), "skipped": False}
+
+    monkeypatch.setattr(suricata, "_fetch_rules", fake_fetch)
+    # no pcaps -> the lane returns after provisioning without touching docker
+    res = suricata.run(output_dir=str(tmp_path / "out"), repo_root=str(repo),
+                       fetch=True, rules_dir=str(rules), pcap_dir=str(tmp_path / "nopcaps"))
+    assert called["dir"] == str(rules)
+    assert (rules / "suricata.rules").exists()
+    assert res["lane"] == "suricata"
+
+
+def test_suricata_run_no_fetch_by_default(tmp_path, monkeypatch):
+    rules = tmp_path / "rules"; rules.mkdir()
+    monkeypatch.setattr(suricata, "_fetch_rules",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fetch")))
+    suricata.run(output_dir=str(tmp_path / "out"), repo_root=str(tmp_path),
+                 fetch=False, rules_dir=str(rules), pcap_dir=str(tmp_path / "nopcaps"))
+
+
+# ---- rule provisioning: hayabusa pinned release ----------------------------
+def test_hb_asset_arch_mapping(monkeypatch):
+    monkeypatch.setattr(hayabusa.platform, "machine", lambda: "x86_64")
+    assert hayabusa._hb_asset("3.4.0") == ("hayabusa-3.4.0-lin-x64-gnu.zip", "x64")
+    monkeypatch.setattr(hayabusa.platform, "machine", lambda: "aarch64")
+    assert hayabusa._hb_asset("3.4.0") == ("hayabusa-3.4.0-lin-aarch64-gnu.zip", "aarch64")
+
+
+def test_hayabusa_pin_shape():
+    # the pinned digest is a real 64-hex sha256 and the version is set
+    assert hayabusa._VERSION
+    assert set(hayabusa._ZIP_SHA256), "at least one arch must be pinned"
+    for arch, sha in hayabusa._ZIP_SHA256.items():
+        assert len(sha) == 64 and int(sha, 16) >= 0, arch
+
+
+def test_hayabusa_fetch_skips_when_binary_present(tmp_path):
+    b = tmp_path / "hayabusa-3.4.0-lin-x64-gnu"
+    b.write_text("#!/bin/sh\n"); b.chmod(0o755)
+    res = hayabusa.fetch(str(tmp_path))               # would need network otherwise
+    assert res["skipped"] is True and res["binary"] == str(b)
+
+
+def test_hayabusa_safe_extract_rejects_zip_slip(tmp_path):
+    import io as _io
+    import zipfile
+    buf = _io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../escape.txt", "nope")
+    buf.seek(0)
+    dest = tmp_path / "dest"; dest.mkdir()
+    with zipfile.ZipFile(buf) as zf:
+        import pytest
+        with pytest.raises(ValueError, match="unsafe path"):
+            hayabusa._safe_extract(zf, str(dest))
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_hayabusa_run_fetches_when_absent(tmp_path, monkeypatch):
+    repo = tmp_path
+    (repo / "data_store").mkdir()
+    hb = tmp_path / "hb"; hb.mkdir()
+
+    def fake_fetch(hb_dir, **kw):
+        exe = hb / "hayabusa-3.4.0-lin-x64-gnu"
+        exe.write_text("#!/bin/sh\n"); exe.chmod(0o755)
+        return {"tool": "hayabusa", "binary": str(exe), "skipped": False}
+
+    monkeypatch.setattr(hayabusa, "_fetch_release", fake_fetch)
+    monkeypatch.setattr(hayabusa, "scan_directory", lambda *a, **k: "")   # no evtx
+    res = hayabusa.run(output_dir=str(tmp_path / "out"), repo_root=str(repo),
+                       fetch=True, hb_dir=str(hb),
+                       loose_dir=str(tmp_path / "none"), scan_disk=False)
+    assert (hb / "hayabusa-3.4.0-lin-x64-gnu").exists()
+    assert res["lane"] == "hayabusa"                 # provisioned, then no evtx -> note
+    assert "no hayabusa binary" not in (res["note"] or "")
+
+
+# ---- provision() orchestrator + --fetch-only -------------------------------
+def test_provision_dispatches_and_is_non_fatal(tmp_path, monkeypatch):
+    from get_sybers_dfir.signatures import detectraptor
+    monkeypatch.setattr(detectraptor, "fetch",
+                        lambda d, **k: {"tool": "detectraptor", "skipped": False})
+    monkeypatch.setattr(suricata, "fetch",
+                        lambda d, **k: {"tool": "suricata", "skipped": False})
+    monkeypatch.setattr(hayabusa, "fetch",
+                        lambda d, **k: (_ for _ in ()).throw(OSError("offline")))
+    summary = signatures.provision(str(tmp_path))
+    assert summary["tool"] == "signatures-provision"
+    assert summary["provisioned"] == 2 and summary["failed"] == 1
+    assert summary["results"]["hayabusa"]["error"] == "offline"
+    # dep dir hangs off repo_root
+    assert summary["dependencies_dir"].endswith(os.path.join("data_store", "dependencies"))
+
+
+def test_provision_yara_defers_to_operator_rules(tmp_path, monkeypatch):
+    ydir = tmp_path / "data_store" / "dependencies" / "yara-rules"
+    ydir.mkdir(parents=True)
+    (ydir / "mine.yar").write_text("rule R { condition: true }\n")
+    from get_sybers_dfir.signatures import detectraptor
+    monkeypatch.setattr(detectraptor, "fetch",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fetch")))
+    summary = signatures.provision(str(tmp_path), lanes=("yara",))
+    assert summary["results"]["yara"]["skipped"] is True
+
+
+def test_main_fetch_only_requires_no_output_dir(tmp_path, monkeypatch):
+    from get_sybers_dfir.signatures import __main__ as cli
+    monkeypatch.setattr(cli, "provision",
+                        lambda repo, lanes, **k: {"tool": "signatures-provision",
+                                                  "provisioned": 3, "failed": 0,
+                                                  "lanes": list(lanes), "results": {}})
+    rc = cli.main(["--fetch-only", "--repo-root", str(tmp_path)])
+    assert rc == 0
+
+
+def test_main_requires_output_dir_without_fetch_only(tmp_path):
+    from get_sybers_dfir.signatures import __main__ as cli
+    import pytest
+    with pytest.raises(SystemExit):
+        cli.main(["--repo-root", str(tmp_path)])     # no --output-dir, no --fetch-only

--- a/scripts/setup-environment.sh
+++ b/scripts/setup-environment.sh
@@ -318,6 +318,19 @@ done
 echo "✅ ansible on PATH: $(/usr/local/bin/ansible-playbook --version 2>/dev/null | head -1 || echo 'ansible-playbook')"
 
 ################################################################################
+# Stage the detection rule sets the `signatures` lane reads.
+#
+# suricata/yara/hayabusa detect against rules provisioned under
+# data_store/dependencies/; a fresh checkout ships only .gitkeep there, so the
+# lanes run clean but find nothing. Stage them now, while we are (presumably)
+# online, by driving the lanes' OWN pinned fetch (scripts/stage-detection-rules.sh
+# -> `python -m get_sybers_dfir.signatures --fetch-only`). Thin by design — no
+# downloading is reimplemented here. Best-effort: the script is idempotent, warns
+# (never fails) offline, and can be re-run later, so it must not abort setup.
+################################################################################
+"$SCRIPT_DIR/stage-detection-rules.sh" || true
+
+################################################################################
 # Install the collection's pinned Ansible dependencies (requirements.yml — never
 # :latest, never a branch). They go to a fixed shared path that the repo-root
 # ansible.cfg puts on collections_path, so every user's runs resolve the same

--- a/scripts/stage-detection-rules.sh
+++ b/scripts/stage-detection-rules.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# ==============================================================================
+# Stage the detection rule sets the `signatures` lane reads.
+#
+# The signature lanes (python/get_sybers_dfir/signatures/) detect against rules
+# provisioned under data_store/dependencies/. A fresh checkout ships only a
+# .gitkeep in each of those directories, so yara/suricata/hayabusa run clean but
+# find NOTHING. This is a THIN wrapper: all downloading lives in the pipeline's
+# OWN, sanctioned fetch path — it invents no parallel machinery and reimplements
+# no downloading here. It drives:
+#
+#     python -m get_sybers_dfir.signatures --fetch-only --repo-root <repo>
+#
+# which provisions each lane through the lane's own pinned fetch:
+#
+#   yara-rules/     the DetectRaptor provisioner (commit-pinned + sha256-verified),
+#                   merged into detectraptor/detectraptor.yar. Operator rules in
+#                   the tree win, so the fetch stands down when any *.yar exists.
+#   suricata-rules/ ET Open, merged into the single suricata.rules the lane loads
+#                   with `-S`. (The hardened dfir/suricata image deliberately
+#                   strips suricata-update and runs with no network, so ET Open is
+#                   provisioned by the lane's host-side pinned fetch, not inside
+#                   the tool container — same discipline as detectraptor.)
+#   hayabusa/       the pinned Hayabusa release (native binary + its bundled Sigma
+#                   rules/ tree). Hayabusa has no tool image, so the lane's fetch
+#                   is a host-side pinned + sha256-verified download.
+#
+# Everything under data_store/** is gitignored — nothing staged here is ever
+# committed; this is a re-runnable ONLINE provisioning step.
+#
+# Idempotent:  a lane whose rules are already present is left untouched (the
+#              fetch itself skips it); --force re-stages.
+# Non-fatal:   a lane that can't be provisioned (offline) is reported and the run
+#              moves on — the script NEVER aborts its caller (setup-environment.sh
+#              runs it as a single best-effort step).
+# No sudo/root is assumed (matches setup-environment.sh).
+#
+# Usage: scripts/stage-detection-rules.sh [--force] [--only LANE]... [--help]
+#          --force        re-stage even if a lane's rules are already present
+#          --only LANE    stage only this lane (yara|suricata|hayabusa); repeatable
+# ==============================================================================
+set -o pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
+
+# A python that can import get_sybers_dfir. The provisioners are stdlib-only, so
+# any python3 works with the repo's python/ on PYTHONPATH — no install required;
+# the dxdfir venv (if present) is preferred so this matches how the pipeline runs.
+DXDFIR_VENV="${DXDFIR_VENV:-/opt/dxdfir/venv}"
+if [[ -x "$DXDFIR_VENV/bin/python" ]]; then
+    PYTHON_BIN="$DXDFIR_VENV/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+else
+    echo "⚠️  No python3 found — cannot stage detection rules (skipping)." >&2
+    exit 0
+fi
+# Prefer the repo's own package (so a locally-updated fetch is what runs) over any
+# copy installed in the venv's site-packages.
+export PYTHONPATH="$REPO_ROOT_DIR/python${PYTHONPATH:+:$PYTHONPATH}"
+
+FETCH_ARGS=()
+ONLY=()
+
+usage() { sed -n '2,/^# =\{10,\}$/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -f|--force) FETCH_ARGS+=("--force") ;;
+        --only)
+            shift
+            [[ -n "${1:-}" ]] || { echo "❌ --only needs a lane (yara|suricata|hayabusa)" >&2; exit 2; }
+            ONLY+=("$1") ;;
+        --only=*) ONLY+=("${1#*=}") ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo "❌ Unknown option: $1" >&2
+            echo "   Usage: $0 [--force] [--only LANE]... [--help]" >&2
+            exit 2 ;;
+    esac
+    shift
+done
+
+for _l in "${ONLY[@]}"; do
+    case "$_l" in
+        yara|suricata|hayabusa) FETCH_ARGS+=("--only" "$_l") ;;
+        *) echo "❌ --only: unknown lane '$_l' (choose from yara, suricata, hayabusa)" >&2; exit 2 ;;
+    esac
+done
+
+echo "🔎 Staging detection rule sets into data_store/dependencies/ ..."
+echo "   (via the signatures lanes' own pinned fetch; data_store/** is gitignored)"
+
+# Drive the sanctioned provisioning path. --fetch-only provisions each lane's
+# rules and exits WITHOUT running detection. It is best-effort: an offline host
+# gets a per-lane note in the JSON summary and a non-zero exit, which we soften to
+# a warning so this step never fails the caller.
+if "$PYTHON_BIN" -m get_sybers_dfir.signatures --fetch-only \
+        --repo-root "$REPO_ROOT_DIR" "${FETCH_ARGS[@]}"; then
+    echo "🎉 Detection rule sets staged."
+else
+    echo "⚠️  One or more lanes could not be provisioned (usually offline)." >&2
+    echo "    Re-run when online:  scripts/stage-detection-rules.sh" >&2
+fi
+echo "   Detect with:  dxdfir process signatures"
+
+# Best-effort by design: staging is network-dependent and must never fail the
+# caller, so the exit status stays success regardless.
+exit 0


### PR DESCRIPTION
Closes #138 (sub-issue of epic #134).

## Problem
`data_store/dependencies/{yara-rules,suricata-rules,hayabusa}` shipped only a `.gitkeep`, so the `signatures` lanes ran clean but detected **nothing** (suricata/yara/hayabusa produced 0 detections).

## Approach — reuse the sanctioned fetch path, no parallel machinery
Rather than hand-roll host-side downloads or bypass the hardened containers, this **completes each lane's already-stubbed `--fetch` contract in Python**, mirroring `detectraptor`'s pinned + `sha256`-verified, stdlib-`urllib` discipline ("stdlib only, like the rest of the signatures package"):

- **yara** already fetched the pinned DetectRaptor ruleset — unchanged, now driven by the same entry point.
- **suricata.fetch** — download **ET Open** and merge its `.rules` into the single `suricata.rules` the lane loads with `-S`. The hardened `dfir/suricata` image *deliberately strips `suricata-update`* (`docker/suricata/Dockerfile`) and runs `--network none`, so the fetch is host-side (like DetectRaptor), **not** inside the tool container.
- **hayabusa.fetch** — download the **pinned Hayabusa release (v3.4.0)**, `sha256`-verified, and unpack the native binary + its bundled Sigma `rules/` exactly where `find_binary()` / `<bin-dir>/rules` look (zip-slip-guarded). Hayabusa has **no tool image**, so this too is host-side.

Both new fetches wire into each lane's `run(fetch=True)` path (previously no-ops), so a detection run with `--fetch` now provisions all three lanes.

### Staging entry + thin shell hook
- `signatures.provision()` + **`python -m get_sybers_dfir.signatures --fetch-only`** provision every lane's rules **without** running detection (idempotent, non-fatal per lane).
- **New `scripts/stage-detection-rules.sh`** is a *thin* wrapper that drives `--fetch-only` — **no downloading is reimplemented in shell**. Idempotent, warns (never fails) offline, `--force` / `--only LANE` supported, `setup-environment.sh`-style output.
- **`scripts/setup-environment.sh`** runs it once, immediately after the `✅ ansible on PATH` step, best-effort (`|| true`) — localized to that anchor.
- Downloaded rules stay **gitignored** (`data_store/.gitignore` is deny-by-default); `.gitkeep` stays tracked.

## Validation
- **Full Python suite green** (`361 passed, 2 pre-existing skips`); 13 new network-free unit tests (pure ET-Open merge, skip-when-present for suricata/hayabusa, `run(fetch=True)` dispatch, `provision()` aggregation + non-fatal, zip-slip guard, `--fetch-only` CLI).
- **Real end-to-end fetch validated** (network available in the dev env), into an isolated temp repo-root:
  - yara → **10,699** merged rules
  - suricata → **52,138** ET Open rule lines from **52** files → one `suricata.rules`
  - hayabusa → binary **sha256-verified**, **4,802** bundled Sigma rule files, `find_binary()` returns it executable
  - **re-run skips all three** (idempotent)
- Confirmed staged artifacts are gitignored (nothing tracked); shell wrapper `--help` / bad-`--only` / real `--only yara` run all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)