### PR TITLE
fix(plaso): discover loose VMDK in vm_dir + psort wrapper readable (Linux disk lane)

### DIFF
--- a/docker/plaso/Dockerfile
+++ b/docker/plaso/Dockerfile
@@ -32,9 +32,17 @@ RUN set -eux; \
     ln -s /usr/local/bin/psort /usr/local/bin/psort.py; \
     ln -s /usr/local/bin/image_export /usr/local/bin/image_export.py; \
     printf 'plaso %s (pypi, libyal built from source)\n' "${PLASO_VERSION}" > /etc/dxdfir-plaso-version
+# The image runs as a non-root uid (2000); the wrapper is the only python entry
+# point psort is invoked through, so it MUST be world-READABLE or
+# `python3 /opt/dxdfir/psort_wrapper.py` fails with Errno 13 for uid 2000. Pin the
+# mode with a `chmod` in the RUN below (NOT `COPY --chmod`, which needs BuildKit —
+# the ansible docker builder uses the legacy builder) rather than inheriting the
+# build-context file's perms (which vary by checkout/umask and have shipped as
+# 0640, breaking every psort render).
 COPY plaso/psort_wrapper.py /opt/dxdfir/psort_wrapper.py
 COPY hardening/harden.yml /tmp/hardening/harden.yml
 RUN set -eux; \
+    chmod 0644 /opt/dxdfir/psort_wrapper.py; \
     ansible-playbook -c local -i localhost, /tmp/hardening/harden.yml -e harden_uid=${DFIR_UID} -e harden_gid=${DFIR_GID}; \
     rm -rf /usr/local/bin/ansible* /usr/local/lib/python3*/site-packages/ansible* \
            /etc/ansible /root/.ansible /tmp/hardening

--- a/python/get_sybers_dxdfir/plaso.py
+++ b/python/get_sybers_dxdfir/plaso.py
@@ -202,11 +202,16 @@ def get_vm_descriptor(vm_dir: str) -> tuple[str | None, str]:
 
 
 # ---- discovery -------------------------------------------------------------
-def discover_images(input_dir: str) -> list[dict]:
+def discover_images(input_dir: str, recursive: bool = True) -> list[dict]:
     """Every processable image under input_dir (content-first), each as
-    {path, rel, format, by}. Skips vmdk-extents and ewf-continuation segments."""
+    {path, rel, format, by}. Skips vmdk-extents and ewf-continuation segments.
+
+    ``recursive=False`` restricts discovery to files sitting DIRECTLY in
+    input_dir (no descent into subdirs) — used to pick up a loose single-file
+    image dropped straight into VM_files/ without confusing it with the
+    per-VM export folders that :func:`discover_vms` owns."""
     picks: list[dict] = []
-    for root, _dirs, files in os.walk(input_dir):
+    for root, dirs, files in os.walk(input_dir):
         for name in sorted(files):
             path = os.path.join(root, name)
             rel = os.path.relpath(path, input_dir)
@@ -221,6 +226,8 @@ def discover_images(input_dir: str) -> list[dict]:
             if fmt in ("", "vmdk-extent", "ewf-cont"):
                 continue
             picks.append({"path": path, "rel": rel, "format": fmt, "by": by})
+        if not recursive:
+            dirs[:] = []   # top level only — never descend into VM-export folders
     # stable order, de-dup by path
     seen, out = set(), []
     for p in sorted(picks, key=lambda d: d["rel"]):
@@ -367,17 +374,28 @@ def process(input_dir, vm_dir, out_dir, module_path, image=_IMAGE, force=False,
 
     images = discover_images(input_dir) if os.path.isdir(input_dir) else []
     vms = discover_vms(vm_dir) if vm_dir else []
+    # Loose single-file images dropped straight into vm_dir (a monolithic .vmdk /
+    # .vhd / .vhdx, or an E01/dd left there) — NOT a per-VM export folder, so
+    # discover_vms misses them. Collection sort routes every VMDK/VHD(X) to
+    # VM_files/, so this is the common case for a single-file VM disk. Top level
+    # only: never re-pick a VM-export folder's own descriptor/extents (those are
+    # handled by discover_vms + get_vm_descriptor below). Each is processed like
+    # any other image, mounting vm_dir instead of input_dir.
+    vm_images = discover_images(vm_dir, recursive=False) if vm_dir and os.path.isdir(vm_dir) else []
     loose = discover_loose(loose_dir) if loose_dir else []
 
     processed = skipped = failed = warnings = 0
     results = []
 
-    for img in images:
+    # (mount_dir, image) pairs: disk-image tree mounts input_dir; a loose image in
+    # vm_dir mounts vm_dir. run_plaso hands log2timeline "/data/<rel>" either way.
+    for mount_dir, img in ([(input_dir, i) for i in images]
+                           + [(vm_dir, i) for i in vm_images]):
         name = get_clean_filename(img["rel"])
         if not force and _already_done(out_dir, name):
             skipped += 1
             continue
-        res = run_plaso(input_dir, img["rel"], name, out_dir, module_path, image)
+        res = run_plaso(mount_dir, img["rel"], name, out_dir, module_path, image)
         if res["ok"]:
             processed += 1
         else:
@@ -423,7 +441,7 @@ def process(input_dir, vm_dir, out_dir, module_path, image=_IMAGE, force=False,
         "input_dir": input_dir,
         "vm_dir": vm_dir,
         "out_dir": out_dir,
-        "images": len(images),
+        "images": len(images) + len(vm_images),
         "vms": len(vms),
         "processed": processed,
         "skipped": skipped,

--- a/python/tests/test_plaso.py
+++ b/python/tests/test_plaso.py
@@ -119,6 +119,43 @@ def test_discover_vms(tmp_path):
     assert got == ["VM-A", "VM-B"]
 
 
+def test_discover_images_non_recursive_top_level_only(tmp_path):
+    # A loose single-file image dropped straight into VM_files/ (monolithic VMDK)
+    # is picked up at the top level, while an image nested inside a VM-export
+    # folder (owned by discover_vms + get_vm_descriptor) is NOT re-picked.
+    _w(tmp_path / "5g-image-1.vmdk", b"KDMV____")            # loose monolithic VMDK
+    nested = tmp_path / "VM-A"
+    nested.mkdir()
+    _w(nested / "vm.vmdk", b"# Disk DescriptorFile\n")       # inside a VM folder
+    top = {(d["rel"], d["format"]) for d in plaso.discover_images(str(tmp_path), recursive=False)}
+    assert ("5g-image-1.vmdk", "vmdk") in top
+    assert all("/" not in rel and "VM-A" not in rel for rel, _ in top)
+    assert len(top) == 1
+    # the default (recursive) scan still descends into the folder
+    deep = {d["rel"] for d in plaso.discover_images(str(tmp_path))}
+    assert os.path.join("VM-A", "vm.vmdk") in deep
+
+
+def test_process_loose_image_in_vm_dir(tmp_path, monkeypatch):
+    # A loose VMDK in vm_dir (no per-VM folder, empty disk-image dir) must be
+    # discovered and handed to run_plaso mounting vm_dir — the ls24-sample case.
+    in_dir = tmp_path / "disk_images"
+    vm_dir = tmp_path / "VM_files"
+    in_dir.mkdir()
+    vm_dir.mkdir()
+    _w(vm_dir / "5g-image-1.vmdk", b"KDMV____")
+    calls = []
+
+    def fake_run_plaso(mount_dir, src_rel, name, out_dir, module_path, image=plaso._IMAGE):
+        calls.append((mount_dir, src_rel, name))
+        return {"source": src_rel, "ok": True, "host": "h", "output": f"{name}.jsonl"}
+
+    monkeypatch.setattr(plaso, "run_plaso", fake_run_plaso)
+    s = plaso.process(str(in_dir), str(vm_dir), str(tmp_path / "out"), "module.py")
+    assert s["images"] == 1 and s["vms"] == 0 and s["processed"] == 1 and s["failed"] == 0
+    assert calls == [(os.path.realpath(str(vm_dir)), "5g-image-1.vmdk", "5g-image-1_vmdk")]
+
+
 # ---- idempotence marker ----------------------------------------------------
 def test_already_done_requires_db_marker_and_jsonl(tmp_path):
     out = tmp_path


### PR DESCRIPTION
The plaso lane produced zero output on a collection whose disk is a loose single-file VMDK (ls24-sample: a monolithic `5g-image-1.vmdk` in `VM_files/`, empty `disk_images/`). Two bugs:

1. **discovery** — a loose single-file image in `vm_dir` was invisible to `discover_vms` (sub-folders only). Added a `recursive` flag to `discover_images` and run it over `vm_dir` too (VM-export folders stay owned by `discover_vms`). +2 tests.
2. **psort perms** — `docker/plaso/Dockerfile` baked `psort_wrapper.py` `0640` (uid0) but the image runs as uid 2000 → psort died Errno 13 → 0 events. Fixed with `RUN chmod 0644` (NOT `COPY --chmod`, which needs BuildKit — the ansible builder is legacy, so `--chmod` errored and the image never rebuilt). **Needs a plaso image rebuild** to take effect.

Verified end-to-end on the real 3 GB Linux VMDK: dfVFS decompresses the streamOptimized image, log2timeline walks the inner EXT filesystem (2.46 GB `.plaso`), psort renders **4,201,497 events** → `5g-webui.jsonl`. 19 tests pass.

> Note: DX_DFIR `dev` is diverged and predates the dfir→dxdfir rename, so this targets `main` directly. The submodule **pin bumps** (PIIAT-MitreCar#54, PIIAT-Mem#3) land in a follow-up once those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)