### PR TITLE
docs(car): property-provenance catalogue — every CAR field × every source it can come from

### DIFF
--- a/docs/car-provenance/COMPLETENESS-BACKLOG.md
+++ b/docs/car-provenance/COMPLETENESS-BACKLOG.md
@@ -1,0 +1,49 @@
+# CAR completeness backlog — ranked
+
+The concrete "squeeze more from every artefact" work items the 13 per-object
+provenance audits surfaced, ranked by value/effort. Each is a source that
+genuinely exists but the pipeline doesn't (yet) turn into the CAR field. Honest
+no-source fields are listed last — document them as permanent nulls, never fake.
+
+## The biggest lever — promote the quarantined audit family
+`to-be-validated/evtx_audit.yml` holds schema-grounded, INERT maps for the
+Windows object-access audit family. It needs one audit-enabled capture to
+validate, then promotion into `mappings/`. It alone unlocks:
+- **file** `write`/`read` actions (4663/4660/4670/5140/5145/5058) — today file has **no `write` source at all**.
+- **registry** live writes (4657) — the only non-Sysmon source of a registry write with the true writer `pid`/`user`/`image_path`.
+- **flow** endpoint identity + **socket** `bind` (5156/5157/5158) — a second, log-native source of `exe`/`pid`/`direction` on a connection (normalize 5158's raw numeric protocol on the way).
+
+## Tier 1 — quick wins (the source is already IN a mapped record)
+1. **file.uid** ← Security 4907 `SubjectUserSid` (already in the record; `evtx_more.py:102`).
+2. **registry.new_content** ← Sysmon 14 `NewName` (native-only today); and flatten the Plaso `windows:registry:*` `values` list → `value`/`data`/`type`.
+3. **thread.uid** — inherit-list asymmetry: the memory lane inherits `uid`, the Sysmon lane inherits `sid` (which thread lacks) not `uid`, so every `remote_create` leaves `thread.uid` null (`relationships.yml`).
+4. **email.return_address** ← zeek smtp `reply_to`; **email.server_relay** ← zeek `path` (both already captured, kept native).
+5. **socket/flow.family** normalize `ipv4`/`ipv6` → `AF_INET`/`AF_INET6` (memory emits ECS-style; the STIX `socket-ext` gate `startswith("AF_")` silently drops it).
+6. **process** — `hostname` null on SRUM app-usage; `image_path` null on prefetch (the `path_hints[]` list is unindexed).
+7. **module** — decompose prefetch `mapped_files` into `module/load` rows (path/name).
+
+## Tier 2 — wire an existing but unmapped source
+1. **authentication: Kerberos 4768/4769/4771 + NTLM 4776** — EvtxECmd already parses them; the object has **one** mapper (4624/4625/4672) and **zero Kerberos** coverage. Highest-value object gap. (Also: Zeek `ssh.json`/`kerberos`/`ntlm` not even ingested; Linux sshd/sudo/PAM auth routed to user_session, dropping `method`.)
+2. **service: the registry `Services` key** — `plaso_registry.py`/`recmd.py` parse it but emit `registry` objects; the full definition (name, ImagePath, ObjectName→`user`, Start/Type) survives only in `native`. **A dead disk yields zero `service` objects today.** Reconstruct `service/create` from it.
+3. **file: `timestomp` + `previous_creation_time`** — from the $MFT $SI/$FN birth mismatch (Plaso already emits per-attribute rows via `attribute_name`; `l2t_mft` flattens them) and Sysmon EID 2. Plus NTFS owner/mode from the security descriptor / $Secure (`OldSd`/`NewSd` sit native).
+4. **flow: Zeek dns/ssl/http → flow by shared `uid`** (the R3 pattern) — fills `application_protocol`/`proto_info`/`dest_fqdn` from logs already produced but unmapped.
+5. **http: UA parsing** → `user_agent_name`/`_version`/`_device` (a pure heuristic post-process; `user_agent_full` is already captured). Plus proxy/IIS logs for decrypted-HTTPS + requester IP.
+6. **module/driver: memory `ldrmodules`** (unlinked = injected) and **dumpfiles+hash**; and **cross-object hash hydration** — disk hashes (amcache sha1, PE sha256) reach file/process but never module/driver — a path/hash join propagates them (exactly what `crosssource.py` enables).
+7. **user_session: 4800/4801 lock/unlock** (the proper `lock` source; today `lock` never fires) and Linux **btmp/lastlog** (failed logins; `login_successful=false` has no source — 4625 is diverted to `authentication`).
+8. **service: svcscan → derive `start`/`stop` from `State`** and propagate its `pid` (today a store-only snapshot).
+
+## Tier 3 — run the plugin / capture the evidence (schema complete, unexercised)
+Several objects are wired but empty on LS24 because the plugin wasn't run or the
+channel wasn't captured: run **windows.piiat.network** (socket `listen`),
+**windows.modules/ldrmodules** (module `base_address` + injection),
+**windows.threads** (thread stacks) over the memdump; capture **Sysmon EID
+6/7/8**, the **Security** channel, and the **audit subcategories**.
+
+## Honest no-source (document as permanent nulls — never fake)
+- authentication `response_time`; file/flow `content`; socket `local_path` (needs Linux auditd `SOCKADDR`), `remote_*`, `close`.
+- process `signer`/`signature_valid`/`target_address`; module `tid` + `unload`; thread `src_tid` + `suspend`/`terminate`; driver `unload` + `pid`; service `delete`/`pause`; email `message_body`/`message_links`/`message_type`/`action_reason` (STARTTLS / server-side verdict).
+
+## Recurring themes
+- **The quarantined audit family is the #1 lever** (file write/read, registry writes, flow/socket endpoint identity) — promote it once an audit-enabled capture exists.
+- **Cross-object hash + identity hydration** (`crosssource.py`) closes many single-source gaps — a hash/path join carries disk hashes onto module/driver and memory-only fields onto their log rows.
+- **Trust the maps, not the CAR sensor cards** — upstream `coverage_map`s overclaim; these tables are ground truth.

--- a/docs/car-provenance/README.md
+++ b/docs/car-provenance/README.md
@@ -1,0 +1,33 @@
+# CAR property-provenance catalogue
+
+A "find once, done" reference: for every MITRE CAR object, every canonical field,
+and **every artefact/source in the DFIR pipeline that can supply it** — grounded
+in the actual engine maps (not the upstream CAR sensor cards, which overclaim),
+in PIIAT-Mem's memory maps, and in real processed evidence.
+
+One file per object (all 13). Each has a per-field table
+(`field | sources (source → native field) | action(s) | currently mapped? | confidence & caveats`)
+plus a source×field coverage matrix.
+
+| object | fields | active producers | headline |
+|---|---:|---:|---|
+| [process](process.md) | 29 | 13 (+1 inert) | `env_vars`/`uid`/`cwd` memory-only; `sid` from 4688/memory not Sysmon1; 67/102 analytics use it |
+| [file](file.md) | 26 | 18 | best-covered; `timestomp`/`previous_creation_time` from $SI/$FN unused; 4663/5140 write path quarantined |
+| [flow](flow.md) | 27 | 5 | endpoint identity (`exe`/`user`/`pid`) only from Sysmon 3 / memory / WFP 5156, never from pcap |
+| [user_session](user_session.md) | 10 | 7 | `login_id` LUID is the cross-artefact join; `lock`/`login_successful=false` unsourced |
+| [registry](registry.md) | 11 | 5 (+1 inert) | live writer (`pid`/`user`/`image_path`) only from Sysmon/4657; dead hives are honest nulls |
+| [authentication](authentication.md) | 19 | 1 | ONE mapper (4624/4625/4672); Kerberos 4768/4769 + NTLM 4776 unwired (biggest gap) |
+| [module](module.md) | 13 | 3 | `base_address` memory-only; injection (ldrmodules) + hash-hydration unused |
+| [thread](thread.md) | 15 | 2 | stacks memory-only (TEB); `remote_create` Sysmon8; `src_tid`/`suspend`/`terminate` no-source |
+| [service](service.md) | 10 | 3 | registry `Services` key → whole object from a dead disk is the big gap; `pid` svcscan-only |
+| [driver](driver.md) | 11 | 2 | `base_address` memory-only, hashes Sysmon6-only; `unload`/`pid` structural no-source |
+| [socket](socket.md) | 10 | 1 | memory netscan → `listen` only; WFP 5158 (`bind`) inert; `remote_*`/`close` by-design no-source |
+| [http](http.md) | 17 | 6 | zeek_http spine; UA→name/version/device unparsed; no analytic consumes http |
+| [email](email.md) | 21 | 1 | zeek_smtp only, STARTTLS → empty in practice; needs a mail-store/server-log parser |
+
+## How to read it
+- **"currently mapped?"** is the gap column — a `NO` where a genuine source exists is a completeness gap (see [COMPLETENESS-BACKLOG.md](COMPLETENESS-BACKLOG.md)); a `NO` with no source is an **honest null** (documented, never faked).
+- Grounded in `piiat_mitrecar/mappings/` + `sources/*.yaml` (engine), `piiat-mem/piiat_mem/mappings.py` (memory), `to-be-validated/evtx_audit.yml` (the quarantined audit family), and `car_data_model.json`.
+- **Do not trust the upstream `*.yaml` `coverage_map`s** — the agents found driver/thread/flow sensor cards overclaim (`pid`, `src_tid`, `uid` listed but not on the wire). The per-field tables here are ground truth.
+
+Generated 2026-09-07 by a per-object deep audit; §1 of `docs/CAR-Extraction-Rules.md` (extract every field the artefact can supply) is the governing principle.

--- a/docs/car-provenance/authentication.md
+++ b/docs/car-provenance/authentication.md
@@ -1,0 +1,236 @@
+# Property-Provenance Catalogue — MITRE CAR `authentication`
+
+**Object:** `authentication` — "An authentication event occurs whenever a user or process attempts to access a privileged system resource. Examples include logging into a system, or elevating privilege."
+**Actions:** `success` · `failure` · `error`
+**Canonical fields (19):** ad_domain, app_name, auth_service, auth_target, decision_reason, fqdn, hostname, method, response_time, target_ad_domain, target_uid, target_user, target_user_role, target_user_type, uid, user, user_agent, user_role, user_type
+
+**Ground truth read:**
+- Semantics: `third_party/piiat-mitrecar/third_party/car/data_model/authentication.yaml`, `.../docs/data_model/authentication.md`, root `car_data_model.json` (13 objects; authentication actions = error/failure/success — confirmed).
+- Engine maps: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/core.py` (the ONLY authentication mapper), generated source spec `third_party/piiat-mitrecar/sources/evtx_security.yaml`.
+- Design law: `third_party/piiat-mitrecar/docs/CAR-Relations.md` (authentication ← 4624/4625; identity/joins/inheritance/limits).
+- Real evidence inspected: `data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json` (85 records — **Sysmon EID 1/45 & 5/40 only, NO Security channel**), `data_store/processed/zeek/*/ssh.json` (real SSH auth, `auth_success` present), zeek dirs (conn/dns/files/http/notice/ssh/ssl/weird/x509 — **no kerberos/ntlm/radius/smtp**), `data_store/processed/linux_logs/` (empty).
+
+---
+
+## 1. What the pipeline maps TODAY (the whole of it)
+
+**One mapper, one artefact key, three EventIds.** `core.py` → source `evtx_security` (EvtxECmd, Windows Security channel):
+
+| EventId | Action | Fields populated (per `evtx_security.yaml` field_provenance) |
+|---|---|---|
+| **4624** (success logon) | `success` | ad_domain, app_name, auth_service, auth_target, hostname, method, target_ad_domain, target_uid, target_user, uid, user (+ user_role via 4672 merge) |
+| **4625** (failed logon) | `failure` | as above **+ decision_reason** (SubStatus\|Status\|FailureReason, coalesced); no user_role |
+| **4672** (special privileges) | `success` | companion entry → **user_role = `administrator`** (const/asserted), user, uid, ad_domain, auth_target only |
+
+**Native (kept for joins, never canonical):** TargetLogonId, SubjectLogonId, LogonType, IpAddress (+ PrivilegeList on 4672). LUID (`TargetLogonId`/`SubjectLogonId`) is the designed join to `user_session`; `ProcessId` (hex) is the heuristic join to `process`.
+
+**Deliberately NOT mapped (documented):** 4648 (explicit-cred logon at issuance — no service response, asserting success/failure would fake an outcome — `core.py:184`, `CAR-Relations.md:44`).
+
+**Nothing else in the repo produces `authentication`:** the only two sources whose YAML mentions the word are `evtx_security.yaml` (the mapper) and `l2t_text.yaml` (only in a native-keys note — it maps SSH syslog to **user_session/login**, not authentication). PIIAT-Mem emits 10 objects (driver/file/flow/module/process/registry/service/socket/thread/user_session) — **not authentication** (its token `AuthenticationId` LUID feeds `user_session.login_id`). Sysmon has no authentication object. Zeek mappers emit email/file/flow only. **No analytic references `authentication/*` in structured `data_model_references`** (0 of 91) — it is consumed only in prose.
+
+---
+
+## 2. Field-by-field provenance
+
+Legend — **Mapped?**: `YES` (+ where) / `NO`. Native field shown as `Source → NativeField`. "Origin" = host the request was made *from*; "target/dest" = machine authenticated *to*.
+
+### ad_domain — AD domain the request was generated from (subject side)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx Security **4624/4625** → `SubjectDomainName` | success, failure | **YES** — `core.py:_auth_props` `ad_domain` | HIGH. Often the *machine/SYSTEM* context on network logons, not a person. |
+| evtx **4672** → `SubjectDomainName` | success | **YES** (companion) | HIGH |
+| evtx Kerberos **4768/4769** → `TargetDomainName` is target-side; subject realm implicit | success, failure | **NO** | MED — 4768/4769 not mapped |
+| zeek **ntlm.log** → `domainname` | success, failure | **NO** | MED — no ntlm mapper/evidence |
+| zeek **kerberos.log** → realm (in `client`/`service`) | success, failure | **NO** | LOW-MED |
+
+### app_name — application that made the request
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `ProcessName` (basename) | success, failure | **YES** — `app_name` `[derived]` | HIGH. Calling process image, e.g. `winlogon.exe`, `svchost.exe`. |
+| evtx **4648** → `ProcessName` | (issuance) | **NO** | MED — 4648 unmapped |
+| syslog auth/secure (Plaso `syslog`) → program (`sshd`/`sudo`/`su`/`login`) | success, failure | **NO** | HIGH-value, unmapped — maps to user_session today |
+| zeek **ssh.log** → `client` (e.g. `SSH-2.0-OpenSSH_for_Windows_8.1`) | success, failure | **NO** | MED — client banner, not strictly app_name |
+| zeek **kerberos.log** → `service` (SPN class) | success | **NO** | LOW |
+| model example `ssh, win:local` | — | — | The canonical example values. |
+
+### auth_service — service used to accomplish authentication
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `LogonProcessName` | success, failure | **YES** — `auth_service` `[direct]` | HIGH. e.g. `NtLmSsp`, `Kerberos`, `User32`, `Negotiate`, `Advapi`. |
+| evtx **4776** → `PackageName` (DC NTLM validation) | success, failure | **NO** | MED — 4776 unmapped |
+| Cloud IdP (Okta / AzureAD / ADFS) sign-in logs | success, failure | **NO** | Model examples are `Okta, ActiveDirectory` — out of scope for this host/network pipeline. |
+
+### auth_target — machine for which authentication was requested (destination)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `Computer` | success, failure | **YES** — `auth_target: "Computer"` `[direct]` | HIGH. The host authenticated TO (opposite direction from `hostname`). |
+| evtx **4672** → `Computer` | success | **YES** (companion) | HIGH |
+| evtx **4648** → `TargetServerName` / `TargetInfo` | (issuance) | **NO** | HIGH-value, unmapped — 4648 explicitly names the target server. |
+| evtx **4769** → `ServiceName`/`ServiceSid` (SPN) | success, failure | **NO** | MED |
+| zeek **ntlm.log** → `server_nb_computer_name` / `server_dns_computer_name` | success, failure | **NO** | MED |
+| zeek **kerberos.log** → `service` | success | **NO** | MED |
+| zeek **radius.log** → `remote_ip` / NAS | success, failure | **NO** | LOW-MED |
+| zeek **ssh.log** → `id.resp_h` | success, failure | **NO** | MED — dest IP, real evidence on hand |
+
+### decision_reason — justification for approve/deny (**failure/error only**)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4625** → `SubStatus` \| `Status` \| `FailureReason` (coalesced) | failure | **YES** — `core.py:153` | HIGH. NTSTATUS carries the real why (`0xC000006A` bad pw, `0xC0000064` no user, `0xC0000234` locked); `FailureReason` is an unresolved `%%` token. |
+| evtx **4776** → `Status` (NTLM validation code) | failure | **NO** | MED |
+| evtx Kerberos **4768/4769/4771** → `Status` (Kerberos result, `0x18` bad pw, `0x12` disabled) | failure | **NO** | MED-HIGH — richest DC-side failure reason, unmapped |
+| zeek **kerberos.log** → `error_msg` | failure, error | **NO** | MED |
+| zeek **ntlm.log** → `status` | failure | **NO** | MED |
+| syslog auth → `Failed password` / `invalid user` / PAM `authentication failure` | failure | **NO** | HIGH-value, unmapped |
+| IIS W3C → `sc-status` / `sc-substatus` (401.x) | failure | **NO** | LOW-MED |
+
+### fqdn — FQDN of the origin host
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| Host-identity enrichment / DNS resolution of origin `IpAddress` | success, failure | **NO** | CAR-Relations: `fqdn ← host identity` by **inheritance**, not from the auth record. |
+| evtx 4624/4625 | — | **NO** | **No native source** — `WorkstationName` is NetBIOS, `Computer` is the *destination*. |
+
+**Near no-source in-record.** Only obtainable by enriching the origin IP against DNS/host identity; the event itself has no origin FQDN.
+
+### hostname — origin host the request was made from
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `WorkstationName` | success, failure | **YES** — `hostname` `[direct]` | HIGH but **client-reported/forgeable — recorded not trusted**; no fallback to `Computer` (that is the destination). |
+| utmp/wtmp/btmp (Plaso `utmp`) → `ut_host` / `hostname` (origin) | success, failure | **NO** | MED — kept native in l2t_utmp (user_session), not surfaced to auth |
+| syslog auth → `rhost` / `from <IP>` (origin, usually IP) | success, failure | **NO** | MED — IP not hostname |
+| zeek ssh/ntlm/kerberos → `id.orig_h` (origin IP) | success, failure | **NO** | MED — IP, real ssh evidence on hand |
+| evtx **4776** → `Workstation` | success, failure | **NO** | MED |
+
+### method — authentication method used
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `AuthenticationPackageName` | success, failure | **YES** — `method` `[direct]` | HIGH. `NTLM`/`Kerberos`/`Negotiate`. **`Negotiate` = negotiated — never assert NTLM vs Kerberos** (CAR-Relations limit). |
+| evtx **4768/4769** → `TicketEncryptionType` (Kerberos enctype) | success, failure | **NO** | MED |
+| evtx **4776** → `PackageName` | success, failure | **NO** | MED |
+| syslog auth → `password` / `publickey` / `keyboard-interactive` (sshd) | success, failure | **NO** | HIGH-value — real SSH method, currently kept as native `authentication_method` in `l2t_text`/`plaso_linux.py` (user_session), **not** surfaced to `authentication.method`. |
+| zeek **kerberos.log** → `cipher` | success | **NO** | LOW-MED |
+| zeek **ssh.log** | — | **NO** | Default ssh.log does **not** record password-vs-pubkey (encrypted). |
+
+### response_time — duration until the auth response
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| — | — | **NO** | **NO SOURCE.** No host/network DFIR artefact records auth-response duration. (Zeek `conn.duration` is the *connection*, not the auth decision.) Model example `12ms` is cloud/API telemetry. Honest null everywhere. |
+
+### target_ad_domain — AD domain within which authentication was requested (target side)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `TargetDomainName` | success, failure | **YES** — `target_ad_domain` `[direct]` | HIGH |
+| evtx Kerberos **4768/4769/4771** → `TargetDomainName` (realm) | success, failure | **NO** | MED |
+| zeek **ntlm.log** → `domainname`; **kerberos.log** → realm | success, failure | **NO** | MED |
+
+### target_uid — SID of the user being authenticated
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `TargetUserSid` | success, failure | **YES** — `target_uid` `[direct]` | HIGH |
+| evtx **4768/4771** → `TargetSid` | success, failure | **NO** | MED |
+| Memory (Volatility `sessions`/token owner SID); getsids | (inferred) | **NO** | LOW — memory feeds user_session, not auth |
+
+### target_user — name of the user being authenticated (the actual principal)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `TargetUserName` | success, failure | **YES** — `target_user` `[direct]` | HIGH. (MITRE's "priv-esc only" clause is its own copy-paste error — Windows fills it every logon — noted in `core.py:74`.) |
+| evtx **4648** → `TargetUserName` | (issuance) | **NO** | HIGH-value, unmapped |
+| evtx **4768/4769/4771** → `TargetUserName`; **4776** → `TargetUserName` | success, failure | **NO** | HIGH-value — the DC-side authenticated account |
+| zeek **ntlm.log** → `username` | success, failure | **NO** | MED |
+| zeek **kerberos.log** → `client` | success | **NO** | MED |
+| zeek **radius.log** → `username` | success, failure | **NO** | LOW-MED |
+| syslog auth → `Accepted/Failed password for <USER>`; su/sudo target `USER=` | success, failure | **NO** | HIGH-value, unmapped |
+| zeek **ssh.log** | — | **NO** | No username (encrypted) in default ssh.log. |
+
+### target_user_role — IPAM access-control role of the target user (priv-esc only)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| IPAM (Infoblox) directory | — | **NO** | **Effectively no source** in a host/network pipeline — the field is IPAM-specific by definition. |
+| evtx 4672 gives role for the *subject*, not target | — | **NO** | Cannot fill target side. |
+
+### target_user_type — type of the target user (priv-esc only)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| Derivable from well-known SID RID (500=Administrator, 501=Guest) on `TargetUserSid` | success, failure | **NO** | LOW — derivation, not recorded; not currently done. |
+| Memory getsids / SAM group membership of target | (inferred) | **NO** | LOW |
+| — | — | **NO direct source.** | The type is not a recorded field on any auth artefact. |
+
+### uid — SID of the process that initiated the request (subject/calling context)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `SubjectUserSid` | success, failure | **YES** — `uid` `[direct]` | HIGH. Often `S-1-5-18` (SYSTEM) on network logons. |
+| evtx **4672** → `SubjectUserSid` | success | **YES** (companion) | HIGH |
+| evtx **4648** → `SubjectUserSid` | (issuance) | **NO** | MED |
+| Memory (`_TOKEN` owner SID) | (inferred) | **NO** | LOW — feeds user_session |
+
+### user — name of the user that initiated the request (subject)
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4624/4625** → `SubjectUserName` | success, failure | **YES** — `user` `[direct]` | HIGH but "the calling context, **never** the person who typed the password" (CAR-Relations limit); often a machine account. |
+| evtx **4672** → `SubjectUserName` | success | **YES** (companion) | HIGH |
+| evtx **4648** → `SubjectUserName` | (issuance) | **NO** | MED |
+| syslog `sudo`/`su` invoking user | success, failure | **NO** | MED |
+| Memory session owner | (inferred) | **NO** | LOW |
+
+### user_agent — user agent through which the request was made
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| zeek **http.log** → `user_agent` (HTTP Basic/NTLM-over-HTTP auth) | success, failure | **NO** | MED — mapped to `http.user_agent_full` (http object), not authentication. |
+| IIS W3C → `cs(User-Agent)` | success, failure | **NO** | LOW-MED |
+| Cloud IdP sign-in logs (`aws-cli/2.0.0 …` — the model example) | success, failure | **NO** | Out of scope for host/network artefacts. |
+| evtx Security channel | — | **NO** | **No source** — Windows logon events carry no user agent. |
+
+### user_role — IPAM access-control role of the initiating user
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| evtx **4672** → `PrivilegeList` present ⇒ `administrator` | success | **YES** — `core.py:176` `const("administrator")`, `[asserted]` | MED — a coarse assertion (admin-equivalent privileges granted), not a true IPAM role. Only on success. |
+| Memory getsids (Administrators group membership) | (inferred) | **NO** | LOW |
+| IPAM (Infoblox) directory | — | **NO** | The literal definition source; not in pipeline. |
+
+### user_type — type of user that initiated the request
+| sources (source → native field) | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|
+| Derivable from `SubjectUserSid` RID / `ElevatedToken` / integrity | success, failure | **NO** | LOW — derivation (500/501, elevated vs standard), not recorded; not done today. |
+| Memory getsids / SAM | (inferred) | **NO** | LOW |
+| — | — | **NO direct source.** | Model example `Administrator, Standard, Guest`. |
+
+---
+
+## 3. Action coverage (which sources prove each action)
+
+| action | mapped sources | additional (unmapped) sources |
+|---|---|---|
+| **success** | evtx 4624, 4672 (`core.py`) | evtx 4768/4769/4776(0x0); zeek ssh `auth_success:true` (real evidence), kerberos `success:T`, ntlm `success:T`, radius `result:success`; syslog `Accepted`; utmp/wtmp login; IIS 200/302 |
+| **failure** | evtx 4625 (`core.py`) | evtx 4771, 4768/4769 fail, 4776 (0xC000006A/0xC0000064…); zeek ssh `auth_success:false`, kerberos `success:F`, ntlm `success:F`, radius fail; syslog `Failed password`/`invalid user`/PAM; **btmp**; IIS 401 |
+| **error** | — (none) | evtx **4649** (replay attack detected); anomalous NTSTATUS/Kerberos KRB-ERR that are not clean auth failures; zeek kerberos `error_msg` | 
+
+`error` has **no clean mapped source**; thin everywhere (4649 is the closest genuine "unexpected error").
+
+---
+
+## 4. Summary
+
+**Coverage of the 19 fields:**
+- **≥1 genuine source (14):** ad_domain, app_name, auth_service, auth_target, decision_reason, hostname, method, target_ad_domain, target_uid, target_user, uid, user, user_agent, user_role.
+- **Derivable-only / effectively no direct source (4):** fqdn (host-identity inheritance / DNS enrichment only), target_user_type & user_type (SID-RID / group-membership derivation, not recorded), target_user_role (IPAM-only).
+- **Hard no-source (1):** **response_time** — no DFIR artefact records auth-response duration.
+
+**Currently mapped:** 12 of 19 fields, from a **single artefact** (evtx Security 4624/4625/4672). decision_reason (failure-only) and user_role (4672-only, asserted) included. Nothing else in the repo produces the object.
+
+### Unmapped gaps ranked by value (a source exists; the pipeline ignores it)
+
+1. **Kerberos DC events 4768 / 4769 / 4771** (EvtxECmd already parses them). The authoritative domain-wide auth record: target_user, target_ad_domain, method (enctype), decision_reason (Kerberos status), auth_target (SPN), hostname (IpAddress), success/failure. **Highest value** — currently zero Kerberos coverage.
+2. **NTLM DC event 4776** — target_user, hostname (Workstation), auth_service (PackageName), decision_reason (Status), success/failure. Fills the DC-side NTLM validation gap.
+3. **Linux syslog auth/secure (sshd/sudo/su/PAM)** via Plaso — real success/failure with user, target_user, method (password/publickey), decision_reason, app_name, origin. **The pipeline already parses these but routes them to `user_session/login` (`l2t_text`), discarding the authentication semantics** (`authentication_method` is dropped to native). High value, low incremental cost.
+4. **Zeek ssh.log** — real evidence is on hand (`auth_success`, `auth_attempts`, orig/resp, client/server) yet **ssh.json is not even ingested** (zeek routing = conn/files/http/smtp only). Yields the success/failure action + origin/target/app for network SSH auth (no username — encrypted).
+5. **Zeek kerberos.log / ntlm.log / radius.log** — target_user, ad_domain, auth_target, method, decision_reason, action. Not present in current evidence but standard Zeek outputs; no mappers exist.
+6. **evtx 4648** (explicit-cred / RunAs) — deliberately unmapped for the *action* (issuance, no outcome), but it uniquely names **auth_target (TargetServerName)** and the Subject→Target credential swap; its fields could be surfaced as native even while the action stays raw.
+7. **RDP operational logs** (TerminalServices-RemoteConnectionManager **1149** "User authentication succeeded"; LocalSessionManager 21/25) — carry User/Domain/Source-Network-Address; 1149 is a genuine network-auth success. Today EID 21 is mapped to `user_session` (`evtx_extra`), not authentication.
+8. **IIS / web-server W3C logs** (HTTP Basic/Windows auth) — user, user_agent (**the only realistic in-pipeline source for `user_agent`**), decision_reason (sc-status), hostname (c-ip). No mapper.
+9. **utmp/wtmp/btmp** — btmp especially is a pure *failure* record; wtmp/utmp logins carry user + origin. Today mapped to `user_session` only.
+
+### Honest non-gaps
+- **response_time**: unreachable from any host/network artefact — accept the null.
+- **user_role / target_user_role / target_user_type / user_type**: IPAM/type semantics are external-directory or derivation-only; only the coarse 4672 `administrator` assertion is defensible. Anything richer would be a near-miss.
+- **fqdn**: correctly treated as host-identity *inheritance*, not an auth-record field.
+- **Memory/Volatility** proves sessions *existed* (implying prior successful auth) and yields uid/user, but records no auth decision/method/target — rightly feeds `user_session`, not `authentication`.
+- **Sysmon** has no authentication object (confirmed against real evidence, which is Sysmon-only here) — not a gap, a non-source.

--- a/docs/car-provenance/driver.md
+++ b/docs/car-provenance/driver.md
@@ -1,0 +1,104 @@
+# MITRE CAR `driver` — Property-Provenance Catalogue
+
+**Object:** `driver` — "software that runs in the operating system kernel."
+**Canonical fields (11):** `base_address`, `fqdn`, `hostname`, `image_path`, `md5_hash`, `module_name`, `pid`, `sha1_hash`, `sha256_hash`, `signature_valid`, `signer`
+**Actions (2):** `load`, `unload`
+
+Grounding: `third_party/piiat-mitrecar/third_party/car/data_model/driver.yaml`, `car_data_model.json` (object index 5), CAR sensor `third_party/piiat-mitrecar/third_party/car/sensors/sysmon_13.yaml`.
+
+> **Authority note.** The bundled `driver.yaml` `coverage_map` is **stale** and is NOT the source of truth. It lists `sysmon_13 → {fqdn, image_path, pid, sha256, signature_valid, signer}` — but that map (a) omits `hostname`, `md5_hash`, `sha1_hash` which the shipped engine *does* extract, and (b) asserts `pid` which the engine correctly does **not** extract (Sysmon EID 6 carries no `ProcessId`). The authoritative "currently mapped" state is the executable engine map `third_party/piiat-mitrecar/piiat_mitrecar/mappings/sysmon.py` (`sysmon_driver_load` variant) and PIIAT-Mem `third_party/piiat-mem/piiat_mem/mappings.py` (`windows.modules`), reflected in generated source files `sources/evtx_sysmon.yaml` and `sources/memory.yaml`.
+
+---
+
+## Source universe (what can produce a `driver` row)
+
+| Src key | Artefact / tool | Event / plugin | Emits object | In pipeline? | File |
+|---|---|---|---|---|---|
+| **S1** | Sysmon (EvtxECmd, `Microsoft-Windows-Sysmon/Operational`) | **EID 6 DriverLoad** | `driver`/`load` | **YES (mapped)** | `mappings/sysmon.py:432` |
+| **S2** | Memory image, Volatility 3 (PIIAT-Mem) | **`windows.modules`** (PsActiveModuleList walk) | `driver`/`load` | **YES (mapped)** | `piiat-mem/piiat_mem/mappings.py:286`; plugin driver `python/get_sybers_dxdfir/volatility.py:58` |
+| S3 | Memory image, Volatility 3 | `windows.dumpfiles` / `moddump` + hasher | (would feed driver hashes) | **NO** (not in `DEFAULT_PLUGINS`) | — |
+| S4 | Windows Event Log | **System 7045** (SCM service install, kernel-mode driver) | currently `service`/`create` | mapped as **service, not driver** | `mappings/evtx_windows.py:180` (`_SVC_*`), `sources/evtx_services.yaml` |
+| S5 | Windows Event Log | **System 20003** (UserPnp driver-service registration, `DriverFileName`) | currently `service`/`create` | mapped as **service, not driver** | `mappings/evtx_more.py` (header §20003) |
+| S6 | Disk image, Plaso `pe` (PE/COFF) | `.sys` PE metadata | currently `file`/`create` | mapped as **file, not driver** | `mappings/plaso_exec.py:250`, `sources/plaso_pecoff.yaml` |
+| S7 | Disk image, Plaso `winreg` **Amcache** (`InventoryDriverBinary`/`AppFile`) | `.sys` amcache entry | currently `file`+`process` | mapped as **file, not driver** | `sources/plaso_exec_winreg.yaml` |
+| S8 | EZ Tools AmcacheParser / PECmd / MFTECmd, YARA over `.sys`, Windows CodeIntegrity/Kernel-PnP | driver `.sys` identity/hash/signature | — | **NO map exists** (evidence dirs empty) | — |
+
+`crosssource.py` treats `driver` as both a **hashed** (`_HASHED`) and **imaged** (`_IMAGED`) object (`mappings/crosssource.py:47-49`), so S1 and S2 driver rows converge across sources on content-hash or `.sys` basename — see §Cross-source.
+
+---
+
+## Per-field provenance
+
+Legend for "currently mapped?": **YES** = shipped engine writes this canonical column for a `driver` row; **NO** = no artefact in the pipeline writes it to the `driver` object (even where the raw datum exists elsewhere).
+
+| field | sources (source → native field) | action(s) | currently mapped? (yes+where / NO) | confidence & caveats |
+|---|---|---|---|---|
+| **base_address** | **S2** memory `windows.modules` → `Base` (kernel virtual load addr) | load | **YES** — `piiat-mem mappings.py:286` (`base_address:"Base"`); `driver.base_address` col in `car.db` | High. **Memory is the ONLY source.** Sysmon EID 6, 7045, PE, amcache carry no runtime load address (disk/log artefacts never observe where the kernel mapped it). S1 leaves it null. |
+| **fqdn** | **S1** Sysmon EID 6 → `Computer` (only if dotted) | load | **YES** — `sysmon.py` `_image_load_props()` via `_FQDN` | High. Inferred: claimed only when `Computer` contains a dot; a NetBIOS name is not faked into an FQDN. S2 (memory) does not stamp fqdn on the driver plugin row → null there. |
+| **hostname** | **S1** Sysmon EID 6 → `Computer` (first DNS label) | load | **YES** — `sysmon.py` via `_HOSTNAME` | High. (The stale `driver.yaml` coverage_map omits this — engine does map it.) S2 windows.modules yields no hostname on the row (kernel-global); memory host lives in `image_context`, not the driver row. |
+| **image_path** | **S1** Sysmon EID 6 → `ImageLoaded`; **S2** memory `windows.modules` → `Path` (FullDllName). *Potential (unmapped-as-driver): S4 7045 `ImagePath`, S5 20003 `DriverFileName`, S6 PE `display_name`, S7 amcache `full_path`.* | load | **YES** — S1 `sysmon.py:432`; S2 `mappings.py:286` | High. A driver loads into the kernel with no module_path, so `ImageLoaded`/`Path` **is** the driver's own file path (note in `sysmon.py:429`). Two independent mapped sources. |
+| **md5_hash** | **S1** Sysmon EID 6 → `Hashes` (`MD5=…`). *Potential: S3 memory dump+hash.* | load | **YES** — `sysmon.py` `_hashes()` (`regex1 MD5=`) | High for S1. **Only Sysmon** currently supplies it. Memory driver rows are hash-less (S2 does no hashing); S3 (dumpfiles+hash) is not wired. IMPHASH from the same blob has no CAR home → stays native. |
+| **module_name** | **S1** Sysmon EID 6 → `basename(ImageLoaded)`; **S2** memory `windows.modules` → `Name` (BaseDllName). *Potential: S4 `ServiceName`, S5 driver-service name.* | load | **YES** — S1 `sysmon.py:432`; S2 `mappings.py:286` | High. Two mapped sources. |
+| **pid** | **none** | load / unload | **NO — honest no-source** | High confidence there is NO source. Sysmon EID 6 (DriverLoad) has no `ProcessId` field — the kernel loads the driver, not a user process (`sysmon.py:429-431`). Memory `windows.modules` is kernel-global (`owning_pid: None`, `mappings.py:286`). The field exists in the model but **no host/memory artefact populates it for `driver`**. The `driver.yaml` coverage_map's `pid:[sysmon_13]` claim is **wrong/stale**. |
+| **sha1_hash** | **S1** Sysmon EID 6 → `Hashes` (`SHA1=…`). *Potential: S7 amcache `sha1` (as file), S3 memory dump+hash.* | load | **YES** — `sysmon.py` `_hashes()` | High for S1. **Only Sysmon** supplies it to the driver object. Amcache carries `.sys` SHA-1 but lands on the `file` object, never `driver` (S7). |
+| **sha256_hash** | **S1** Sysmon EID 6 → `Hashes` (`SHA256=…`). *Potential: S6 PE `sha256_hash` (as file), S3 memory dump+hash.* | load | **YES** — `sysmon.py` `_hashes()` | High for S1. **Only Sysmon** to the driver object. Plaso PE carries `.sys` SHA-256 but emits a `file` row (S6). |
+| **signature_valid** | **S1** Sysmon EID 6 → `SignatureStatus` (`Valid`→True only). *Potential: Windows CodeIntegrity (S8).* | load | **YES** — `sysmon.py:159` `_SIGNATURE_VALID = map_value(SignatureStatus,{Valid:True})` | High. Asserts True **only** on `Valid`; every other status (Unavailable/Errors/…) is a problem-signal kept native, never faked to False. Memory/PE/amcache do not verify signatures → null there. |
+| **signer** | **S1** Sysmon EID 6 → `Signature`. *Potential: CodeIntegrity/authenticode (S8).* | load | **YES** — `sysmon.py` `_image_load_props()` (`signer: Signature`) | High. `Signature` = who signed; the verdict is `signature_valid`. Only Sysmon supplies it. |
+
+---
+
+## Per-action coverage
+
+### `load`
+Two **complementary** mapped sources whose field coverage barely overlaps:
+
+- **S1 Sysmon EID 6** → identity + integrity: `module_name, image_path, md5/sha1/sha256, signer, signature_valid, hostname, fqdn`. **No `base_address`, no `pid`.**
+- **S2 Memory `windows.modules`** → runtime identity: `base_address, image_path, module_name`. **No hashes, no signer, no signature_valid, no pid, no host.**
+
+**Union of mapped sources covers 10 of 11 fields** — everything except `pid` (which has no source at all). `base_address` comes *only* from memory; hashes + signature come *only* from Sysmon. Neither source alone is complete; together (via cross-source join, below) they reconcile.
+
+### `unload`
+**ZERO coverage — no source anywhere.** The `driver.yaml` coverage_map's `unload` row is empty, and no artefact in the repo emits a driver-unload event:
+- Sysmon has **no** DriverUnload event (EID 6 is load-only).
+- Memory `windows.modules` is a **load-state snapshot** (a module present in `PsLoadedModuleList`), not an unload observation; ts is `None`/store-only.
+This is an **honest structural no-source**, not merely an unmapped one.
+
+---
+
+## Cross-source convergence (wired, report-layer)
+
+`third_party/piiat-mitrecar/piiat_mitrecar/crosssource.py` converges per-source `car.db` stores. Because `driver ∈ _HASHED` (line 47) and `driver ∈ _IMAGED` (line 49), a Sysmon EID 6 driver row and a memory `windows.modules` driver row for the **same `.sys`** converge:
+- at **DEFINITIVE_CONTENT** tier if a shared content hash exists (only if the memory row were hashed — currently it is not), or
+- at **HEURISTIC_IMAGE** tier on the `image_path` **basename** (this is the realistic join today).
+
+`_merge_properties()` (line 138) **unions** the group's canonical columns, recording each property's source. So the converged view of a driver carries `base_address` (from memory) **and** `md5/sha1/sha256/signer/signature_valid` (from Sysmon) together — the two partial sources reconcile into near-complete coverage. Caveat: this is a **convergence report** (`crosssource.jsonl`), not a write-back into the per-source `driver` rows; consumers must read the merged view.
+
+---
+
+## Evidence-store reality check (`data_store/processed`)
+
+The current light test set (LS24) exercises **no** driver evidence:
+- `windows_logs/unspecified_host/log_EvtxECmd_Output.json`: **0** Sysmon EID 6 records, **0** System 7045.
+- `volatility/memdump.mem/plugins/`: only `banners, mftscan, piiat.processes, piiat.registry, piiat.sessions, pslist` ran — **`windows.modules` did not run / produced nothing**, so `car.db` `driver` table = **0 rows** (the table + full 11-column schema exist and are correct).
+
+So the maps are in place and correct, but there is **no grounded driver output in the processed store** to validate against yet. A memory image with kernel modules, or a Sysmon-6-bearing evtx, is needed to exercise the driver lane end-to-end.
+
+---
+
+## Summary
+
+**Coverage of `driver`:**
+- **load:** strong. 10/11 fields covered across two mapped sources (Sysmon EID 6 + memory `windows.modules`); `base_address` memory-only, hashes/signature Sysmon-only, and they reconcile via cross-source image-path join.
+- **unload:** 0/11 — no source exists anywhere (structural, not a mere gap).
+- **`pid`:** 0 sources on either action — a model field nothing populates for drivers (kernel loads them).
+
+**Unmapped gaps, ranked by value:**
+
+1. **Hash/signature enrichment of memory driver rows (MEDIUM).** `windows.modules` gives `base_address`+path+name but **no hashes/signer/signature_valid**. Fixable by (a) wiring S3 `windows.dumpfiles`/`moddump` + hashing of dumped `.sys`, or (b) relying on the existing cross-source image-path join to inherit Sysmon/PE/amcache hashes. Enables allow/deny-listing on memory-only evidence.
+2. **Disk `.sys` hashes never reach the driver object (MEDIUM).** Plaso PE (`sha256`, S6), amcache (`sha1`, S7) parse driver `.sys` files but emit `file`/`process` rows — the `driver` object never sees them. A `driver↔file` cross-source join on `image_path` (basename) would let a driver inherit disk-derived hashes + compile_time. Not wired for the driver object today.
+3. **`base_address` absent on Sysmon driver rows (LOW-MEDIUM).** Only memory observes the load address; a memory↔Sysmon join on `image_path`+host (already available via `crosssource.py`) is the remedy — no new source needed, just consume the merged view.
+4. **Kernel-mode-service installs modelled as `service`, not `driver` (LOW / debatable).** System 7045 (with kernel `ServiceType`) and 20003 (`DriverFileName`) are genuine driver-registration events carrying `module_name`+`image_path`, but land on `service`. Dual-emit or driver-link is possible; the `service` modelling is defensible, so this is a note, not a hard gap. No hashes/base_address available from these anyway.
+5. **`driver/unload` (NONE feasible).** No telemetry source exists in scope (Sysmon has no unload event; memory is a load snapshot). Honest no-source — not actionable without a new sensor.
+6. **`pid` on driver (NONE feasible).** No artefact carries it; kernel-loaded drivers have no initiating user process. Honest no-source.
+
+**Bottom line:** the driver `load` lane is well-built and honest — Sysmon and memory each supply exactly what their vantage point can prove, `base_address`/hashes/signature never faked onto the wrong source, and cross-source convergence reconciles the two. The real opportunities are enrichment joins (memory driver ← disk/Sysmon hashes), not new primary sources. `unload` and `pid` are genuine structural dead-ends.

--- a/docs/car-provenance/email.md
+++ b/docs/car-provenance/email.md
@@ -1,0 +1,92 @@
+# CAR `email` — Property-Provenance Catalogue
+
+Authoritative "find once, done" map of every canonical `email` field to every artefact/source that can supply it, what the DX_DFIR engine maps **today**, and what an unmapped field **would** need. Grounded in-repo; honest about the gaps.
+
+- **Object semantics:** `third_party/piiat-mitrecar/third_party/car/data_model/email.yaml`, `.../docs/data_model/email.md`, `python model/car/objects/email.yml`, `python model/projection/objects/email.yml` (ECS projection).
+- **Engine mapping (the only email mapper):** `third_party/piiat-mitrecar/piiat_mitrecar/mappings/zeek_extra.py` (map `zeek_smtp`), contract `third_party/piiat-mitrecar/sources/zeek_smtp.yaml`, helpers `piiat_mitrecar/normalize.py`.
+- **Design record / caveats:** `docs/CAR-Relations.md` § "email (no artefact yet — principles recorded for the first mapper)".
+- **Evidence checked:** `data_store/processed/zeek/*` (DFIRdump, ME_FOR_1308, keylogging).
+
+## Object at a glance
+
+- **21 fields** · **5 actions**: `deliver`, `block`, `redirect`, `quarantine`, `delete`.
+- Email events are defined **at the mail-server level**. Identity key (per CAR-Relations): `(source_host, smtp_uid, action, time)`.
+
+## Headline finding
+
+**`email` has NO live source in the store today.** Exactly one mapper exists — `zeek_smtp` — and it emits **only `deliver`** and **only when the SMTP row carries real content** (predicate `zeek_is_smtp_message`: any of `mailfrom`/`rcptto`/`from`/`to`/`subject`). No `smtp.json` exists in any processed capture; the DFIRdump capture carries only dns/ssh/ssl/http (0 SMTP-port connections), and per CAR-Relations "the one real smtp capture on hand is STARTTLS-encrypted — an empty `car_email` table is the honest output." So even the 11 fields the mapper *can* fill produce **zero rows** on current evidence.
+
+- **11 fields have a live mapper** (all via `zeek_smtp`, all tier `direct`/`coalesced`/`derived`): `date, dest_address, dest_ip, dest_port, from, src_address, src_domain, src_ip, src_port, subject, to`.
+- **10 fields are unmapped**: `action_reason, attachment_mime_type, attachment_name, attachment_size, message_body, message_links, message_type, return_address, server_relay, smtp_uid`.
+- **4 of 5 actions are unmapped**: `block, redirect, quarantine, delete` have **no source wired at all** (they are mail-**server** security/audit verdicts, not wire-observable). Only `deliver` has a mapper.
+- **No mail-store / mail-server parser is wired anywhere** (grep for pff/PST/OST/mbox/EML/maillog/Exchange/Postfix across `piiat_mitrecar/` returns nothing). Plaso adapters exist (`l2t_*`, `plaso_*`) but none map to `email`. No CAR sensor (sysmon/osquery/auditd/…) and no CAR analytic (`grep email/`) covers `email` upstream either. Suricata appears only as a signature/alert engine (`python/get_sybers_dxdfir/detect/rules/sig-suricata-alert.yml`), **not** as a CAR extraction source.
+
+**Provenance tiers** (engine vocabulary): `[direct]` = verbatim native field · `[coalesced]` = first non-empty of several (`normalize.first`) · `[derived]` = computed (`domain_of`, `ext`, `epoch_ts`) · `[native/raw]` = retained in the `native` blob but **not** promoted to a canonical column · `[none]` = no source produces it.
+
+## Source universe (shorthand used in the table)
+
+| Source | What it is | In-repo status |
+|---|---|---|
+| **Zeek smtp.log** | Wire-observed SMTP transaction (headers + envelope, **no body**). Native fields: `ts, uid, trans_depth, helo, mailfrom, rcptto, from, to, cc, reply_to, msg_id, in_reply_to, date, subject, first_received, second_received, last_reply, path, user_agent, tls, fuids, x_originating_ip, is_webmail, id.orig_h/p, id.resp_h/p`. | **Mapped** (`zeek_smtp`, content-bearing rows → `deliver`; STARTTLS/contentless → raw). No live evidence. |
+| **Zeek files.log** | File objects Zeek reconstructs from traffic; joined to the SMTP txn by `fuids`. Native: `filename, mime_type, seen_bytes, total_bytes, md5, sha1, sha256, source(=SMTP)`. | **Mapped to the `file` object** (`zeek_files`), **not** into `email.attachment_*`. |
+| **Zeek conn.log** | 5-tuple / flow for the SMTP `uid`. | Mapped to `flow`; contributes src/dest ip/port to the smtp row via the shared `uid`. |
+| **Exchange message-tracking** | `MessageTrackingLog` (EVENTID DELIVER/RECEIVE/FAIL/…, `InternalMessageId`, sender/recipient, subject). | Not wired. Would need a maillog/CSV parser. |
+| **O365 / Defender for O365** | Unified Audit + `EmailEvents` / message-trace / `EmailAttachmentInfo` / `EmailUrlInfo` / `UrlClickEvents`. | Not wired. |
+| **Google Workspace Gmail audit / BigQuery email logs** | Server-side delivery + security verdicts. | Not wired. |
+| **Postfix / Sendmail / Exim maillog** | syslog lines (queue-id, `from=`/`to=`, `status=`, reject reason) → Plaso syslog parser. | Not wired. |
+| **Plaso mail-store parsers** | PST/OST (`pff`), `mbox`, single-message EML/MSG, browser webmail cache. Full RFC5322 headers **and body**. | Not wired (no email mapper for any Plaso data_type). |
+| **Mail-client process memory** | Decrypted body/headers resident in RAM. | Not wired; limited/heuristic. |
+| **Suricata smtp events** | `eve.json` smtp (helo, mail_from, rcpt_to, from/to/subject). | Not wired as a CAR source. |
+
+---
+
+## Per-field provenance
+
+Format: `field | sources (source → native field) | action(s) | currently mapped? | confidence & caveats`.
+
+| # | field | sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|---|---|
+| 1 | **action_reason** | Exchange transport-rule/DLP verdict; O365/Defender `EmailEvents.ThreatTypes`/`DetectionMethods`; mail-gateway (Proofpoint/Mimecast) disposition; Postfix maillog reject text → *(native reason string)* | block, redirect, quarantine (delete) | **NO** | **[none] today.** Inherently a mail-**server** security decision — **never wire-observable**, so Zeek can never supply it. Meaningful only for the 4 unmapped actions. Needs a gateway/server security-log parser. |
+| 2 | **attachment_mime_type** | Zeek files.log → `mime_type` (libmagic, join by `fuids`); mail-store PST/OST/EML/MSG → attachment `Content-Type`; O365 `EmailAttachmentInfo.FileType` | deliver (Zeek); any (mail-store) | **NO** (Zeek `mime_type` lands on the `file` object, not `email.attachment_mime_type`) | Med. CAR calls this "declared, not actual"; Zeek's value is libmagic-**observed** (more trustworthy than the MIME header). Needs an email↔file bridge over `fuids`, or a mail-store parser. |
+| 3 | **attachment_name** | Zeek files.log → `filename` (join by `fuids`); PST/OST/EML/MSG → attachment filename; O365 `EmailAttachmentInfo.FileName` | deliver; any | **NO** (Zeek `filename` → `file` object only) | Med. Same fuids-bridge gap. Zeek only names files its analyzers extracted from the (cleartext) stream. |
+| 4 | **attachment_size** | Zeek files.log → `seen_bytes`/`total_bytes` (kept in the `file` map's `keep`, join by `fuids`); PST/OST/EML attachment size; O365 `EmailAttachmentInfo.FileSize` | deliver; any | **NO** | Med. CAR example "567 Kb" is loose text; ECS `email.attachments.file.size` wants bytes (projection notes coercion keeps unparseable text verbatim). |
+| 5 | **date** | **Zeek smtp.log → `date`** (RFC5322 Date header); PST/OST/EML/MSG Date header / `PR_CLIENT_SUBMIT_TIME`; mbox Date | deliver | **YES** — `zeek_smtp`: `date [direct]` (`zeek_extra.py`; `sources/zeek_smtp.yaml`) | High as a header value; **but it is the client's header, forgeable — never the event timestamp** (the store's own `timestamp` = `ts`). |
+| 6 | **dest_address** | **Zeek smtp.log → `rcptto` \| `to`** (envelope RCPT TO = real recipient); Exchange `RecipientAddress`; Postfix `to=`; O365 `RecipientEmailAddress`; PST/OST recipient table | deliver (all, at a server) | **YES** — `zeek_smtp`: `rcptto | to [coalesced]` | High. Envelope recipient is authoritative — this, not `to`, is the real delivery target. |
+| 7 | **dest_ip** | **Zeek smtp.log → `id.resp_h`** (receiving MTA); Zeek conn.log `id.resp_h`; derivable from `server_relay` Received chain | deliver | **YES** — `zeek_smtp`: `id.resp_h [direct]` | High within the capture vantage — the observed next-hop server IP. |
+| 8 | **dest_port** | **Zeek smtp.log → `id.resp_p`** (25/465/587); Zeek conn.log | deliver | **YES** — `zeek_smtp`: `id.resp_p [direct]` | High. |
+| 9 | **from** | **Zeek smtp.log → `from`** (header From display); PST/OST/EML From; message-tracking (sometimes) | deliver (all) | **YES** — `zeek_smtp`: `from [direct]` | **FORGEABLE** (MITRE says so verbatim). Display sender — **never attribute** identity from it. |
+| 10 | **message_body** | PST/OST (`pff`) message body; mbox; EML/MSG body; mail-client process memory; browser webmail cache. **Not** in Exchange/O365 audit. | any (mail-store) | **NO** | **[none] from network.** Zeek smtp.log carries no body, and real SMTP here is STARTTLS-encrypted. **Honest no-source under STARTTLS** — needs a mail-store artefact (or RAM). |
+| 11 | **message_links** | Derived from body → same mail-store/memory sources as `message_body`; O365 `EmailUrlInfo.Url` / `UrlClickEvents` as a dedicated source | any | **NO** | **[none] from network** (body encrypted/not logged). O365 URL telemetry is the cleanest dedicated feed; otherwise derive after a body exists. |
+| 12 | **message_type** | Body `Content-Type` (`text/html` vs `text/plain`) → PST/OST/EML/MSG, mbox | any | **NO** | **[none] from network.** Needs the body part's declared Content-Type. Projects to ECS `email.content_type`. |
+| 13 | **return_address** | **Zeek smtp.log → `reply_to`** (Reply-To) / envelope Return-Path (`mailfrom`); PST/OST/EML Reply-To / Return-Path header | deliver (all) | **NO** — **available in Zeek `reply_to` but the map does not extract it** (not in `props`, not in `keep`) | **Lowest-hanging gap.** Attacker-chosen; a mismatch vs `src_address` is *signal, not identity*. A one-line `props` add fills it wherever an SMTP artefact exists. |
+| 14 | **server_relay** | **Zeek smtp.log → `path` / `first_received` / `second_received`** (Received chain); PST/OST/EML full `Received:` header chain (most complete) | deliver | **NO** — `path` is retained `[native/raw]` in the map's `keep` but **not promoted** to the canonical column | Med. Trustworthy only from the observing server inward. Promotion of `path` fills it today; mail-store gives the whole chain. |
+| 15 | **smtp_uid** | Exchange `InternalMessageId`/`MessageId`; Postfix queue-id (maillog hex id); O365 `NetworkMessageId`. Zeek smtp.log → `msg_id` (RFC5322 Message-ID — a **semantic-mismatch proxy**) | deliver (shared across actions at one server) | **NO** — map builds the store GUID from `uid`+`trans_depth`; **does not populate `smtp_uid`** (and `msg_id` is not even kept) | CAR `smtp_uid` = server-**local** queue/transaction id (the identity discriminator), **≠ RFC Message-ID**. True value comes from server logs; Zeek `msg_id` is only the closest proxy. |
+| 16 | **src_address** | **Zeek smtp.log → `mailfrom` \| `from`** (envelope MAIL FROM = real sender); Exchange `SenderAddress`; Postfix `from=`; O365 `SenderMailFromAddress`; PST/OST Sender | deliver (all) | **YES** — `zeek_smtp`: `mailfrom | from [coalesced]` | High. Envelope sender authoritative (MAIL FROM spoofable at open relays — pairs with `src_ip`/`server_relay`). |
+| 17 | **src_domain** | Derived `domain_of(mailfrom \| from)`; any source supplying `src_address` supplies this | deliver (all) | **YES** — `zeek_smtp`: `domain_of(mailfrom | from) [derived]` | High (mechanical derivation; inherits `src_address`'s forgeability). |
+| 18 | **src_ip** | **Zeek smtp.log → `id.orig_h`** (connecting client/relay); Zeek conn.log; Zeek `x_originating_ip` (true client behind webmail); first `Received:` IP from `server_relay` | deliver | **YES** — `zeek_smtp`: `id.orig_h [direct]` | High at the capture vantage — but the connecting host may be a relay, not the true origin. `x_originating_ip` (unmapped) recovers the real client for webmail. |
+| 19 | **src_port** | **Zeek smtp.log → `id.orig_p`**; Zeek conn.log | deliver | **YES** — `zeek_smtp`: `id.orig_p [direct]` | High but ephemeral — low forensic value. |
+| 20 | **subject** | **Zeek smtp.log → `subject`**; PST/OST/EML Subject; Exchange `MessageSubject`; O365 `Subject` | deliver (all) | **YES** — `zeek_smtp`: `subject [direct]` | High (cleartext only; empty under STARTTLS). |
+| 21 | **to** | **Zeek smtp.log → `to`** (header To display); PST/OST/EML To header | deliver (all) | **YES** — `zeek_smtp`: `to [direct]` | Header To **≠ recipient list** (the envelope `dest_address` is the real recipient); CC/BCC not represented. |
+
+---
+
+## Coverage summary
+
+| | count | fields |
+|---|---|---|
+| **Mapped** (live mapper, `zeek_smtp` only) | 11 | date, dest_address, dest_ip, dest_port, from, src_address, src_domain, src_ip, src_port, subject, to |
+| **Unmapped** | 10 | action_reason, attachment_mime_type, attachment_name, attachment_size, message_body, message_links, message_type, return_address, server_relay, smtp_uid |
+
+- **Action coverage:** only `deliver` has a mapper. `block / redirect / quarantine / delete` (and their `action_reason`) have **no source wired** — they require mail-server/gateway security & audit logs, none of which are ingested.
+- **Live-data coverage: 0 rows.** No `smtp.json` in the store; the only real SMTP capture is STARTTLS-encrypted. The 11 "mapped" fields are contract-tested but unpopulated.
+
+## Unmapped gaps, ranked (what WOULD supply each)
+
+1. **`return_address`** — *lowest-hanging.* Zeek smtp.log **already carries `reply_to`**; a one-line `props: {return_address: "reply_to"}` in the `zeek_smtp` map fills it wherever an SMTP artefact exists. High signal (Reply-To/Return-Path mismatch = phishing tell).
+2. **`server_relay`** — Zeek `path` is **already captured raw** in the map's `keep`; promote `path`/`first_received`/`second_received` to the canonical column. Full `Received:` chain comes from a mail-store parser.
+3. **`smtp_uid`** — Zeek `msg_id` is available now as a proxy (flag the RFC-Message-ID ≠ queue-id caveat); the *true* server-local id needs an Exchange message-tracking / Postfix maillog / O365 parser. Identity-relevant (the CAR discriminator).
+4. **`attachment_name` / `attachment_mime_type` / `attachment_size`** — Zeek files.log **already extracts** name/mime/bytes onto the `file` object; needs an **email↔file bridge over `fuids`** to copy them into `email.attachment_*` (malware-triage critical). Mail-store parsers supply them directly.
+5. **`action_reason`** — needs a **mail-server/gateway security-log parser** (Exchange transport-rule/DLP, O365 Defender `EmailEvents`, Proofpoint/Mimecast, Postfix reject). No wire source can ever supply it; unlocks the `block/redirect/quarantine` actions too.
+6. **`message_body` / `message_links` / `message_type`** — **content fields, impossible from Zeek** (STARTTLS-encrypted; body never logged). Require a **mail-store parser** — Plaso PST/OST (`pff`), `mbox`, or EML/MSG — or, for links specifically, O365 `EmailUrlInfo`/`UrlClickEvents`. Mail-client process memory is a last-resort heuristic source.
+
+**Bottom line:** to make `email` produce *any* rows, the pipeline needs a real content-bearing artefact — a cleartext SMTP capture (feeds the existing `zeek_smtp` map) or, better for depth, a mail-store parser (PST/OST/mbox/EML) or mail-server log parser (Exchange/O365/Postfix). The latter class is the only path to the 4 unmapped actions and to the content/security fields (`action_reason`, `message_body`, `message_links`, `message_type`) that Zeek can never see.

--- a/docs/car-provenance/file.md
+++ b/docs/car-provenance/file.md
@@ -1,0 +1,319 @@
+# CAR `file` object — Property-Provenance Catalogue
+
+Authoritative "find once, done" map of **every canonical field → every artefact/source that can supply it**, grounded in the DX_DFIR engine as it stands today. READ-ONLY analysis.
+
+- **Object semantics:** `third_party/piiat-mitrecar/third_party/car/data_model/file.yaml`; `car_data_model.json` (canonical field list confirmed identical to the task).
+- **Canonical fields (26):** company, content, creation_time, extension, file_name, file_path, fqdn, gid, group, hostname, image_path, link_target, md5_hash, mime_type, mode, owner, owner_uid, pid, ppid, previous_creation_time, sha1_hash, sha256_hash, signature_valid, signer, uid, user.
+- **Actions (7):** acl_modify, create, delete, modify, read, timestomp, write.
+
+**Legend for "mapped?"** — `YES` (active map emits it) with file:line; `INERT` (spec exists but quarantined in `to-be-validated/evtx_audit.yml`, never runs); `NO` (nothing in the engine, source may or may not exist).
+
+---
+
+## 1. Source universe (every producer that emits — or provably could emit — a CAR `file`)
+
+### Active maps (currently emit `file` rows)
+
+| # | Source (map key) | Origin | Actions | Map location |
+|---|---|---|---|---|
+| S1 | **l2t_filestat** | disk image — filestat (`fs:stat`, POSIX/$SI stat) | create, delete, modify, read | `piiat_mitrecar/mappings/plaso_linux.py:351` (`_macb_entry`, `posix=True, hashes=True`) |
+| S2 | **l2t_mft** | disk image — NTFS `$MFT` (MFTECmd/plaso `mft`) | create, delete, modify, read | `plaso_linux.py:354` |
+| S3 | **l2t_usnjrnl** | disk image — NTFS `$UsnJrnl:$J` | create (0x100), delete (0x200), modify (default) | `plaso_linux.py:356` |
+| S4 | **l2t_lnk** | disk image — Windows `.lnk` target MAC times | create, modify, read | `piiat_mitrecar/mappings/plaso_artifacts.py:110` |
+| S5 | **l2t_recyclebin** | disk image — `$Recycle.Bin` / INFO2 | delete | `plaso_artifacts.py:120` |
+| S6 | **plaso_shellitem** | disk image — shell items in LNK + shellbags (`windows:shell_item:file_entry`) | create, modify, read | `piiat_mitrecar/mappings/plaso_shellitem.py:97` |
+| S7 | **plaso_pecoff** | disk image — PE binary (`pe_coff:file`) | create (ts=None, off-timeline) | `piiat_mitrecar/mappings/plaso_fs_extra.py:188` |
+| S8 | **plaso_olecf** | disk image — OLE document `olecf:summary_info` | create, modify | `plaso_fs_extra.py:197` |
+| S9 | **plaso_fseventsd** | disk image — macOS FSEvents journal | modify only | `plaso_fs_extra.py:163` |
+| S10 | **plaso_exec_winreg / amcache_link_time** | disk image — Amcache "Link Time" row | create (ts=None, off-timeline) | `piiat_mitrecar/mappings/plaso_exec.py:244` |
+| S11 | **jlecmd_dest** | disk image — jump-list DestList entry | read | `piiat_mitrecar/mappings/jlecmd.py:25` |
+| S12 | **evtx_sysmon EID 11** (FileCreate) | Sysmon Operational | create | `piiat_mitrecar/mappings/sysmon.py:346` |
+| S13 | **evtx_sysmon EID 23** (FileDelete) | Sysmon Operational | delete | `sysmon.py:369` |
+| S14 | **evtx_more 4907** (SACL change, ObjectType=File) | Security log | acl_modify | `piiat_mitrecar/mappings/evtx_more.py:98` |
+| S15 | **zeek_files** (files.log) | network pcap — Zeek file analyzer | create ("first seen on wire") | `piiat_mitrecar/mappings/zeek_extra.py:67` |
+| S16 | **windows.mftscan.MFTScan** | memory image — Volatility `$MFT` pages (PIIAT-Mem, finished-CAR passthrough) | create | `third_party/piiat-mem/piiat_mem/mappings.py:192` (+ merge `enrich.py:154`) |
+| S17 | **windows.piiat.files** | memory image — handle-enumerated files with owner | (action None — inventory) | `piiat-mem/piiat_mem/mappings.py:236` |
+| S18 | **windows.filescan** | memory image — `FILE_OBJECT` pool scan | (action None — inventory) | `piiat-mem/piiat_mem/mappings.py:300` |
+
+### Inert / to-be-validated (spec written, NOT wired into the pipeline)
+
+Quarantined in `third_party/piiat-mitrecar/to-be-validated/evtx_audit.yml` (pipeline note: `piiat_mitrecar/pipeline.py:45`). These are schema-grounded but no corpus has the audit subcategory enabled, so they never run.
+
+| # | Source | Actions | Spec |
+|---|---|---|---|
+| I1 | **Security 4663** object access (ObjectType=File) | read / write / delete (by `AccessMask`) | `evtx_audit.yml:33` |
+| I2 | **Security 4660** object deleted | delete (path via paired 4663 HandleId) | `evtx_audit.yml:56` |
+| I3 | **Security 4670** permissions changed | acl_modify | `evtx_audit.yml:72` |
+| I4 | **Security 5140** share access | read / write | `evtx_audit.yml:127` |
+| I5 | **Security 5145** detailed share access | read / write (+ per-file leaf) | `evtx_audit.yml:141` |
+| I6 | **Security 5058** key-file operation | read (present in lonewolf; action inferred) | `evtx_audit.yml:206` |
+
+### Groundable but entirely absent (no active map, no quarantined spec)
+
+| # | Source | Would supply | Native fields |
+|---|---|---|---|
+| N1 | **Sysmon EID 2** (FileCreateTime / timestomp) | **timestomp** action, `previous_creation_time`, `creation_time` | `PreviousCreationUtcTime`, `CreationUtcTime`, `TargetFilename`, `Image`, `User` |
+| N2 | **Sysmon EID 15** (FileCreateStreamHash) | ADS `content`, `md5/sha1/sha256_hash` on create | `Hash`, `Contents`, `TargetFilename` |
+| N3 | **Sysmon EID 26** (FileDeleteDetected) | delete (logged-not-archived) | same shape as EID 23 |
+| N4 | **Security 4656/4658** (handle request/close) | open→read/write correlation | `ObjectName`, `AccessMask`, `HandleId` |
+| N5 | disk **$MFT $SI vs $FN** split (plaso `mft` emits per-attribute rows w/ `attribute_name`) | **timestomp** via $SI/$FN birth mismatch, `previous_creation_time` | `attribute_name`, the FN vs SI Created stamps |
+| N6 | disk **$MFT security descriptor / $Secure** | NTFS `owner`/`owner_uid`/`uid` (owner SID), NTFS `mode` (ACL) | owner SID, group SID, DACL |
+| N7 | **Volatility windows.dumpfiles** | `content` / hashes of memory-resident file | dumped bytes (written to disk, not into CAR today) |
+| N8 | **Suricata fileinfo / eve.json** | `mime_type`, `md5/sha1/sha256`, `file_name` (network) | magic, stored hashes |
+| N9 | **PE VERSIONINFO + Authenticode** (no hasher/verify plugin exists in-repo) | `company`, `signer`, `signature_valid` | CompanyName, cert subject, WinVerifyTrust verdict |
+
+---
+
+## 2. Per-field provenance matrix
+
+Format: `field | sources (source → native field) | action(s) | mapped? | confidence & caveats`
+
+### company
+| | |
+|---|---|
+| **sources** | PE VERSIONINFO `CompanyName` (N9, not extracted by plaso `pe_coff`); Autoruns / Sysmon `Company` field (maps to **process/module**, never file) |
+| **actions** | create, modify (per MITRE coverage_map) |
+| **mapped?** | **NO** — no active or inert source. `plaso_pecoff` extracts imphash/pe_type/sections but *not* VERSIONINFO company (`plaso_fs_extra.py:109-111`). |
+| **confidence** | High-confidence no-source. Genuinely needs a richer PE VERSIONINFO parser or Autoruns. Honest null everywhere. |
+
+### content
+| | |
+|---|---|
+| **sources** | Sysmon EID 15 `Contents` (ADS only, N2); Volatility `windows.dumpfiles` (N7); Zeek/Suricata extracted-file bytes; disk carving |
+| **actions** | write, create |
+| **mapped?** | **NO** — nothing emits `content`. dumpfiles writes bytes to disk, never into a CAR column. |
+| **confidence** | High-confidence no-source. Inline file content rarely belongs in CAR; deliberately hard. Honest null. |
+
+### creation_time
+| | |
+|---|---|
+| **sources** | filestat → `Timestamp` (SI birth, create rows only) `plaso_linux.py:210`; mft → `Timestamp`; usnjrnl → `Timestamp` (0x100 create); lnk → `Timestamp`; shellitem → `Timestamp` `plaso_shellitem.py:69`; **Sysmon EID 11 → `CreationUtcTime`** (the file's OWN stamp, not event time) `sysmon.py:357`; mftscan-mem → `Created` (SI) `piiat-mem mappings.py:196` |
+| **actions** | create (asserted only on action=create — any other MACB row's time is provably not the birth time; see `plaso_linux.py:209`) |
+| **mapped?** | **YES** — broad. |
+| **confidence** | Strong. Caveat: Sysmon 11 correctly separates file-creation stamp from event ts (overwrite verdict in native); plaso asserts it only on the create variant. |
+
+### extension
+| | |
+|---|---|
+| **sources** | every file source, derived `ext(path)` |
+| **actions** | all |
+| **mapped?** | **YES** — universal (S1–S18, incl. zeek `ext(filename)`). |
+| **confidence** | Trivial derivation; only null when the path/name is null (e.g. 4660). |
+
+### file_name
+| | |
+|---|---|
+| **sources** | every file source, `basename(path)` (zeek/mftscan-mem straight from `filename`/`Filename`) |
+| **actions** | all |
+| **mapped?** | **YES** — universal. |
+| **confidence** | Strong. Only 4660 (I2) lacks it (no ObjectName in the record). |
+
+### file_path
+| | |
+|---|---|
+| **sources** | filestat (`filename`\|`display_name`); mft (`name`\|`filename`; note plaso can't index `path_hints[0]` — kept native); usnjrnl; lnk (`local_path`\|`network_path`\|`link_target`); recyclebin (`original_filename`); shellitem (`shell_item_path`\|`long_name`\|`name`); pecoff; olecf; fseventsd (`path`); amcache_link (`full_path`); jlecmd (`Path`); Sysmon 11/23 (`TargetFilename`); 4907 (`ObjectName`); piiat.files (`Path`); filescan (`Name`) |
+| **actions** | all |
+| **mapped?** | **YES** — broad. |
+| **confidence** | Strong. **NOT** on zeek_files (network file — no host path) or mftscan-mem (only `Filename`, full path not in memory-resident $MFT). |
+
+### fqdn
+| | |
+|---|---|
+| **sources** | Sysmon 11/23 → `EVTX_FQDN` (Computer, only if dotted) `sysmon.py:200`; 4907 → `_FQDN` |
+| **actions** | create, delete, acl_modify |
+| **mapped?** | **YES (partial)** — Windows EVTX host-telemetry only. |
+| **confidence** | Medium. Plaso disk sources map only `hostname` (image_hostname), never fqdn — honest null, not a near-miss. |
+
+### gid
+| | |
+|---|---|
+| **sources** | **l2t_filestat → `group_identifier`** (POSIX numeric) `plaso_linux.py:208` |
+| **actions** | create, delete, modify, read |
+| **mapped?** | **YES (filestat only)**. |
+| **confidence** | Strong on POSIX (verified on real evidence: `fs:stat` EXT record carries `group_identifier: 0`). No NTFS analogue (NTFS has no gid). |
+
+### group
+| | |
+|---|---|
+| **sources** | POSIX `/etc/group` join on gid (not implemented) |
+| **actions** | — |
+| **mapped?** | **NO** — filestat carries only the numeric gid, never the group name. |
+| **confidence** | High-confidence no-source. Requires a passwd/group resolution step. Honest null. |
+
+### hostname
+| | |
+|---|---|
+| **sources** | filestat/mft/usn/lnk/recyclebin/shellitem/pecoff/olecf/fseventsd/amcache (`image_hostname`); jlecmd (`Hostname`); Sysmon 11/23 + 4907 (`Computer` first label) |
+| **actions** | all |
+| **mapped?** | **YES** — broad. |
+| **confidence** | Strong. NOT on zeek_files (network file, no host) or mftscan-mem props. For disk artefacts it is the imaged-host stamp (recorded, not the event's own claim). |
+
+### image_path
+| | |
+|---|---|
+| **sources** | Sysmon 11/23 → `Image` (acting process exe) `sysmon.py:196`; 4907 → `ProcessName` |
+| **actions** | create, delete, acl_modify |
+| **mapped?** | **YES (partial)** — Windows host-telemetry only. |
+| **confidence** | Medium. MITRE defines the hash fields as "hash of the file at image_path"; for disk artefacts the file IS the subject (file_path==the hashed file), so image_path is left null there rather than duplicating file_path. INERT 4663/4660/4670/5140/5145 also carry `ProcessName`→image_path. |
+
+### link_target
+| | |
+|---|---|
+| **sources** | **l2t_lnk → `link_target`** (the shortcut's stored target string) `plaso_artifacts.py:101` |
+| **actions** | create, modify, read |
+| **mapped?** | **YES (lnk only)**. |
+| **confidence** | Medium. Recorded-not-trusted (a .lnk can be stale/crafted). POSIX symlinks (fseventsd/OSSEM `symlink_name`) are NOT mapped to link_target — potential add. |
+
+### md5_hash
+| | |
+|---|---|
+| **sources** | filestat → `md5_hash` (file's own) `plaso_linux.py:195`; **Sysmon EID 23** → `MD5=` from `Hashes` `sysmon.py:154`; zeek_files → `md5` |
+| **actions** | create (filestat), delete (Sysmon 23, zeek create) |
+| **mapped?** | **YES** (3 sources). |
+| **confidence** | Strong. **NOT** on mft/usnjrnl (a hash there would be the `$MFT`/`$UsnJrnl` artefact's own — deliberately omitted, `plaso_linux.py:33`), **NOT** on Sysmon EID 11 create (event carries no hash). Sysmon EID 15 (N2) would add it on create. |
+
+### mime_type
+| | |
+|---|---|
+| **sources** | **zeek_files → `mime_type`** (incl. `application/x-dosexec` = PE) `zeek_extra.py:76`; Suricata fileinfo magic (N8) |
+| **actions** | create |
+| **mapped?** | **YES (zeek only)**. |
+| **confidence** | Medium. Network-observed only. No host source computes MIME; libmagic on carved/dumped files would be the host path. |
+
+### mode
+| | |
+|---|---|
+| **sources** | **l2t_filestat → `mode`** (POSIX permission bits, e.g. `420`=0o644) `plaso_linux.py:207`; NTFS ACL (N6 — not mapped) |
+| **actions** | create, delete, modify, read |
+| **mapped?** | **YES (filestat POSIX only)**. |
+| **confidence** | Strong on POSIX (verified: real `fs:stat` EXT record `mode: 420`). **GAP:** NTFS "ACL" mode has no source — 4670/4907 carry `OldSd`/`NewSd` and mftscan-mem carries `Permissions`, all kept **native**, never decoded into `mode`. |
+
+### owner
+| | |
+|---|---|
+| **sources** | plaso_olecf → `author` (document author — best-effort near-miss) `plaso_fs_extra.py:142`; POSIX passwd join (not implemented); NTFS owner-SID→name (N6) |
+| **actions** | create, modify (olecf) |
+| **mapped?** | **weak/near-miss (olecf author only)** — no true filesystem-owner name anywhere. |
+| **confidence** | Low. The OLE `author` is document metadata, not the filesystem owner; treat with caution. filestat gives only numeric owner_uid, not a name. Effectively an honest no-source for the real owner. |
+
+### owner_uid
+| | |
+|---|---|
+| **sources** | **l2t_filestat → `owner_identifier`** (POSIX numeric UID) `plaso_linux.py:207`; NTFS owner SID (N6 — not mapped) |
+| **actions** | create, delete, modify, read |
+| **mapped?** | **YES (filestat POSIX only)**. |
+| **confidence** | Strong on POSIX (verified: `owner_identifier: 0` = root; a 0 is a real id, not a blank). **GAP:** NTFS owner SID from `$MFT` security descriptor / `$Secure` → owner_uid/uid unmapped. |
+
+### pid
+| | |
+|---|---|
+| **sources** | Sysmon 11/23 → `ProcessId`; 4907 → `hex_int(ProcessId)`; piiat.files → `PID` (handle-holder) |
+| **actions** | create, delete, acl_modify |
+| **mapped?** | **YES (partial)** — host-telemetry + memory-handle only. |
+| **confidence** | Medium. Files at rest (disk artefacts) have no acting pid — honest null. Sysmon also surfaces `owning_pid`/`owning_guid` (tier-1 process link). INERT audit family adds pid to 4663/4660/4670. |
+
+### ppid
+| | |
+|---|---|
+| **sources** | none direct; only via process-object enrichment (file.pid → its process → that process's ppid) |
+| **actions** | — |
+| **mapped?** | **NO** — no file event source carries the acting process's parent pid. |
+| **confidence** | High-confidence no-source at map time. A cascade could inherit it from the linked process; never asserted on the file row today. Honest null. |
+
+### previous_creation_time
+| | |
+|---|---|
+| **sources** | **PIIAT-Mem mftscan** — SI birth vs FILE_NAME birth mismatch, filled at merge `enrich.py:186`; Sysmon EID 2 `PreviousCreationUtcTime` (N1, unmapped); disk $MFT $SI/$FN split (N5, unmapped) |
+| **actions** | create (the DATA rides on a create row; the timestomp verdict is left to the analyst) |
+| **mapped?** | **YES (memory mftscan only)**. |
+| **confidence** | Medium, single-source. **This is the largest timestomp gap:** neither disk `$MFT` (l2t_mft doesn't compare $SI/$FN — one row per timestamp_desc) nor Sysmon EID 2 is mapped, so on-disk / host-telemetry timestomp evidence is invisible. |
+
+### sha1_hash
+| | |
+|---|---|
+| **sources** | filestat → `sha1_hash`; Sysmon 23 → `SHA1=`; zeek_files → `sha1`; **amcache_link_time → `sha1`** (the PROGRAM's SHA-1) `plaso_exec.py:259` |
+| **actions** | create (filestat, amcache, zeek), delete (Sysmon 23) |
+| **mapped?** | **YES** (4 sources). |
+| **confidence** | Strong. Amcache is the notable disk source that ships a real program SHA-1 without on-image hashing. |
+
+### sha256_hash
+| | |
+|---|---|
+| **sources** | filestat → `sha256_hash`; Sysmon 23 → `SHA256=`; zeek_files → `sha256`; **pecoff → `sha256_hash`** (PE's own) `plaso_fs_extra.py:123`; **olecf → `sha256_hash`** (doc's own) `plaso_fs_extra.py:141` |
+| **actions** | create (filestat/pecoff/olecf/zeek), delete (Sysmon 23), modify (olecf) |
+| **mapped?** | **YES** (5 sources). |
+| **confidence** | Strong. Caveat: shellitem/recyclebin/fseventsd carry a `sha256_hash` that is the ARTEFACT's own (the .lnk/hive/DB), deliberately kept as `artefact_sha256` native — never the target file's hash. |
+
+### signature_valid
+| | |
+|---|---|
+| **sources** | Sysmon EID 6/7 `SignatureStatus` (maps to **driver/module**.signature_valid, `sysmon.py:163` — never file); Authenticode verify (N9) |
+| **actions** | modify (per MITRE coverage_map) |
+| **mapped?** | **NO** for the file object. |
+| **confidence** | High-confidence no-source. Would need Authenticode verification on a PE; no hasher/verify plugin exists in-repo (grep for hasher/yara/Authenticode: none). Honest null. |
+
+### signer
+| | |
+|---|---|
+| **sources** | Sysmon EID 6/7 `Signature` → **module/driver**.signer (`sysmon.py:246`, never file); PE Authenticode cert subject (N9) |
+| **actions** | create, modify (per MITRE coverage_map) |
+| **mapped?** | **NO** for the file object. |
+| **confidence** | High-confidence no-source. Same as signature_valid. Honest null. |
+
+### uid
+| | |
+|---|---|
+| **sources** | 4907 `SubjectUserSid` (present but **unmapped** — `evtx_more.py` maps `user` only); INERT 4663/4660/4670/5140/5145 → `SubjectUserSid` (`evtx_audit.yml`); NTFS owner SID (N6) |
+| **actions** | delete, acl_modify, read, write (per the audit spec) |
+| **mapped?** | **NO** (active). Trivially groundable from 4907's own `SubjectUserSid`. |
+| **confidence** | Medium. `owner_uid` (POSIX) is filled but is the *owner*, not the acting SID — different field. Quick win: add `uid` to the 4907 map. |
+
+### user
+| | |
+|---|---|
+| **sources** | filestat/mft/usn/lnk/recyclebin (`username`); Sysmon 11/23 (`User`); 4907 (`SubjectUserName`) |
+| **actions** | create, delete, modify, read, acl_modify |
+| **mapped?** | **YES** — broad. |
+| **confidence** | Strong where the record fills it. Caveat: disk artefacts' `username` is the imaged-host context and is frequently `-` → honest null. jlecmd/shellitem/pecoff/zeek/filescan carry no user. |
+
+---
+
+## 3. Action coverage (which sources reach each canonical action)
+
+| action | active sources | status |
+|---|---|---|
+| **create** | filestat, mft, usn(0x100), lnk, shellitem, pecoff, olecf, amcache_link, Sysmon 11, zeek_files, mftscan-mem | Well covered |
+| **delete** | filestat(deletion desc), mft, usn(0x200), recyclebin, Sysmon 23 | Covered (INERT: 4660/4663; MISSING: Sysmon 26) |
+| **modify** | filestat, mft, usn(default), shellitem, olecf, fseventsd | Covered |
+| **read** | filestat, mft, lnk, shellitem, jlecmd | Covered (INERT: 4663/5140/5145/5058) |
+| **acl_modify** | **4907** (single source) | Thin — one source (INERT: 4670) |
+| **write** | **none** | **GAP — no active source.** USN "modify" is the nearest but is action=modify. Only INERT 4663/5140/5145 emit `write`. |
+| **timestomp** | **none** | **GAP — no source emits action=timestomp.** mftscan-mem provides `previous_creation_time` DATA on a *create* row (verdict deferred to analyst), not the action. Canonical source is Sysmon EID 2 (unmapped) + $MFT $SI/$FN split (unmapped). |
+
+---
+
+## 4. Summary — coverage and ranked UNMAPPED gaps
+
+**Coverage today.** The `file` object is the best-covered object in the engine — 15 active maps plus 3 memory maps span **18 producers** across disk (filestat/$MFT/$UsnJrnl/lnk/recyclebin/shellitem/PE/OLE/FSEvents/Amcache/jump-lists), host telemetry (Sysmon 11/23, Security 4907), network (Zeek files.log), and memory (mftscan/filescan/handle-enum). Path/name/extension, creation_time, the three hashes, POSIX mode/owner_uid/gid, hostname/user are all well grounded. **20 of 26 fields have at least one active source.**
+
+**Fields with NO active source (6):** `company`, `content`, `group`, `ppid`, `signature_valid`, `signer`, plus effectively `owner` (only the weak OLE-author near-miss) and `uid` (present-but-unmapped in 4907). Actions `write` and `timestomp` have no active source at all.
+
+**UNMAPPED gaps, ranked by value × groundedness:**
+
+1. **`timestomp` action + `previous_creation_time` from disk & host telemetry — HIGHEST.** Only memory mftscan supplies it. Two clean, groundable sources are unused: **Sysmon EID 2** (`PreviousCreationUtcTime`/`CreationUtcTime` → the canonical timestomp event, N1) and the **disk `$MFT` $SI vs $FN birth mismatch** (plaso `mft` already emits per-attribute rows carrying `attribute_name` — the current l2t_mft map flattens them by timestamp_desc and never compares, N5). Highest anti-forensics value; both fully groundable.
+
+2. **`write` action — HIGH.** No active source. The **inert Security 4663/5140/5145** audit family (`evtx_audit.yml`) is the ready-made spec (AccessMask→read/write/delete); promote once validated against an audit-enabled capture. Sysmon has no write event, so this is the only route.
+
+3. **NTFS owner/uid/mode from the `$MFT` security descriptor / `$Secure` (N6) — HIGH.** Today `owner_uid`/`gid`/`mode` are POSIX-only (filestat). On Windows images these stay null even though the owner SID and DACL are on disk. `4907`/`4670` already carry `OldSd`/`NewSd` and mftscan carries `Permissions` — all kept native, never decoded into `mode`/`owner`.
+
+4. **`uid` on Security 4907 — QUICK WIN.** `SubjectUserSid` is already in the record; the map emits `user` but not `uid` (`evtx_more.py:102`). One-line add; also unlocks uid across the inert audit family.
+
+5. **Hashes/`content` on file-create host telemetry — MEDIUM.** **Sysmon EID 15** (FileCreateStreamHash, N2) would add `md5/sha1/sha256_hash` (and ADS `Contents`) to create events — currently only *delete* (EID 23) ships hashes on the host. **Sysmon EID 26** (FileDeleteDetected, N3) is the logged-not-archived delete, unmapped (only EID 23).
+
+6. **`signer` / `signature_valid` / `company` — MEDIUM, needs new tooling.** No PE VERSIONINFO/Authenticode extractor exists in-repo (no hasher/verify plugin). Sysmon 6/7 signer data is spent on module/driver. Requires a PE-metadata/Authenticode step (or Autoruns ingest) — the only realistic route to these three "signed executable" fields.
+
+7. **`mime_type` on host files — LOW.** Only Zeek supplies it (network). A libmagic pass over carved/dumped files, or Suricata fileinfo (N8), would extend it host-side.
+
+8. **`group` (name), `content`, `ppid` — LOW / by design.** `group` needs a passwd/group join; `content` needs carving/dumpfiles wired into a CAR column (rarely appropriate); `ppid` is a cascade-inheritance concern, never a map-time file field. Honest nulls.
+
+**Honest no-source (correctly left null):** `company`, `signer`, `signature_valid` (no signing extractor); `content` (no carving-to-CAR); `group` (no name resolution); `ppid` (no file source). These are not conservatism gaps — the producers do not exist in the pipeline.

--- a/docs/car-provenance/flow.md
+++ b/docs/car-provenance/flow.md
@@ -1,0 +1,113 @@
+# CAR `flow` — Property-Provenance Catalogue
+
+**Object:** `flow` — *"A sequence of packets from a source computer to a destination… This may be captured at network or host level."*
+**Actions:** `start`, `message`, `end`.
+**Fields (27):** application_protocol, content, dest_fqdn, dest_hostname, dest_ip, dest_port, end_time, exe, fqdn, hostname, image_path, in_bytes, network_direction, out_bytes, packet_count, pid, ppid, proto_info, src_fqdn, src_hostname, src_ip, src_port, start_time, tcp_flags, transport_protocol, uid, user.
+
+Grounded in: `third_party/piiat-mitrecar/third_party/car/data_model/flow.yaml`, `car_data_model.json`, the four active flow maps, the quarantined WFP audit spec, PIIAT-Mem, and real evidence (`data_store/processed/{zeek,volatility}`).
+
+> **The central fact for `flow`.** A network-vantage source (Zeek conn, pcap, NetFlow) gives the 5-tuple, volume, protocols, and TCP history — but carries **no endpoint identity**: no `exe`/`pid`/`ppid`/`user`/`image_path`. Those fields — the ones CAR flow analytics actually key on (`exe`, `user` appear in the detection corpus) — come **only from a host-side source that watches the socket owner**: **Sysmon EID 3**, **memory netscan**, or **WFP 5156** (quarantined). This catalogue's job is to show, per field, which side each source can and cannot fill.
+
+---
+
+## Source universe (what actually exists in this repo)
+
+| # | Source | Map | Status | Vantage | Gives endpoint owner (exe/pid/user)? |
+|---|--------|-----|--------|---------|--------------------------------------|
+| **S1** | **Zeek conn.log** | `piiat_mitrecar/mappings/zeek_conn.py` | **MAPPED** | network | **NO** (pcap has no host identity) |
+| **S2** | **Sysmon EID 3 NetworkConnect** | `piiat_mitrecar/mappings/sysmon.py:311` | **MAPPED** | host (endpoint) | **YES** — `exe`,`image_path`,`pid`,`user` native; `ppid` inherited |
+| **S3** | **Memory netscan / netstat** (Volatility) | `piiat-mem/piiat_mem/mappings.py:125` (`_FLOW_MAP`) | **MAPPED** | host (memory) | **YES** — `pid`,`exe` native; `image_path`,`user`,`uid`,`ppid` **inherited** from owning `_EPROCESS` (definitive) |
+| **S4** | **SMBClient/Connectivity 30803** | `piiat_mitrecar/mappings/evtx_more.py:152` | **MAPPED (thin)** | host (endpoint) | NO (no process ctx on 30803) — only `dest_fqdn` |
+| **S5** | **SRUM network_usage** (Plaso esedb/srum) | `piiat_mitrecar/mappings/plaso_srum.py:73` | **MAPPED** | host (per-app aggregate) | partial — `exe`,`image_path`,`uid` native; no pid/user/endpoints |
+| **U1** | **WFP 5156 (allow) / 5157 (block)** | `piiat-mitrecar/to-be-validated/evtx_audit.yml:157` | **QUARANTINED — NOT active** | host (endpoint) | **YES (spec)** — `image_path`,`pid`,`owning_pid`; no user/exe |
+| **U2** | **Zeek dns/ssl/http per-protocol logs** | (raw; `zeek_extra.py` docstring) | **NOT mapped to flow** | network | NO — could enrich `application_protocol`/`proto_info`/`dest_fqdn` by shared `uid` at cascade, not done |
+| **U3** | **Sysmon EID 22 DnsQuery** | (raw; `sysmon.py:469` default None) | **NOT mapped** | host | — (DNS resolution, not a flow; could feed `dest_fqdn`) |
+| **U4** | **Suricata EVE / NetFlow-IPFIX / raw pcap payload** | — | **NOT mapped (no mapper exists)** | network | NO — but pcap payload is the *only* real source of `content` & `proto_info` |
+| **U5** | **Plaso firewall/pfirewall.log, browser history** | (browser→http via `plaso_web`) | **NOT mapped to flow** | host | — |
+
+**Evidence check.** Zeek `conn.json` present for 2 captures (fields verified: `ts`,`uid`,`id.orig_h/p`,`id.resp_h/p`,`proto`,`duration`,`orig_bytes`/`resp_bytes`,`conn_state`,`history`,`orig_pkts`/`resp_pkts`,`local_orig`/`local_resp`,`ip_proto`). Memory `car.db` has a **`flow` table with the full 27-field schema plus owner-link columns** (`owning_pid`,`owning_offset`,`owning_guid`,`parent_pid`,`parent_guid`,`link_confidence`) — but **0 flow rows in this sample** (this memory image produced no `windows.netscan`/`piiat.network` output; only mftscan+processes ran). Pipeline is schema-complete for memory flow; this particular image just has no connections to show.
+
+---
+
+## Per-field provenance table
+
+Legend for "mapped?": **yes** = an active map fills it; **inherit** = filled by the enrich cascade from the owning process (fill-only-null, never overwrites native); **quarantined** = spec exists in `to-be-validated/`, not active; **NO** = no source in the repo fills it.
+
+| field | sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|---|
+| **src_ip** | S1 Zeek `id.orig_h`; S2 Sysmon3 `SourceIp`; S3 mem `LocalAddr`; U1 WFP `SourceAddress` | start/message/end | **yes** (S1,S2,S3) | High. Convention: `src`=originator (Zeek) / local endpoint (Sysmon,mem). Memory's local=src is a **snapshot convention**, not proven originator (`network_direction` null there). S4 SMB has only SOCKADDR-hex `LocalAddress`→native, **not** src_ip. |
+| **src_port** | S1 `id.orig_p`; S2 `SourcePort`; S3 `LocalPort`; U1 `SourcePort` | start/message/end | **yes** (S1,S2,S3) | High, same convention as src_ip. |
+| **dest_ip** | S1 `id.resp_h`; S2 `DestinationIp`; S3 `ForeignAddr`; U1 `DestAddress` | start/message/end | **yes** (S1,S2,S3) | High. S4 SMB `RemoteAddress` is SOCKADDR-hex→native, **honest-null dest_ip**. |
+| **dest_port** | S1 `id.resp_p`; S2 `DestinationPort`; S3 `ForeignPort`; U1 `DestPort` | start/message/end | **yes** (S1,S2,S3) | High. Most-used field in flow analytics (11 refs). |
+| **transport_protocol** | S1 `proto` (tcp/udp/icmp); S2 `Protocol`; S3 `Proto` (TCPv4→TCP); U1 `Protocol` (6→tcp,17→udp) | start/message/end | **yes** (S1,S2,S3) | High. Authoritative model name (KQL's stale `protocol` was renamed). Memory normalizes `TCPv4`→`TCP`. |
+| **application_protocol** | S1 Zeek `service` only | start/message/end | **yes** (S1) | Medium. Zeek `service` is the app-proto label. **Only Zeek fills it.** Richer L7 (via dns/ssl/http uid-join = U2) is possible but **not done**. Sysmon3 `Source/DestinationPortName` are port name-table guesses → **native, deliberately NOT application_protocol** (near-miss refused). |
+| **tcp_flags** | S1 Zeek `history` only | start/message/end | **yes** (S1) | Medium — **recorded, not literal.** Zeek `history` is per-event state-history letters (`ShADadFf`, upper=orig/lower=resp), present on UDP/ICMP too, **NOT a TCP flag bitmask**. Consumers must read it as Zeek history. No other source carries flags (Sysmon3/mem/WFP have none). |
+| **out_bytes** | S1 Zeek `orig_bytes`; S5 SRUM `bytes_sent` | end/message | **yes** (S1,S5) | High. Zeek: payload bytes, src=originator ⇒ out=orig-sent. `orig_ip_bytes` is IP-level, **never a fallback**. Absent counters (S0/REJ) stay **null, not 0**. SRUM = hourly per-app aggregate (no endpoints). |
+| **in_bytes** | S1 Zeek `resp_bytes`; S5 SRUM `bytes_received` | end/message | **yes** (S1,S5) | High, mirror of out_bytes. |
+| **packet_count** | S1 Zeek `_zc_packet_count` = `orig_pkts`+`resp_pkts` | end/message | **yes** (S1) | High. Derived sum; **null when neither counter present** (a missing pair is not a 0-packet flow). Only Zeek. |
+| **start_time** | S1 Zeek `ts`; S2 Sysmon3 `TimeCreated`; S3 mem `Created`; S4 SMB `TimeCreated`; S5 SRUM `Timestamp` | start/message/end | **yes** (S1–S5) | High for S1/S2/S4. **Caveat S3:** memory `Created` on a live-connection snapshot is the socket-create time *as recorded in the acquired image*, reliable only as far as the acquisition. **Caveat S5:** SRUM is the aggregate's Recorded Time (hourly bucket), not a connect instant. |
+| **end_time** | S1 Zeek `_zc_end_time` = `ts`+`duration` | end/message | **yes** (S1) | Medium. Only when Zeek MEASURED a duration (S0/REJ attempts → null). Single-event sources (Sysmon3, SMB, WFP) have **no end** — honest null. |
+| **network_direction** | S2 Sysmon3 `Initiated` (TRUE→outbound/FALSE→inbound); U1 WFP `Direction` (%%14593→out/%%14592→in) | start | **yes** (S2); quarantined (U1) | Medium. **Sysmon3 is the only active source.** Zeek could derive from `local_orig`/`local_resp` (both present in evidence) but **deliberately leaves it null** (vetted view asserts no direction). Memory=null (socket snapshot can't tell originator). |
+| **exe** | S2 Sysmon3 `Image`; S3 mem `Owner` (proc name); S5 SRUM `application` (basename) | start/message | **yes** (S2,S3,S5) | **The endpoint field.** Sysmon3/memory are authoritative. SRUM `application` may be a device path (basename→exe) or bare service name. **Zeek/pcap/NetFlow give NOTHING here.** Used by flow analytics (4 refs). |
+| **image_path** | S2 Sysmon3 `Image`; S3 mem **inherited** from owning `_EPROCESS` `Path`; S5 SRUM `application` (if `\Device\…`); U1 WFP `Application` | start/message | **yes** (S2,S5) / **inherit** (S3) | High for S2. Memory netscan's own row has only `Owner` (name); full `image_path` arrives via **definitive owner inheritance** (`owning_offset`→process `Path`). No path from Zeek/pcap. |
+| **pid** | S2 Sysmon3 `ProcessId`; S3 mem `PID`; U1 WFP `ProcessID` | start/message | **yes** (S2,S3) | **Endpoint field.** Sysmon3/memory authoritative. WFP `ProcessID` is **decimal** (not hex) per spec. None from network sources. |
+| **ppid** | S2 Sysmon3 **inherited** (owner ProcessGuid, definitive); S3 mem **inherited** (owner `_EPROCESS`, definitive) | start | **inherit** (S2,S3) | Medium. **No source carries ppid natively on a flow record.** Filled by the enrich cascade from the owning process (`from_owning_process` includes `ppid` = the parent of the process the flow belongs to). Sysmon3's `owning_guid`=ProcessGuid and memory's `owning_offset` make this link **definitive** (tier-1). Absent an owner link (Zeek, SMB30803, SRUM, WFP) → **honest null**. |
+| **user** | S2 Sysmon3 `User`; S3 mem **inherited** token `User` from owning `_EPROCESS` | start/message | **yes** (S2) / **inherit** (S3) | **Endpoint field.** Sysmon3 native. Memory inherits the owning process's token user (definitive). **WFP 5156 has no user field; SRUM gives a SID not a name; Zeek/pcap give nothing.** Used by flow analytics. |
+| **uid** *(SID / user-id of flow-handling entity)* | S3 mem **inherited** owner `Sid`; S5 SRUM `user_identifier` (only if `S-1-` form) | start/message | **inherit** (S3) / **yes** (S5) | Medium. This is the *SID/user-id* family field, **not** the Zeek connection uid (that stays in `_native`, filling it would be a category error — see zeek_conn.py). Sysmon3 gives `User` (name) but **no SID → uid null on Sysmon3**. SRUM gates on real `S-1-` form (an SRUM internal index is not an identity). |
+| **dest_hostname** | S2 Sysmon3 `DestinationHostname` | start | **yes** (S2) | Medium — Sysmon-resolved remote name (best-effort, may be empty). No reverse-DNS resolver in pipeline. |
+| **src_hostname** | S2 Sysmon3 `SourceHostname` | start | **yes** (S2) | Medium — same as dest_hostname. |
+| **dest_fqdn** | S4 SMB30803 `ServerName`; (U3 Sysmon22 `QueryName` — not mapped) | start | **yes** (S4) | Low coverage. SMB30803 `ServerName` is the target server name (SMB-specific), the **only** active dest_fqdn source. Sysmon22 DNS or a Zeek dns uid-join could add it — **not implemented**. |
+| **src_fqdn** | — | — | **NO** | **Honest no-source.** No mapped source resolves the originator's FQDN. Would require reverse-DNS of `src_ip` — no resolver stage exists. |
+| **fqdn** *(observing host)* | S2 Sysmon3 `Computer` (if dotted); S4 SMB30803 `Computer` | start | **yes** (S2,S4) | Medium. This is the **vantage host** FQDN (the collection endpoint), per MITRE flow.fqdn = "the host". `regex1(Computer, ^([^.]+\.+)$)` — null on a bare workgroup name. **Zeek flow has null fqdn** (capture vantage is the pipeline `source_host` column, not written to this CAR field); memory flow inherits host fqdn from the image context. |
+| **hostname** *(observing host)* | S2 Sysmon3 `host_label(Computer)`; S3 mem inherited image host; S4 SMB30803 `host_label(Computer)` | start | **yes** (S2,S4) / **inherit** (S3) | Medium. Vantage host short name (NOT a flow endpoint — those are src/dest_hostname). **Zeek flow hostname = null** (no `hostname` prop in zeek_conn map; source_host is separate). |
+| **proto_info** | — (native to none) | — | **NO** | **Honest no-source — and a real gap.** Application-layer decode (SMB write request, HTTP headers/content). Only full **pcap payload / Suricata DPI / Zeek per-protocol logs** could produce it; **no mapper exists**. Zeek `service`→`application_protocol` deliberately leaves proto_info null (a bare service label would be a near-miss). **Flow analytics reference `proto_info` heavily (~10 refs) — the single biggest semantic gap for flow detections.** |
+| **content** | — (native to none) | — | **NO** | **Honest no-source.** ASCII of the flow payload (`GET https://… HTTP/1.1`). Requires **full-packet capture / PCAP payload**; the pipeline ingests Zeek *logs*, not payload. Referenced by ≥1 flow analytic. No source in repo. |
+
+---
+
+## Coverage summary
+
+**Fields with an active source (23 of 27):** src_ip, src_port, dest_ip, dest_port, transport_protocol, application_protocol, tcp_flags, out_bytes, in_bytes, packet_count, start_time, end_time, network_direction, exe, image_path, pid, ppid(inherit), user, uid, dest_hostname, src_hostname, dest_fqdn, fqdn/hostname.
+
+**Two-sided coverage is real:** the **network side** (5-tuple, volume, protocols, flags, times) is carried by **Zeek conn** (S1); the **endpoint side** (exe/image_path/pid/ppid/user/uid) is carried by **Sysmon EID 3** (S2) and **memory netscan** (S3). These are complementary vantages of the *same* flow — the pipeline keeps them as separate rows (different guids: Zeek `uid` vs record-guid vs proto+endpoint tuple); a cross-source 5-tuple+window bridge (`community_id`) is **deferred** (CAR-Relations.md).
+
+### The endpoint-side owner — who fills exe/pid/user/image_path (what pcap/Zeek lack)
+
+| owner field | Sysmon 3 | Memory netscan | WFP 5156 (quarantined) | Zeek/pcap/NetFlow |
+|---|---|---|---|---|
+| `exe` | native (`Image`) | native (`Owner`) | derivable (basename `Application`) | **never** |
+| `image_path` | native (`Image`) | inherit (owner `Path`) | native (`Application`) | **never** |
+| `pid` | native (`ProcessId`) | native (`PID`) | native (`ProcessID`, decimal) | **never** |
+| `ppid` | inherit (definitive) | inherit (definitive) | — (no owner link) | **never** |
+| `user` | native (`User`) | inherit (owner token) | **none** | **never** |
+| `uid`(SID) | **none** (name only) | inherit (owner `Sid`) | **none** | **never** |
+
+### Honest no-source / weak-source (ranked gaps)
+
+1. **`proto_info` — NO SOURCE, highest-impact gap.** ~10 references across flow analytics; nothing fills it. Needs pcap DPI / Suricata / Zeek per-protocol decode. **U2 (Zeek dns/ssl/http uid-join) is the cheapest realistic win — the logs already exist unmapped.**
+2. **`content` — NO SOURCE.** Requires full-packet PCAP payload; pipeline ingests logs, not payload.
+3. **`src_fqdn` — NO SOURCE**, and **`dest_fqdn` weak** (only SMB30803 `ServerName`). No reverse-DNS/DNS-answer join stage exists (U2 Zeek dns or U3 Sysmon22 would supply dest_fqdn).
+
+### UNMAPPED opportunities, ranked (build-order)
+
+1. **WFP 5156/5157 → flow (U1)** — spec is written and schema-grounded in `to-be-validated/evtx_audit.yml` (`security_5156_wfp_connection_allowed` → flow/start; 5157 → flow/message). Gives endpoint 5-tuple + `image_path` + `pid` + `network_direction` from the **Windows Security log** (no Sysmon required). **Blocked only on a capture with the Filtering-Platform-Connection audit subcategory enabled** (absent from lonewolf/M57/attack-samples). Highest value: a second, log-native endpoint source.
+2. **Memory netscan flow (S3) — already mapped, under-exercised.** Schema/pipeline complete; the on-hand memory image produced no netscan rows. Validate against an image that has live connections to prove the exe/pid/user/uid/ppid inheritance end-to-end.
+3. **Zeek dns/ssl/http → flow enrichment by `uid` (U2)** — fills `application_protocol` (richer), `proto_info`, and `dest_fqdn` for network-vantage flows. The logs are already produced and sit raw; a cascade `from_owning_flow`-style rule (the R3 pattern already used for http/file) would attach them.
+4. **Sysmon EID 22 DnsQuery (U3), Suricata EVE / NetFlow / pcap (U4)** — no mappers today; would add DNS-based `dest_fqdn`, and (pcap/Suricata) the only realistic path to `content`/`proto_info`.
+
+### Notes on honesty / near-misses the engine deliberately refuses
+- Zeek `tcp_flags` = state-history letters, **not** a TCP bitmask (documented).
+- Zeek `service` → `application_protocol` only; **`proto_info` stays null** (near-miss refused).
+- Sysmon3 `Source/DestinationPortName` → **native**, not `application_protocol` (port-name-table guess).
+- SMB30803 `RemoteAddress`/`LocalAddress` → **native SOCKADDR hex**, never faked into `dest_ip`/`src_ip`.
+- `flow.uid` (SID family) is **never** the Zeek connection uid (category error) — the Zeek uid lives in `_native` as the http/files join key.
+- Zeek/mem `network_direction` left **null** rather than guessed, though the raw fields (`local_orig`/`local_resp`; socket local/foreign) exist.
+- **`flow.yaml` `coverage_map` lists `sysmon_13`** for the start action — that is MITRE's own sensor-taxonomy token for its Sysmon network-connection sensor config, **not** Windows Sysmon EventID 13 (RegistryValueSet). This repo's authoritative endpoint source for flow is **Sysmon EventID 3 (NetworkConnect)**; treat the data-model `coverage_map` as MITRE's generic placeholder, not this engine's coverage.
+
+### Key file references
+- Active maps: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/{zeek_conn.py, sysmon.py:311, evtx_more.py:152, plaso_srum.py:73}`
+- Memory flow map: `third_party/piiat-mem/piiat_mem/mappings.py:125` (`_FLOW_MAP`); inheritance list `piiat_mem/enrich.py:72` (`_INHERIT`)
+- Enrich inheritance rules: `piiat_mitrecar/relationships.yml` (`from_owning_process` includes `ppid`)
+- Quarantined WFP spec: `third_party/piiat-mitrecar/to-be-validated/evtx_audit.yml:157-189`
+- Model + semantics: `car_data_model.json`, `third_party/piiat-mitrecar/third_party/car/data_model/flow.yaml`
+- Relations discipline: `docs/CAR-Relations.md`

--- a/docs/car-provenance/http.md
+++ b/docs/car-provenance/http.md
@@ -1,0 +1,315 @@
+# Property-Provenance Catalogue — MITRE CAR `http`
+
+**Scope.** Every canonical field of the CAR `http` object, and every artefact/source in this
+repo (and its realistic universe) that can supply it. Grounded in the CAR data model, the
+DX_DFIR engine maps (`piiat_mitrecar.mappings`), the generated `sources/*.yaml`, the repo's
+`docs/CAR-Relations.md`, OSSEM-CDM, and the actual processed evidence store. READ-ONLY analysis.
+
+- Object semantics: `third_party/piiat-mitrecar/third_party/car/data_model/http.yaml`, `.../docs/data_model/http.md`, `car_data_model.json` (lines 173-201).
+- OSSEM-CDM richer semantics: `third_party/piiat-mitrecar/third_party/car/OSSEM-CDM/schemas/entities/http.yml`.
+- Engine maps (source of truth): `piiat_mitrecar/mappings/core.py` (zeek_http), `.../evtx_extra.py` (BITS), `.../plaso_web.py` (browser/cache/java), `.../_common.py`, `.../normalize.py`.
+- Generated per-source coverage: `sources/{zeek_http,evtx_bits,l2t_msiecf,l2t_firefox_cache,l2t_firefox_places,l2t_javaidx}.yaml`.
+- Design rationale/limits: `docs/CAR-Relations.md` §"http (← Zeek http.log)" (lines 57-87).
+- Ground-truth records: `data_store/processed/zeek/DFIRdump_FOR_200_capture_pcap/http.json`.
+
+**Actions:** `get`, `post`, `put`, `tunnel` (CONNECT). MITRE's action set is deliberately
+incomplete — HEAD/OPTIONS/DELETE/PATCH/etc. have no canonical CAR action and stay raw
+(`core.py` `default: None`; `CAR-Relations.md` line 85-87).
+
+---
+
+## 0. Canonical fields + MITRE definition caveats (READ THIS FIRST)
+
+The upstream MITRE `http` data model carries three copy-paste defects that the repo has
+already diagnosed. They matter because they corrupt the field *semantics*, not just docs:
+
+| Field | MITRE's literal text | Reality (implement this) |
+|---|---|---|
+| `url_scheme` | "type of user that initiated the request." | **Copy-paste error.** Implement the field *name*: the URL scheme (`http`/`https`). Confirmed in `docs/CAR-Relations.md` line 77-78 and the map comment in `plaso_web.py`. |
+| `user_agent_full` | example `HOST1\LOCALUSER1` | Example is a pasted *user* value, not a UA string. The field is the **full User-Agent header string**. |
+| `user_agent_name` | example is the *entire* UA string `Mozilla/5.0 (...) Chrome/58...` | Example is swapped with `user_agent_full`. `user_agent_name` is meant to be the **parsed product name** (e.g. `Chrome`), `user_agent_version` the parsed version (`58.0.3029.83`), `user_agent_device` the parsed device (`SM-G930VC`). Splitting one UA string into name/version/device is a **heuristic parse** — see §3. |
+
+The 17 canonical fields: `hostname`, `http_version`, `request_body_bytes`,
+`request_body_content`, `request_referrer`, `requester_ip_address`, `response_body_bytes`,
+`response_body_content`, `response_status_code`, `url_domain`, `url_full`, `url_remainder`,
+`url_scheme`, `user_agent_device`, `user_agent_full`, `user_agent_name`, `user_agent_version`.
+
+**Provenance-quality legend** (as used by the engine's generated `field_provenance`):
+`[direct]` = 1:1 copy of a native field · `[derived]` = deterministic transform of one native
+field (regex/label/host extraction) · `[coalesced]` = first-non-empty of alternatives ·
+`[inferred]` = regex-parsed out of a compound field (url) · `[asserted]` = a constant the
+observation itself proves (e.g. scheme `http` for a cleartext zeek transaction) ·
+`[heuristic]` = a best-effort guess with real error rate (no source does this today).
+
+---
+
+## 1. Source universe
+
+### 1a. Currently mapped (wired in the engine + regenerated `sources/*.yaml`)
+
+| Map key | Tool / parser | Native log | Object/actions | Vantage of `hostname` |
+|---|---|---|---|---|
+| `zeek_http` (`core.py`) | Zeek | `http.log` (`http.json`) | http **get/post/put** (origin-form), **tunnel** (CONNECT) | *not mapped* — pcap has no endpoint identity; vantage carried by `source_host` |
+| `evtx_bits` (`evtx_extra.py`) | EvtxECmd / Plaso winevt | Microsoft-Windows-Bits-Client/Operational **59/60** | http **get** | `Computer` (the endpoint that issued the transfer) |
+| `l2t_msiecf` (`plaso_web.py`) | Plaso | `msiecf` (IE `index.dat`) | http **get** | `image_hostname` (imaged endpoint) |
+| `l2t_firefox_cache` (`plaso_web.py`) | Plaso | `firefox_cache` | http **get/post/put** (from recorded method) | `image_hostname` |
+| `l2t_firefox_places` (`plaso_web.py`) | Plaso | `sqlite/firefox_history` (`places.sqlite`) | http **get** | `image_hostname` |
+| `l2t_javaidx` (`plaso_web.py`) | Plaso | `java_idx` (Java IDX download cache) | http **get** | `image_hostname` |
+
+Routing confirmed in `pipeline.py` (`http.json`→zeek_http; `.L2tMsiecf`/`.L2tFirefoxCache`/
+`.L2tSqlite`/`.L2tJavaIdx`→plaso web; `evtx_bits` in the EvtxECmd fan-out).
+
+### 1b. Realistic sources that exist in the domain but are NOT mapped here
+
+| Source | Where it lives | What it could supply | Status |
+|---|---|---|---|
+| **Suricata http EVE** (`eve.json` `event_type:http`) | `data_store/processed/signatures/suricata/` (dir present, **empty** in current evidence) | url/host/UA/method/status/referrer/body-lengths — near-Zeek parity, plus `http.request_headers`/`response_headers` | **UNMAPPED** (no map, no records) |
+| **Proxy access logs** (Squid `access.log`, BlueCoat/ProxySG, Zscaler) | not in store | full URL, method, status, bytes, UA, referrer, client IP, **decrypted HTTPS** | **UNMAPPED** |
+| **IIS / Apache / NGINX W3C access logs** | not in store | server-side: url_remainder, method, status, bytes, UA, referrer, client IP (`c-ip`), `cs-host` | **UNMAPPED** (OSSEM-CDM http schema explicitly names IIS/Apache/NGINX as http sources) |
+| **WinINET/WinHTTP** (`WebCacheV01.dat` ESE, Sysmon/ETW) | not in store | url, host, downloaded bytes | **UNMAPPED** |
+| **Chrome/Edge/Safari history & cache** (Plaso `chrome:history:page_visited`, `safari:history:visit`, `chrome_cache`) | possible under `.L2tSqlite` | url, referrer (chrome `from_visit`), visit metadata | **UNMAPPED** — `.L2tSqlite` routes only to `l2t_firefox_places`, whose predicate gates strictly on `data_type == "firefox:places:page_visited"`; Chrome/Safari rows fall through to raw |
+| **Defender SmartScreen / DNS-Client (1014)** | not in store | requested url / queried host | **UNMAPPED** (SmartScreen carries url; DNS-Client only a hostname, weak fit) |
+| **Browser process memory** (`memory.yaml` sensor) | `data_store/processed/volatility/` | url strings recovered from a browser process | **UNMAPPED for http** (memory sensor emits its own CAR pass-through, not via these maps) |
+| **UA-string parser** (`ua_parser`/`woothee`/`user-agents`) | *nowhere in repo* | `user_agent_name` / `_version` / `_device` from `user_agent_full` | **UNMAPPED** — confirmed no UA-split code anywhere (`grep` for `user_agent_name/version/device` returns only the CAR schema + this catalogue). Would be `[heuristic]`. |
+
+---
+
+## 2. Per-field provenance (the catalogue)
+
+Format: `source → native field [quality]`. "Currently mapped?" cites the exact map/source file.
+Actions listed are those the mapping actually emits.
+
+### `hostname` — host on which the request was *seen* (the vantage)
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | *(none)* | — | **NO — deliberate** (`core.py` L19-23, L110-113) | pcap carries no endpoint identity; the vantage is the sensor's `source_host`, not a client-forgeable Host header. Mapping it would fake host attribution. |
+| evtx_bits | `Computer` → `host_label(Computer)` [derived] | get | **yes** — `evtx_extra.py` L63, `sources/evtx_bits.yaml` L39 | High. The endpoint that issued the BITS transfer *is* the http vantage. |
+| l2t_msiecf | `image_hostname` [direct] | get | **yes** — `plaso_web.py` L91 | High. Imaged endpoint = the vantage the artefact was seen on. |
+| l2t_firefox_cache | `image_hostname` [direct] | get/post/put | **yes** | High. |
+| l2t_firefox_places | `image_hostname` [direct] | get | **yes** | High. |
+| l2t_javaidx | `image_hostname` [direct] | get | **yes** | High. |
+| Proxy/IIS/Suricata | proxy host / `s-computername` / sensor host | — | **NO** | Would be direct if mapped. |
+
+### `http_version`
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `version` [direct] | get/post/put/tunnel | **yes** — `core.py` L116, `sources/zeek_http.yaml` L38 | High/direct. |
+| Suricata http EVE | `http.protocol` (e.g. `HTTP/1.1`) | — | **NO** | Direct if mapped (needs `HTTP/`-strip). |
+| Proxy/IIS | `cs-version` (IIS) | — | **NO** | Server-side, direct. |
+| evtx_bits / all Plaso browser | — | — | **NO** | Not recorded by BITS or browser-history artefacts. Honest no-source. |
+
+### `request_body_bytes`
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `request_body_len` [direct] | get/post/put/tunnel | **yes** — `core.py` L118 | High/direct. (For tunnel this is bytes of the CONNECT request, ~0.) |
+| Suricata http EVE | `http.request_body_len` (if body-logging on) | — | **NO** | Direct if mapped. |
+| Proxy | `cs-bytes` | — | **NO** | Direct. |
+| evtx_bits / Plaso browser | — | — | **NO** | Not recorded. Honest no-source. |
+
+### `request_body_content` — body of the HTTP request
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| **any source** | — | — | **NO — no source anywhere** | Zeek `http.log` records only body *length*, not content. Body *content* would come from Zeek file-extraction (`orig_fuids` → files.log → extracted file on disk) or a full-packet/proxy capture with body logging. `core.py` keeps `orig_fuids`/`orig_mime_types` in `keep` (join keys to `zeek_files`→`file`) but never asserts `request_body_content`. **Genuine gap; honest null.** |
+
+### `request_referrer` — the referring URL (client-supplied, forgeable)
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `referrer` [direct] | get/post/put/tunnel | **yes** — `core.py` L122 | Direct, but **client-supplied** — never proof of real navigation (`CAR-Relations.md` L83-84). Note: rare in evidence — only 1 `referrer` field present across all captured `http.json` rows. |
+| l2t_firefox_places | `from_visit` → `first(regex1(from_visit, ^\S+), from_visit)` [coalesced] | get | **yes** — `plaso_web.py` L142-144 | Medium. Firefox's recorded referring page ("url (host)" suffix stripped). Client-side recorded data, not navigation provenance. |
+| Suricata http EVE | `http.http_refer` [direct] | — | **NO** | Direct if mapped. |
+| Proxy/IIS | `cs(Referer)` | — | **NO** | Direct. |
+| Chrome/Safari history | chrome `from_visit` / safari referrer | — | **NO** | Would be `[coalesced]`; blocked by the firefox-only `.L2tSqlite` predicate. |
+| evtx_bits, l2t_msiecf, l2t_firefox_cache, l2t_javaidx | — | — | **NO** | Not recorded by those artefacts. Honest no-source. |
+
+### `requester_ip_address` — IP the request was made from
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `id.orig_h` [direct] | get/post/put/tunnel | **yes** — `core.py` L119 | High/direct (connection-truth origin). |
+| Suricata http EVE | `src_ip` [direct] | — | **NO** | Direct. |
+| Proxy/IIS | `c-ip` / `cs(X-Forwarded-For)` | — | **NO** | Direct (`c-ip`); XFF is client-forgeable. |
+| l2t_javaidx | *(only the server `ip_address` is recorded — kept native, NOT requester)* | get | **NO — deliberate** | The IDX cache records the *server* IP, not the requester; `plaso_web.py` L166 keeps it in `native_extract`, honestly not as `requester_ip_address`. |
+| evtx_bits, other Plaso | — | — | **NO** | Endpoint-side artefacts don't record their own source IP here. Honest no-source. |
+
+### `response_body_bytes`
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `response_body_len` [direct] | get/post/put/tunnel | **yes** — `core.py` L120 | High/direct. |
+| evtx_bits | `bytesTransferred` [direct] | get | **yes** — `evtx_extra.py` L61, `sources/evtx_bits.yaml` L42 | Medium-High. Bytes *transferred* by the BITS job (0 at 'started', final at 'stopped'). Maps to *response* body (a download) — reasonable but note it is transfer-total, not strictly HTTP response-body length. |
+| Suricata http EVE | `http.length` / `http.response_body_len` | — | **NO** | Direct if mapped. |
+| Proxy/IIS | `sc-bytes` | — | **NO** | Direct. |
+| Plaso browser (msiecf/ffcache/places/java) | `data_size`/`data_size` kept native, not asserted | — | **NO** | Cache `data_size` is cached-object size, not wire response bytes — correctly left native (`plaso_web.py` `native_extract`). |
+
+### `response_body_content` — content of the response (no header)
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| **any source** | — | — | **NO — no source anywhere** | Like request body: Zeek records only length; actual content needs file-extraction (`resp_fuids`→files.log→extracted file) or full-packet/proxy body logging. `resp_fuids`/`resp_mime_types` are kept as join keys to `file`, never asserted as content. Firefox/IE cache *do* hold cached response bodies on disk, but the Plaso plugins used emit metadata rows only (size/count), not the object bytes. **Genuine gap; honest null.** |
+
+### `response_status_code`
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `status_code` [direct] | get/post/put/tunnel | **yes** — `core.py` L121 | High/direct. Null `status_code` = **no response captured** → asserts no outcome (`CAR-Relations.md` L82), never a fake 0. |
+| l2t_firefox_cache | `response_code` → `hex_int(regex1(response_code, "\s(\d{3})\s"))` [derived] | get/post/put | **yes** — `plaso_web.py` L122-123 | Medium. Parsed out of the cached status line `HTTP/1.1 200 OK`. Deterministic parse. |
+| Suricata http EVE | `http.status` [direct] | — | **NO** | Direct. |
+| Proxy/IIS | `sc-status` | — | **NO** | Direct. |
+| evtx_bits, l2t_msiecf, l2t_firefox_places, l2t_javaidx | — | — | **NO** | Not recorded by those artefacts. Honest no-source. |
+
+### `url_domain` — domain portion of the URL (the Host)
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `domain_of(host)` [derived] | get/post/put/tunnel | **yes** — `core.py` L114 | High. This is the client-sent **Host header** (lowercased) — client-forgeable (domain fronting); connection-truth destination is `id.resp_h`, kept native (`CAR-Relations.md` L74-76). |
+| evtx_bits | `regex1(url, ^https?://([^/?#]+))` [inferred] | get | **yes** — `evtx_extra.py` L57 | Medium. Parsed from the full BITS url. |
+| l2t_msiecf | `regex1(url, ^https?://([^/?#:]+))` [inferred] | get | **yes** — `plaso_web.py` `_http_props` | Medium. Null for non-URL targets (`about:Home`) — honest. |
+| l2t_firefox_cache | same regex [inferred] | get/post/put | **yes** | Medium (after `HTTP:` prefix strip). |
+| l2t_firefox_places | same regex [inferred] | get | **yes** | Medium. |
+| l2t_javaidx | same regex [inferred] | get | **yes** | Medium. |
+| Suricata/Proxy/IIS | `http.hostname` / `cs-host` [direct] | — | **NO** | Direct. |
+
+### `url_full` — the full URL requested
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `concat("http://", host, uri)` [derived] | get/post/put **(NOT tunnel)** | **yes** — `core.py` L204 | Medium. **Reconstructed** from request-line + Host header, only origin-form. Null if any part missing. **NOT** emitted for tunnel (CONNECT target is authority-form, no URL). Scheme forced `http` — see caveat under `url_scheme`. |
+| evtx_bits | `url` [direct] | get | **yes** — `evtx_extra.py` L55 | High/direct (BITS records the full remote url). |
+| l2t_msiecf | `_IE_URL` = `first(regex1(url, ^Visited:\s*[^@]*@(.+)$), url)` [coalesced] | get | **yes** — `plaso_web.py` L75, L84 | Medium. IE history renders `Visited: user@<url>`; the real URL is extracted. |
+| l2t_firefox_cache | `_FFC_URL` = `first(regex1(url, ^HTTP:(.+)$), url)` [coalesced] | get/post/put | **yes** — `plaso_web.py` L77 | Medium (strips cache `HTTP:` prefix). |
+| l2t_firefox_places | `url` [direct] | get | **yes** | High/direct. |
+| l2t_javaidx | `url` [direct] | get | **yes** | High/direct. |
+| Suricata/Proxy/IIS | assembled `scheme://host + uri` / `cs-uri` | — | **NO** | Would be `[derived]`. |
+
+### `url_remainder` — path after the root domain
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `uri` [direct] | get/post/put/tunnel | **yes** — `core.py` L115 | High/direct (the request-target path+query). |
+| evtx_bits | `regex1(url, ^https?://[^/]+(/[^\s]*))` [inferred] | get | **yes** — `evtx_extra.py` L59 | Medium. |
+| l2t_msiecf | same regex [inferred] | get | **yes** | Medium. |
+| l2t_firefox_cache | same regex [inferred] | get/post/put | **yes** | Medium. |
+| l2t_firefox_places | same regex [inferred] | get | **yes** | Medium. |
+| l2t_javaidx | same regex [inferred] | get | **yes** | Medium. |
+| Suricata/Proxy/IIS | `http.url` / `cs-uri-stem`+`cs-uri-query` [direct] | — | **NO** | Direct. |
+
+### `url_scheme` — URL scheme (**NOT** "type of user" — see §0)
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `const("http")` [asserted] | get/post/put **(NOT tunnel)** | **yes** — `core.py` L203; `sources/zeek_http.yaml` L47 `[asserted]` | Medium. Zeek `http.log` sees **cleartext** HTTP only, so scheme is provably `http`; HTTPS payloads never appear here (they surface as `tunnel`/TLS). Not emitted for tunnel. |
+| evtx_bits | `regex1(url, ^(https?))` [inferred] | get | **yes** — `evtx_extra.py` L58 | Medium (real https/http preserved from the BITS url). |
+| l2t_msiecf / firefox_cache / firefox_places / javaidx | `regex1(url, ^(https?)://)` [inferred] | get(/post/put) | **yes** — `plaso_web.py` `_http_props` | Medium. Null for non-http targets — honest. |
+| Suricata/Proxy/IIS | derived from url / `cs-uri-scheme` | — | **NO** | Direct/derived. |
+
+### `user_agent_full` — the complete User-Agent header string
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| Zeek http | `user_agent` [direct] | get/post/put/tunnel | **yes** — `core.py` L122, `sources/zeek_http.yaml` L48 | Direct, but **client-supplied** — never proof of real client software (`CAR-Relations.md` L83-84). (Evidence sample: `masscan/1.0 (...)`.) |
+| Suricata http EVE | `http.http_user_agent` [direct] | — | **NO** | Direct. |
+| Proxy/IIS | `cs(User-Agent)` [direct] | — | **NO** | Direct. |
+| evtx_bits, all Plaso browser | — | — | **NO** | BITS/history/cache artefacts don't retain the UA header. Honest no-source. |
+
+### `user_agent_name` / `user_agent_version` / `user_agent_device` — parsed UA components
+
+| Source | native → field | action(s) | Mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| **(derived from `user_agent_full`)** | UA-string parse → name/version/device | — | **NO — no source anywhere** | **Genuine, highest-value gap.** No UA-parsing code exists in the repo (`grep` for these three field names hits only the CAR schema). Splitting one UA string into product name / version / device is a **`[heuristic]`** parse (regex or a `ua_parser`/`woothee` library) with a real error rate, especially for spoofed/embedded/webview UAs — hence honestly unmapped rather than faked. `user_agent_full` is available (from Zeek) to feed such a parser. |
+
+---
+
+## 3. Coverage matrix (source × field)
+
+`Y`=mapped · `d`=deliberately not mapped (principled null) · `·`=no source in that artefact ·
+`N*`=no source anywhere (see notes).
+
+| field | zeek_http | evtx_bits | l2t_msiecf | l2t_ff_cache | l2t_ff_places | l2t_javaidx |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|
+| hostname | d | Y | Y | Y | Y | Y |
+| http_version | Y | · | · | · | · | · |
+| request_body_bytes | Y | · | · | · | · | · |
+| request_body_content | N* | · | · | · | · | · |
+| request_referrer | Y | · | · | · | Y | · |
+| requester_ip_address | Y | · | · | · | · | d |
+| response_body_bytes | Y | Y | · | · | · | · |
+| response_body_content | N* | · | · | · | · | · |
+| response_status_code | Y | · | · | Y | · | · |
+| url_domain | Y | Y | Y | Y | Y | Y |
+| url_full | Y¹ | Y | Y | Y | Y | Y |
+| url_remainder | Y | Y | Y | Y | Y | Y |
+| url_scheme | Y¹ | Y | Y | Y | Y | Y |
+| user_agent_full | Y | · | · | · | · | · |
+| user_agent_name | N* | · | · | · | · | · |
+| user_agent_version | N* | · | · | · | · | · |
+| user_agent_device | N* | · | · | · | · | · |
+
+¹ `url_full`/`url_scheme` for zeek are emitted on **get/post/put only**, never `tunnel` (CONNECT).
+
+**Field mapped by ≥1 source:** 13 / 17.
+**Fields with NO source anywhere (N\*):** `request_body_content`, `response_body_content`,
+`user_agent_name`, `user_agent_version`, `user_agent_device` — 4 distinct field-classes (bodies ×2, UA-parse ×3).
+**Principled deliberate nulls (`d`):** zeek `hostname` (pcap vantage), javaidx `requester_ip_address` (server IP only).
+
+---
+
+## 4. Analytics consumers
+
+**None.** No shipped CAR analytic references the `http` object or any of its fields
+(`grep` across all 102 analytics in `third_party/car/analytics/` for `object: http`,
+`url_full`, `url_domain`, `user_agent*`, `response_status_code`, `request_referrer`,
+`requester_ip_address`, `url_scheme`, `http_version` → 0 hits; the only "http" strings are
+`http(s)://` URLs in prose). The `http` object is a data-model / provenance surface here,
+not an analytic input — so provenance quality is the whole value.
+
+---
+
+## 5. Summary — coverage and ranked gaps
+
+**Coverage.** 13/17 canonical fields have at least one wired source. Zeek `http.log` is the
+spine (14 of 17 fields, all four actions, the only source for `http_version`,
+`request_body_bytes`, `request_referrer`, `requester_ip_address`, `user_agent_full`).
+Endpoint artefacts (BITS + 4 Plaso browser/cache/java maps) add the `hostname` vantage and
+independent url/status evidence but are all url-centric. Byte counts, status, referrer, and
+UA come almost exclusively from Zeek. The maps are honest: deliberate nulls (zeek `hostname`,
+javaidx server-IP) and principled `default: None` (HEAD/OPTIONS, encrypted tunnels) are
+documented, not faked.
+
+**UNMAPPED gaps, ranked by value:**
+
+1. **UA parsing → `user_agent_name` / `user_agent_version` / `user_agent_device` (3 fields, 0 sources).**
+   Highest value: `user_agent_full` is already captured, the split is pure post-processing, and
+   these three fields are otherwise permanently empty. Needs a `[heuristic]` UA parser
+   (`ua_parser`/`woothee`) with the honest caveat that spoofed/webview UAs mislead it. Cheapest
+   win, biggest field-count uplift.
+
+2. **Proxy / IIS-Apache-NGINX access logs (0 sources today).** OSSEM-CDM explicitly lists these
+   as first-class http sources. They deliver server-side `url_remainder`, `response_status_code`,
+   bytes, referrer, UA, and `requester_ip_address` (`c-ip`) — and, uniquely, **decrypted HTTPS**
+   that Zeek cannot see (Zeek only logs cleartext, forcing `url_scheme=http`). Directly closes the
+   Zeek blind spot for TLS traffic.
+
+3. **Suricata http EVE (`event_type:http`).** Directory scaffolded (`signatures/suricata/`) but
+   empty; a map would give near-Zeek parity from an already-run sensor — low effort, and adds a
+   second independent network vantage (status, referrer, UA, method, url).
+
+4. **Browser-history depth beyond Firefox.** `.L2tSqlite` routes only to `l2t_firefox_places`,
+   gated to `firefox:places:page_visited`. **Chrome/Edge/Safari** page-visit + download rows
+   (which Plaso already parses) fall through to raw — a same-shape extension would add
+   `url_full`/`url_domain`/`request_referrer`/`hostname` for the dominant browsers.
+
+5. **Request/response body *content* (2 fields, 0 sources).** Genuinely hard: Zeek gives only
+   lengths; content needs Zeek file-extraction (join via `orig_fuids`/`resp_fuids`→`file`) or
+   full-packet/proxy body logging. The join keys are already kept native, so the plumbing exists
+   — but asserting the content fields requires an extraction pipeline that isn't wired. Lowest
+   priority; often infeasible for HTTPS anyway.
+
+**Data-model hygiene note (not a source gap).** `url_scheme`, `user_agent_full`, and
+`user_agent_name` carry upstream MITRE copy-paste defects (§0). The repo already implements the
+*intended* semantics; any downstream doc/UI should render field *names*, not MITRE's pasted
+descriptions/examples, for these three.

--- a/docs/car-provenance/module.md
+++ b/docs/car-provenance/module.md
@@ -1,0 +1,187 @@
+# Property-Provenance Catalogue — MITRE CAR `module`
+
+**Object:** `module` — "executable (and potentially non-executable) content, loaded as a contiguous region of memory into the address space of a process. Each process has the main image plus shared libraries (DLLs in Windows) and their dependencies."
+**Actions:** `load`, `unload`
+**Fields (12):** `base_address, fqdn, hostname, image_path, md5_hash, module_name, module_path, pid, sha1_hash, sha256_hash, signature_valid, signer, tid`
+
+Grounding read:
+- Semantics: `third_party/piiat-mitrecar/third_party/car/data_model/module.yaml`; `third_party/piiat-mitrecar/third_party/car/OSSEM-CDM/schemas/entities/module.yml` (fields: name, path, is_signed, signature, signature_status — no hashes, no base_address, no tid in the CDM either); `car_data_model.json` (object list).
+- Engine maps: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/sysmon.py` (EID 7), `.../mappings/evtx_more.py` (WMI 5857); sources `.../sources/evtx_sysmon.yaml`, `.../sources/evtx_more.yaml`, `.../sources/memory.yaml`.
+- Memory maps (PIIAT-Mem, finished-CAR passthrough): `third_party/piiat-mem/piiat_mem/mappings.py`, plugin `third_party/piiat-mem/plugins/windows/piiat/modules.py`, enrichment `third_party/piiat-mem/piiat_mem/enrich.py`.
+- Evidence: `data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json`; `data_store/processed/volatility/memdump.mem/car.db`.
+
+---
+
+## 1. Currently-mapped source universe (module → CAR)
+
+Three sources emit `module` events today. **All three emit only `action: load`. Nothing emits `unload`.**
+
+| Source (sensor) | EID / plugin | → object/action | Map file | module fields it supplies |
+|---|---|---|---|---|
+| **Sysmon** `Microsoft-Windows-Sysmon/Operational` | **EID 7 ImageLoad** | module/load | `sysmon.py:389` (`sysmon_module_load`, EID==7) | module_path, module_name, image_path, pid, md5_hash, sha1_hash, sha256_hash, signer, signature_valid, hostname, fqdn — **11 of 12** (no base_address, no tid) |
+| **WMI-Activity** `Microsoft-Windows-WMI-Activity/Operational` | **EID 5857** (provider DLL loaded) | module/load | `evtx_more.py:120` (`em_is_wmi_5857`) | module_path, module_name, image_path, pid, hostname, fqdn — **6 of 12** |
+| **Memory / Volatility3** (PIIAT-Mem) | `windows.piiat.modules` (PEB load-order walk; == `windows.dlllist`) | module/load | `piiat-mem mappings.py:223` + `:275`; plugin `modules.py` | module_path(Path), module_name(Name), **base_address(Base)**, pid, + image_path/hostname/fqdn by enrichment — **7 of 12** |
+
+The Sysmon EID 7 map is the only one the upstream `module.yaml coverage_map` records (as sensor `sysmon_13`). WMI-5857 and memory are wired in this repo's maps but not reflected in that upstream coverage stub.
+
+**Live evidence caveat:** the current processed store contains **zero** module rows. The EvtxECmd export has only Sysmon EID 1 (45) and EID 5 (39) — no EID 7 — and the `memdump.mem/car.db` `module` table has 0 rows (the `windows.piiat.modules` plugin was not run in that capture; only pslist/processes/registry/sessions/mftscan/banners were). The `module` table schema in `car.db` does carry all 12 canonical columns + `base_address` + `tid`, so the pipe is complete; it just has no populated sample here.
+
+---
+
+## 2. Per-field provenance (EVERY field × EVERY source)
+
+Native-field notation: `source → NativeField`. "Mapped?" = does the shipping engine assert this canonical field from that source today.
+
+### base_address
+| sources (source → native field) | action | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| Memory `windows.piiat.modules`/`windows.dlllist` → `Base` (`DllBase` of `_LDR_DATA_TABLE_ENTRY`) | load | **YES** — piiat-mem `mappings.py:228,280` (`base_address: "Base"`) | **High.** Memory is the *only* source that has a base address — it is a runtime virtual-address concept. Point-in-time snapshot of currently-loaded state. |
+| Sysmon EID 7 | load | NO | **No-source.** ImageLoad event carries no load address. |
+| WMI 5857 / Plaso pe / amcache / prefetch | load | NO | **No-source.** None are runtime-memory views; none carry a VA. |
+
+> `base_address` is a **memory-exclusive** field. Same for the parallel `driver` object (Volatility `windows.modules` → driver base).
+
+### fqdn
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `Computer` (claimed only if it contains a dot) | load | **YES** — `sysmon.py:248` via `_FQDN` (`EVTX_FQDN`) | **High**, but null when `Computer` is a bare NetBIOS name (honest null, never faked). |
+| WMI 5857 → `Computer` | load | **YES** — `evtx_more.py:129` (`_FQDN`) | High, same dot-guard caveat. |
+| Memory `windows.piiat.modules` (inherited) | load | **YES (derived)** — `enrich.py:72` `_INHERIT` copies `fqdn` from the owning process | **Medium.** Present only if the owning process event itself carries fqdn (from `windows.info`); memory images often lack a real FQDN → null. |
+
+### hostname
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `Computer` (first DNS label) | load | **YES** — `sysmon.py:248` (`_HOSTNAME`) | **High.** Always derivable from `Computer`. |
+| WMI 5857 → `Computer` | load | **YES** — `evtx_more.py:129` (`_HOST`) | High. |
+| Memory `windows.piiat.modules` (inherited) | load | **YES (derived)** — `enrich.py` `_INHERIT` | **Medium.** Inherited from owning process (from `windows.info` computer name); null if unavailable. |
+
+### image_path  *(CAR: "the file system location of the **process** image" — i.e. the OWNING process, not the DLL)*
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `Image` (the loading process) | load | **YES** — `sysmon.py:396` (`image_path: payload("Image")`) | **High.** Directly the loader process image. Correct CAR semantics. |
+| WMI 5857 → `HostProcess` | load | **YES** — `evtx_more.py:127` | **High.** `HostProcess` is the WMI host process image. |
+| Memory `windows.piiat.modules` → owning `_EPROCESS` image (inherited) | load | **YES (derived)** — `enrich.py:340,380` `_inherit` fills `image_path` from the owner joined by `OwnerOffset` (definitive) or PID (heuristic) | **Medium-High.** Map deliberately leaves it null at extraction (`mappings.py` comment: module.image_path is the OWNING process's image; the DLL's own path is `module_path`), then enrichment fills it. Confidence tracks the join: definitive via OwnerOffset, heuristic via PID. |
+
+### md5_hash
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `Hashes` (`MD5=…` substring) | load | **YES** — `sysmon.py:245` `_image_load_props` → `_hashes()` regex `MD5=` | **High**, *iff* Sysmon config has `<HashAlgorithms>MD5</HashAlgorithms>`. Sysmon default is SHA256 only → MD5 often absent (honest null). |
+| Memory (dumpfiles + external hashing) | load | NO | **No-source (not implemented).** dlllist/PEB walk yields no hash; `windows.dumpfiles` + a hash step could produce it but PIIAT-Mem does not run it. |
+| Plaso pe/pecoff | load | NO (pecoff emits **sha256 only**, and as a `file` object) | **No-source for md5.** See sha256 row. |
+| amcache | load | NO (amcache emits **sha1 only**, as a `process` object) | **No-source for md5.** |
+| WMI 5857 | load | NO | No-source. |
+
+### module_name  *(basename on disk; internal lookup key)*
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `basename(ImageLoaded)` | load | **YES** — `sysmon.py:395` | **High.** |
+| WMI 5857 → `basename(ProviderPath)` | load | **YES** — `evtx_more.py:126` | **High.** |
+| Memory `windows.piiat.modules` → `Name` (`BaseDllName`) | load | **YES** — `mappings.py:228,280` | **High.** Native `BaseDllName` string; blank on unreadable entries → null. |
+
+### module_path  *(full path to the DLL/EXE loaded into the process)*
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `ImageLoaded` | load | **YES** — `sysmon.py:394` | **High.** The definitive path of the loaded image. |
+| WMI 5857 → `ProviderPath` (WMI provider DLL) | load | **YES** — `evtx_more.py:125` | **High**, but scope-limited: only WMI provider DLL loads, not general LoadLibrary. |
+| Memory `windows.piiat.modules` → `Path` (`FullDllName`) | load | **YES** — `mappings.py:227,279` | **High**, occasionally blank/paged-out `FullDllName` → null. |
+
+### pid  *(the process the module is loaded into)*
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `ProcessId` | load | **YES** — `sysmon.py:397` | **High.** |
+| WMI 5857 → `ProcessID` | load | **YES** — `evtx_more.py:128` | **High.** |
+| Memory `windows.piiat.modules` → `PID` (`UniqueProcessId` of the walked `_EPROCESS`) | load | **YES** — `mappings.py:228,280` | **High.** Also carries `OwnerOffset` (kernel pointer) for a definitive process link beyond the reusable PID. |
+
+### sha1_hash
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `Hashes` (`SHA1=…`) | load | **YES** — `_hashes()` `sysmon.py:154` | **High** *iff* Sysmon config includes SHA1 (non-default) → often null. |
+| amcache → `sha1` (program SHA-1) | load | NO — currently mapped to **process/create**, not module (`plaso_exec.py:286`) | **Potential enrich source.** amcache carries the file's SHA-1 but the DLL entries are folded into process rows, not exploded to module. Path-join enrichment could lift it. |
+| Memory (dumpfiles+hash) / Plaso pe (sha256 only) / WMI 5857 | load | NO | No-source for sha1 (pe gives sha256, not sha1). |
+
+### sha256_hash
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `Hashes` (`SHA256=…`) | load | **YES** — `_hashes()` `sysmon.py:155` | **High.** SHA256 is the Sysmon **default** algorithm → most reliable hash from EID 7. |
+| Plaso pe/pecoff → `sha256_hash` (PE/COFF file hash) | load | NO — mapped to **file/create** entity, not module (`plaso_fs_extra.py:125`, source `plaso_pecoff.yaml` `data_model_coverage: file`) | **Potential enrich source.** Every on-disk PE (incl. DLLs) gets a sha256 as a `file` entity; joining by `module_path` could hydrate module.sha256. Also carries native `imphash`, `pe_type`, `compile_time`, `export_dll_name`. |
+| Memory (dumpfiles+hash) | load | NO | No-source (not implemented). |
+| WMI 5857 / amcache | load | NO | No-source (amcache = sha1). |
+
+### signature_valid  *(bool: signature current & not revoked)*
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `SignatureStatus` (mapped `Valid → true`) | load | **YES** — `sysmon.py:163` `_SIGNATURE_VALID = map_value(SignatureStatus, {"Valid": True})` | **High, deliberately asymmetric.** Only the WinVerifyTrust `Valid` verdict asserts `true`; every other status (`Unavailable`, `Errors`, …) is left **null** (evidence of a problem, not proof of forgery) and kept native as `Signed`/`SignatureStatus`. Requires `CheckRevocation` in Sysmon config; absent → status `Unavailable` → null. |
+| Memory / WMI 5857 / Plaso pe / amcache | load | NO | **No-source.** None run Authenticode verification. (A memory `dumpfiles` + external `WinVerifyTrust`/cert-parse could produce it but is not implemented.) |
+
+### signer  *(organisation that signed the module)*
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Sysmon EID 7 → `Signature` (the WHO) | load | **YES** — `sysmon.py:246` (`signer: payload("Signature")`) | **High** when `<Signature>`/hashing enabled; null otherwise. Note `Signature` = signer name; `SignatureStatus` = validity (kept separate). `Company`/`OriginalFileName` are **not** signer and stay native in Payload. |
+| Memory / WMI 5857 / Plaso pe / amcache | load | NO | **No-source.** pe/pecoff extracts PE metadata but not the Authenticode signer cert subject. |
+
+### tid  *(thread ID responsible for the load/unload)*
+| sources | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| — none — | load | **NO (honest no-source)** | **No artefact in this pipeline records the loading thread.** Sysmon EID 7 has no thread id; WMI 5857 has none; the memory PEB load-order walk (`_LDR_DATA_TABLE_ENTRY`) records no calling-thread. Only kernel ETW (`Microsoft-Windows-Kernel-Process` ImageLoad w/ thread context) would carry it, and that is not collected. The `car.db` `module` table has a `tid` column, but it is never populated. |
+
+---
+
+## 3. Action coverage
+
+| action | mapped sources | notes |
+|---|---|---|
+| **load** | Sysmon EID 7, WMI 5857, Memory `windows.piiat.modules`/`dlllist` | All three sources emit only `load`. |
+| **unload** | **NONE (honest no-source)** | No collected artefact emits a module-unload event. Sysmon has no unload EID; `FreeLibrary` is unlogged. Memory is a point-in-time snapshot of *currently-loaded* state (a load view, not an unload event). The upstream `coverage_map` also lists load only. |
+
+---
+
+## 4. Native fields available per source (reference — what's on the wire vs. what's mapped)
+
+- **Sysmon EID 7 (ImageLoad):** `ImageLoaded`(→module_path), `Image`(→image_path), `ProcessId`(→pid), `ProcessGuid`(owner link), `Hashes`(MD5/SHA1/SHA256/**IMPHASH**), `Signed`, `Signature`(→signer), `SignatureStatus`(→signature_valid), `OriginalFileName`, `Company`, `Product`, `Description`, `FileVersion`, `User`, `Computer`(→hostname/fqdn), `UtcTime`, `RuleName`. **Kept native but NOT canonical:** IMPHASH, OriginalFileName, Company, Signed, raw SignatureStatus (`_KEEP` + Payload blob). No `base_address`, no thread id on the wire.
+- **WMI-Activity 5857:** `ProviderPath`(→module_path), `ProviderName`(native), `HostProcess`(→image_path), `ProcessID`(→pid), `Code`(native), `Computer`. No hashes, signer, base_address, tid.
+- **Memory `windows.piiat.modules`** (plugin `modules.py`): `OwnerOffset`(definitive owner link), `PID`(→pid), `ProcessName`(native), `Base`(→**base_address**), `Size`(native), `Name`(→module_name), `Path`(→module_path), `LoadTime`(→ts; Win≥6.1, zeroed for the EXE itself), `LoadCount`(native). No hash/signer/tid available from the PEB walk.
+
+---
+
+## 5. Coverage summary & UNMAPPED gaps (ranked)
+
+**Coverage at a glance (12 fields × load):**
+
+| field | Sysmon7 | WMI5857 | Memory | best today |
+|---|:--:|:--:|:--:|---|
+| base_address | – | – | ✅ | Memory only |
+| fqdn | ✅ | ✅ | (inh) | High |
+| hostname | ✅ | ✅ | (inh) | High |
+| image_path | ✅ | ✅ | (inh) | High |
+| md5_hash | ✅* | – | – | Sysmon7 (config-gated) |
+| module_name | ✅ | ✅ | ✅ | High |
+| module_path | ✅ | ✅ | ✅ | High |
+| pid | ✅ | ✅ | ✅ | High |
+| sha1_hash | ✅* | – | – | Sysmon7 (config-gated) |
+| sha256_hash | ✅ | – | – | Sysmon7 (default algo) |
+| signature_valid | ✅ | – | – | Sysmon7 only |
+| signer | ✅ | – | – | Sysmon7 only |
+| tid | – | – | – | **no-source** |
+
+`✅* = present only if the Sysmon HashAlgorithms config enables that algorithm (default = SHA256).` `(inh) = filled by enrichment from the owning process, not native to the module row.`
+
+**Well-covered:** identity fields (module_path/module_name/pid/image_path/hostname/fqdn) have 2–3 independent sources. Sysmon EID 7 is the single richest source (11/12). base_address is memory-exclusive and already mapped.
+
+### UNMAPPED gaps — ranked
+
+1. **Memory injection detection — `ldrmodules` / unlinked-module view (NOT IMPLEMENTED).** PIIAT-Mem walks only the PEB *load-order* list (`windows.piiat.modules` == `windows.dlllist`), so it sees only linked modules. There is **no `ldrmodules` plugin** cross-referencing the three PEB lists (load/init/mem order) to flag unlinked = injected/hidden DLLs. `malfind` exists but is a **trigger only** (timeline overlay, never stored as a module record — `piiat_mem/timeline.py`, `cli.py:71`). *Highest-value gap: injected-module detection is absent from the module object.* Would add nothing to the 12 canonical fields but a native `unlinked/injected` flag (no CAR home → native) plus base_address for hidden modules.
+
+2. **Prefetch loaded-modules list (`mapped_files`) not exploded into module rows.** Plaso `windows:prefetch:execution` carries `mapped_files` — the DLL/file list the run touched — but it is kept **native on the process/create event** (`plaso_exec.py:231`), never decomposed into `module/load` rows. *High value, low cost:* each `mapped_files` entry → a `module/load` with `module_path`, `module_name`, and `pid`/`image_path` from the owning process event. Caveat: prefetch has no per-module load time, no base_address, no hash (path only), and mixes DLLs with data files.
+
+3. **Hash hydration by path-join (sha256 from pe, sha1 from amcache).** Two on-disk sources carry file hashes today but attach them to the wrong object:
+   - Plaso **pe/pecoff** → `sha256_hash` on a **file** entity (`plaso_pecoff.yaml`), + native `imphash`/`pe_type`/`compile_time`.
+   - **amcache** → `sha1` on a **process** event (`plaso_exec.py:286`).
+   A cross-source enrichment joining `module.module_path` to these `file`/entity rows would hydrate `sha256_hash`/`sha1_hash`/`md5_hash` for modules that Sysmon logged without hashing (or that only memory/prefetch saw). Not wired.
+
+4. **Memory module hashing (`dumpfiles` + hash) — NOT IMPLEMENTED.** Would give md5/sha1/sha256 for a module seen only in memory (incl. injected ones from gap #1). PIIAT-Mem does not run `windows.dumpfiles` or hash dumped regions.
+
+5. **Signer/signature_valid limited to Sysmon EID 7.** Any module seen only via WMI/memory/prefetch/pe has null signer & signature_valid. No Authenticode verification runs outside Sysmon's own WinVerifyTrust stamp. (EZ-Tools/PECmd/AmcacheParser are not wired as module sources — Plaso covers those artefact classes.)
+
+6. **`tid` — genuine no-source.** No collected artefact records the loading thread ID; only uncollected kernel ETW would. Column exists, permanently null. Honest.
+
+7. **`unload` action — genuine no-source.** No artefact emits module unloads; all three sources are load-only / snapshot. Honest.

--- a/docs/car-provenance/process.md
+++ b/docs/car-provenance/process.md
@@ -1,0 +1,176 @@
+# PROPERTY-PROVENANCE CATALOGUE — MITRE CAR `process`
+
+**Object:** `process` — "A running program on a computer." The single most important CAR object:
+**67 of 102** CAR analytics (66%) reference it, and its `create` action alone is cited **132×**
+across their `data_model_references`. If any object must be complete, it is this one.
+
+**Actions:** `create`, `terminate`, `access`.
+**Canonical fields (29):** access_level, call_trace, command_line, current_working_directory,
+env_vars, exe, fqdn, guid, hostname, image_path, integrity_level, md5_hash, parent_command_line,
+parent_exe, parent_guid, parent_image_path, pid, ppid, sha1_hash, sha256_hash, sid,
+signature_valid, signer, target_address, target_guid, target_name, target_pid, uid, user.
+
+Grounded in (read verbatim):
+`third_party/piiat-mitrecar/third_party/car/data_model/process.yaml` (+ `docs/data_model/process.md`);
+`car_data_model.json`; the live engine maps
+`piiat_mitrecar/mappings/{sysmon,evtx_windows,plaso_exec,plaso_srum}.py`,
+`piiat_mem/mappings.py`, the memory plugin `plugins/windows/piiat/{processes,access}.py`;
+generated sources `sources/{evtx_sysmon,evtx_process,memory,plaso_exec_prefetch,plaso_exec_winreg,plaso_exec_cron}.yaml`;
+`piiat_mitrecar/enrich.py` + `relationships.yml`; `docs/CAR-Relations.md`; the quarantined
+`to-be-validated/evtx_audit.yml`; and real evidence
+(`data_store/processed/volatility/memdump.mem/car.db`, 180 process rows;
+`data_store/processed/windows_logs/.../log_EvtxECmd_Output.json`).
+
+---
+
+## A. Source universe (process producers)
+
+| # | Source (artefact key / predicate) | Tool / parser | Action(s) | Live? | Nature |
+|---|---|---|---|---|---|
+| S1 | **Sysmon EID 1** `evtx_sysmon`/`sysmon_proc_create` | EvtxECmd (Sysmon/Operational) | create | ✅ active | create-time telemetry — **richest single source** |
+| S2 | **Sysmon EID 5** `evtx_sysmon`/`sysmon_proc_terminate` | EvtxECmd | terminate | ✅ active | terminate telemetry (shares ProcessGuid with S1) |
+| S3 | **Sysmon EID 10** `evtx_sysmon`/`sysmon_proc_access` | EvtxECmd | access | ✅ active | cross-proc handle open (cred-dump/injection) |
+| S4 | **Security 4688** `evtx_process`/`evtxwin_is_sec_4688` | EvtxECmd (Security) | create | ✅ active | audit-log process create |
+| S5 | **Security 4689** `evtx_audit.yml`/`security_4689_process_exit` | EvtxECmd (Security) | terminate | ⛔ **INERT** (quarantined, un-validated) | audit-log process exit |
+| S6 | **Memory processes** `windows.piiat.processes` | PIIAT-Mem / Volatility 3 | create | ✅ active | live PEB+token snapshot — **only source for a resident process with cleared logs** |
+| S7 | **Memory access** `windows.piiat.access` | PIIAT-Mem (handle scan) | access | ✅ active | open Process-type handle = "A accesses B" |
+| S8 | **Prefetch** `plaso_exec_prefetch`/`plaso_is_prefetch_execution` | Plaso L2tPrefetch (≈PECmd) | create | ✅ active | execution **proof** (run count/times) |
+| S9 | **Amcache** `plaso_exec_winreg/amcache` | Plaso L2tWinreg (≈AmcacheParser) | create | ✅ active | presence→execution **inferred**; carries SHA-1 |
+| S10 | **Userassist** `plaso_exec_winreg/userassist` | Plaso L2tWinreg | create | ✅ active | GUI-launch counter |
+| S11 | **BAM/DAM** `plaso_exec_winreg/bam` | Plaso L2tWinreg | create | ✅ active | last-run time **+ per-user SID** |
+| S12 | **AppCompatCache/Shimcache** `plaso_exec_winreg/appcompatcache` | Plaso L2tWinreg (≈AppCompatCacheParser) | create | ✅ active | presence-**inferred**; `native.execution_inferred=True`, time is $SI mtime, **not a run time** |
+| S13 | **SRUM app usage** `l2t_srum/application_usage` | Plaso esedb/srum (SrumECmd can't run on Linux) | create | ✅ active | app demonstrably ran in the recorded hour |
+| S14 | **Cron** `plaso_exec_cron`/`plaso_is_cron_task_run` | Plaso L2tText/syslog | create | ✅ active | Linux `CMD` task-run line |
+
+**Identity notes carried over from grounding, so the tables below are not misread:**
+- **S3 (EID 10)** is the ONLY Sysmon EID that populates process-`access` columns. **Sysmon EID 8
+  (CreateRemoteThread) is mapped to the `thread` object, NOT process** — its Target* values land on
+  `thread.tgt_*`/`native`, so it does **not** fill `process.target_*`. (Corrects a common assumption.)
+- **Amcache "Link Time" row** (`plaso_exec_winreg/amcache_link_time`) is deliberately mapped to a
+  **`file`** record (the PE compile stamp), **not** process — so it is not a process source and does
+  not enter the timeline.
+- **guid**: only Sysmon `ProcessGuid` (S1/S2) is a *real* Windows process GUID. Memory mints
+  `proc-<offset>`; 4688 mints a per-record event id; every Plaso source mints a uuid5 **spindle**
+  entity id (`piiat_mitrecar/spindle.yml`). All fill the `guid` slot honestly but are synthetic.
+- **parent_guid** is never a native column — `enrich.py` (`ev["parent_guid"]`) resolves it, then
+  inherits `parent_exe/parent_image_path/parent_command_line` from the resolved parent
+  (`relationships.yml → from_parent_process`).
+
+---
+
+## B. Per-field provenance (the catalogue)
+
+Legend — **map?**: ✅ mapped (file:line) · ⛔ mapped-but-inert · ✗ not mapped / no source.
+Confidence — **D** definitive (native identity), **H** heuristic (pid+window / presence-inferred),
+**C** config-conditional.
+
+| Field | Sources → native field (✅ live · ⛔ inert · ✗ unmapped) | Action(s) | Currently mapped? | Confidence & caveats |
+|---|---|---|---|---|
+| **command_line** | S1 `CommandLine`; S4 `CommandLine`; S6 `CommandLine` (PEB); S14 `command` (full) · ✗ PowerShell-console/PSReadLine, bash_history, WMI-Activity, 4104 (all raw) | create | ✅ S1 `sysmon.py:269`, S4 `evtx_windows.py:318`, S6 `mem/mappings.py:153`, S14 `plaso_exec.py:384` | **D**/**H**. **S4 only if cmdline process-creation auditing is ON** (else honest null). S6 null when PEB paged out (evidence: 157/180). Execution artefacts (S8–S13) record path only, **never args**. Analytics #2 field (46 refs). |
+| **exe** | S1/S2 `Image`; S3 `SourceImage`; S4 `NewProcessName`; S5 `ProcessName`; S6 `basename(Path)`→`ImageFileName`; S7 `ProcessName`; S8 `executable`; S9 `basename(full_path)`; S10 `basename(UEME_RUNPATH)`; S11 `basename(path)`; S12 `basename(path)`; S13 `basename(application)`; S14 `basename(command[0])` | create, terminate, access | ✅ **every source** (S5 ⛔) | **D**. The one near-universal field (180/180 in memory) and the **#1 analytics field (47 refs)**. S6 always fills via 15-char `ImageFileName` fallback even when `Path` null. |
+| **image_path** | S1/S2 `Image`; S3 `SourceImage`; S4 `NewProcessName`; S5 `ProcessName`; S6 `Path` (PEB); S9 `full_path`; S10 path-form value only; S11 `path`; S12 `path` (NT `\??\`); S13 `\Device\...` form only; S14 rooted `/path` only · **✗ S8 (prefetch)**, **✗ S7 (mem-access)** | create, terminate, access | ✅ most; **✗ prefetch**, **✗ mem-access** | **D**/**H**. **Prefetch fills `exe` only — `image_path` stays null** (`path_hints[]` unindexable → surfaced native). S10/S13/S14 fill only when the value is provably a path. S6 157/180 (null→exe fallback). |
+| **pid** | S1 `ProcessId`; S2 `ProcessId`; S3 `SourceProcessId`; S4 `hex_int(NewProcessId)`; S5 `hex_int(ProcessId)`; S6 `PID`; S7 `PID`; S14 `pid` (crond worker) · **✗ S8–S13** | create, terminate, access | ✅ live sources; ✗ execution-inferred | **D**. Execution artefacts (prefetch/amcache/UA/BAM/shimcache/SRUM) record **no pid** — honest null. |
+| **ppid** | S1 `ParentProcessId`; S4 `hex_int(ProcessId)` (creator); S6 `PPID` · ✗ all others | create | ✅ S1, S4, S6 | **D**. Only the three create-time live sources carry it. |
+| **parent_exe** | S1 `basename(ParentImage)`; S4 `basename(ParentProcessName)`; S6 `basename(ParentPath)`; *enrich* from resolved parent | create | ✅ S1, S4, S6 (native); enrich fill | **D**. Native on all three; **#3 analytics field (16 refs)**. |
+| **parent_image_path** | S1 `ParentImage`; S4 `ParentProcessName`; S6 `ParentPath` | create | ✅ S1, S4, S6 | **D**. |
+| **parent_command_line** | S1 `ParentCommandLine` (native) · S6/S4 via *enrich* inheritance from resolved parent | create | ✅ S1 `sysmon.py:271`; S4/S6 enriched | **D** (S1); **D/H** (enrich: definitive via ParentProcessGuid/memory guid, heuristic via 4688 ppid+window). Only Sysmon EID 1 carries it *natively*. |
+| **parent_guid** | **Resolved, never native.** Key: S1 `ParentProcessGuid`→definitive; S6 parent guid→definitive; S4 ppid+create-window→heuristic | create | ✅ via `enrich.py:474` | **D** (S1/S6, 164/180 in memory) vs **H** (S4). No source asserts it directly. |
+| **guid** | S1/S2 `ProcessGuid` (**real**); S6 `proc-<offset>` (synth 180/180); S4 record-id (synth); S8–S14 uuid5 **spindle** (synth); S3/S7 event-id for the access row | create, terminate, access | ✅ all | **D**. **Only Sysmon ProcessGuid is a true GUID**; everything else is a minted identity filling the slot. On `access`, the row `guid` is the event id — the process's own guid is `owning_guid` (S3 `SourceProcessGUID`, S7 `proc_guid(OwnerOffset)`). |
+| **hostname** | S1/S2/S3 `Computer`[0]; S4 `host_label(Computer)`; S6 image_context; S8–S12 `image_hostname`; S14 `image_hostname`→`hostname` · **✗ S13 (SRUM)** | create, terminate, access | ✅ near-universal; **✗ SRUM** | **D**. **SRUM app-usage sets no host key** — a real (small) gap. |
+| **fqdn** | S1/S2/S3 `Computer` **only when it contains a dot** · **✗ S4, ✗ S6, ✗ all Plaso** | create, terminate, access | ✅ Sysmon only (conditional) | **C**. Only Sysmon, and only when `Computer` is a real FQDN. **4688 sets hostname but NOT fqdn.** Memory/Plaso carry hostname without domain (0/180). Frequently null. |
+| **integrity_level** | S1 `IntegrityLevel` (string); S4 `MandatoryLabel` (S-1-16 SID→vocab); S6 token label · ✗ all Plaso | create | ✅ S1, S4, S6 | **D**. Normalized to low/medium/high/system across sources. Memory 164/180. |
+| **current_working_directory** | S1 `CurrentDirectory`; S6 `Cwd` (PEB) · **✗ S4, ✗ all Plaso** | create | ✅ S1, S6 only | **D**. **Only Sysmon EID 1 and memory** supply CWD — 4688 and every execution artefact leave it null. |
+| **env_vars** | **S6 `EnvVars` (PEB) — SOLE SOURCE** (156/180) · ✗ everything else | create | ✅ **memory only** `mem/mappings.py:165` | **D**. **Structurally memory-exclusive.** No log or disk artefact records a process's environment block. |
+| **user** | S1 `User`; S2 `User`; S3 `SourceUser`; S4 `TargetUserName`→`SubjectUserName`; S5 `SubjectUserName`; S6 `User` (token); S8 `username`; S9 `username`; S10 `username`; S11 `username`; S12 `username`; S14 `username` · **✗ S7 (mem-access), ✗ S13 (SRUM)** | create, terminate, access | ✅ broad (S5 ⛔) | **D**/**C**. Plaso `username` is usually `"-"`→null; the real owner hides in `native.hive_user_sid` (UA). `enrich.py` canonicalizes well-known SIDs → names and fills blanks (e.g. "Local System" ×). |
+| **sid** | S4 `TargetUserSid`→`SubjectUserSid` (S-1-0-0 guarded); S5 `SubjectUserSid`; S6 `Sid` (token, 164/180); S11 `user_identifier`; S13 `user_identifier` (S-1- form) · **✗ S1 (Sysmon EID1 has User name, NO SID)** · ✗ S8/S9/S10/S12/S14 | create | ✅ S4, S6, S11, S13 (S5 ⛔) | **D**. **Key gap: Sysmon EID 1 does not carry a SID** — the map leaves it null; SID for a Sysmon-only host comes only via memory or 4688. Userassist's `hive_user_sid` is native-only (join key), not canonical `sid`. |
+| **uid** | S6 `Sid` (Windows token SID reused as uid, 164/180) · **✗ everything else** | create | ✅ **memory only** `mem/mappings.py:161` | **D**. Effectively memory-exclusive. 4688/BAM/SRUM fill `sid` but **not** `uid`; cron maps `username`→user, no numeric uid. Linux uid has **no live source**. |
+| **md5_hash** | S1 `Hashes` (`MD5=`) **iff MD5 in Sysmon HashAlgorithms** · **✗ S9 amcache (SHA-1 only), ✗ S6 (0/180), ✗ all else** | create | ✅ **Sysmon EID 1 only** `sysmon.py:153` | **C**. Single-sourced and config-dependent — often null. |
+| **sha1_hash** | S1 `Hashes` (`SHA1=`, config); **S9 amcache `sha1`** (definitive on-disk hash) · ✗ S6 (0/180) | create | ✅ S1, **S9** `plaso_exec.py:286` | **D** (amcache) / **C** (Sysmon). **Amcache is the key non-Sysmon hash source** — the only hash for a binary that is gone or was never Sysmon-logged. |
+| **sha256_hash** | S1 `Hashes` (`SHA256=`, Sysmon default) · **✗ amcache (SHA-1 only), ✗ memory, ✗ all else** | create | ✅ **Sysmon EID 1 only** `sysmon.py:155` | **C**. The model's default hash, yet **single-sourced** here. Null without Sysmon. |
+| **access_level** | S3 `GrantedAccess`; S7 `GrantedAccess` · ✗ else | access | ✅ S3 `sysmon.py:419`, S7 `mem/mappings.py:181` | **D**. Raw mask (e.g. `0x1FFFFF`), not decoded. Access action only. |
+| **call_trace** | S3 `CallTrace` · **✗ S7 (memory has no call stack), ✗ else** | access | ✅ **Sysmon EID 10 only** `sysmon.py:420` | **D**. Sysmon-exclusive; access only. |
+| **target_pid** | S3 `TargetProcessId`; S7 `TargetPid` · ✗ else | access | ✅ S3, S7 | **D**. Access only. |
+| **target_guid** | S3 `TargetProcessGUID`; S7 `proc_guid(TargetOffset)` · ✗ else | access | ✅ S3 `sysmon.py:417`, S7 `mem/mappings.py:183` | **D**. Access only. |
+| **target_name** | S3 `basename(TargetImage)`; S7 `TargetName` · ✗ else | access | ✅ S3, S7 | **D**. Access only. |
+| **target_address** | **✗ NO SOURCE.** Model example (`08048000-0804c000`) is a Linux `/proc/<pid>/maps` range; Sysmon EID 10 has no address range (EID 8 `StartAddress`→`thread.start_address`). | access | ✗ **none** | Honest no-source. Not populated by any current or realistically-addable Windows source. |
+| **signer** | **✗ NO PROCESS SOURCE.** Sysmon EID 1 `Company`/`OriginalFileName` are kept native (a PE string ≠ Authenticode signer — deliberate near-miss avoidance). Amcache `Publisher` not mapped. (Only `module`/`driver` EID 6/7 map `signer`.) | create | ✗ **none** | **Honest gap.** Would need PE Authenticode parse (not done) or amcache Publisher promotion. Structurally null everywhere for process. |
+| **signature_valid** | **✗ NO PROCESS SOURCE** (0/180). Same story as `signer` — only module/driver EID 6/7 `SignatureStatus` map it. | create | ✗ **none** | **Honest gap.** No WinVerifyTrust step in the process path. |
+
+---
+
+## C. Currently-mapped fill matrix (live sources only)
+
+`✔` native/derived at map time · `⊕` filled by enrichment (parent/owner inherit or SID canonicalization) ·
+blank = null.
+
+### create
+| field | S1 Sysmon1 | S4 4688 | S6 Mem | S8 Prefetch | S9 Amcache | S10 UserAssist | S11 BAM | S12 Shimcache | S13 SRUM | S14 Cron |
+|---|---|---|---|---|---|---|---|---|---|---|
+| exe | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| image_path | ✔ | ✔ | ✔ | | ✔ | ○ | ✔ | ✔ | ○ | ○ |
+| command_line | ✔ | ○ | ✔ | | | | | | | ✔ |
+| pid | ✔ | ✔ | ✔ | | | | | | | ✔ |
+| ppid | ✔ | ✔ | ✔ | | | | | | | |
+| parent_exe | ✔ | ✔ | ✔ | | | | | | | |
+| parent_image_path | ✔ | ✔ | ✔ | | | | | | | |
+| parent_command_line | ✔ | ⊕ | ⊕ | | | | | | | |
+| parent_guid | ⊕D | ⊕H | ⊕D | | | | | | | |
+| guid | ✔real | ✔synth | ✔synth | ✔synth | ✔synth | ✔synth | ✔synth | ✔synth | ✔synth | ✔synth |
+| hostname | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | | ✔ |
+| fqdn | ○ | | | | | | | | | |
+| integrity_level | ✔ | ✔ | ✔ | | | | | | | |
+| current_working_directory | ✔ | | ✔ | | | | | | | |
+| env_vars | | | ✔ | | | | | | | |
+| user | ✔ | ✔/⊕ | ✔/⊕ | ○ | ○ | ○ | ✔ | ○ | | ✔ |
+| sid | | ✔ | ✔ | | | | ✔ | ✔ | | |
+| uid | | | ✔ | | | | | | | |
+| md5_hash | ○ | | | | | | | | | |
+| sha1_hash | ○ | | | | ✔ | | | | | |
+| sha256_hash | ○ | | | | | | | | | |
+
+`○` = conditional (config/audit policy on, or value provably a path/host).
+
+### terminate — **S2 Sysmon EID 5** (active) · S5 4689 (⛔ inert)
+Fills: `exe, image_path, pid, user, guid(real), hostname, fqdn○`. (4689 would add `sid`.)
+**Memory emits no terminate** (snapshot: 180/180 create, 0 terminate); exit times feed only enrich R2 window-bounding.
+
+### access — **S3 Sysmon EID 10** + **S7 memory access** (both active)
+Fills: `pid, exe, image_path(S3), access_level, call_trace(S3 only), target_pid, target_guid, target_name, user(S3 only), hostname/fqdn(S3)`.
+*Evidence note:* both maps exist but neither fired in the sampled corpus (car.db access=0; raw evtx sample had EID 1/5 only, no EID 10) — access is real but sparse in current test data.
+
+---
+
+## D. Coverage summary
+
+- **Fully, richly covered (multi-source, high confidence):** exe, image_path, pid, ppid, parent_exe,
+  parent_image_path, integrity_level, user, hostname, guid, command_line. These carry the analytics load
+  (exe/command_line/parent_exe/image_path = 119 of the 132 create references).
+- **Access triad well covered** (Sysmon EID 10 + memory access): access_level, call_trace, target_pid,
+  target_guid, target_name.
+- **Total live process producers: 13** (S1–S4, S6–S14); one inert (S5/4689).
+
+## E. UNMAPPED / single-source gaps — ranked
+
+**Tier 1 — genuinely single-source (a whole class of evidence disappears if that one source is absent):**
+1. **`env_vars` — MEMORY ONLY.** No log/disk artefact records a process's environment block. Absent memory ⇒ always null.
+2. **`current_working_directory` — Sysmon EID 1 + memory only.** 4688 and all execution artefacts leave it null.
+3. **`uid` — memory only.** Windows token SID reused as uid; no other source fills it, and Linux uid has no live source (cron maps only `username`).
+4. **`sha256_hash` — Sysmon EID 1 only** (config-dependent). The model's default hash is single-sourced.
+5. **`md5_hash` — Sysmon EID 1 only** *and* requires MD5 in the configured HashAlgorithms.
+6. **`call_trace` — Sysmon EID 10 only** (memory access has no call stack).
+
+**Tier 2 — honest no-source (structurally null for process; not a pipeline omission):**
+7. **`signer`** and **`signature_valid`** — no process producer maps either (only module/driver EID 6/7 do).
+   Fillable in principle: amcache `Publisher`/`IsPeSigned` (currently kept raw), or a PE Authenticode verify — neither implemented.
+8. **`target_address`** — no Windows source; a Linux `/proc/maps` concept with no artefact behind it.
+
+**Tier 3 — fillable field the pipeline currently leaves null (fixable):**
+9. **`sid` missing from Sysmon EID 1.** A Sysmon-only Windows host gets `user` (name) but no SID from process-create — SID then depends on 4688 or memory being present. (Sysmon EID 1 genuinely lacks a SID field, so this is a data limit, but a host with 4688 *and* Sysmon can cross-fill via enrichment on the LogonId/user — not currently done for `sid`.)
+10. **`hostname` null on SRUM app-usage** (`l2t_srum/application_usage` sets no host key, unlike every sibling source) — a small, clearly fixable omission in `plaso_srum.py`.
+11. **`image_path` null on prefetch** — `Record.path_hints[]` holds the full path but is a list the marker set cannot index, so only `exe` is filled (path surfaced as `native.path_hints`). Fixable with a list-index marker.
+12. **`fqdn` rarely filled** — only Sysmon, only when `Computer` is a dotted FQDN; 4688 could set it from `Computer` the same way but does not.
+
+**Tier 4 — evidence classes with NO process mapping at all (raw-but-queryable, per canonical-or-raw rule):**
+PowerShell console/PSReadLine history & bash_history (command_line evidence), PowerShell 4104 script-block,
+WMI-Activity/Operational & WMI-remote 4688, MUICache (GUI-exec), Security 4696 (primary-token assigned),
+scheduled-task 4698 registration. None has a clean CAR process action, so all stay raw.

--- a/docs/car-provenance/registry.md
+++ b/docs/car-provenance/registry.md
@@ -150,7 +150,7 @@ Legend: **Mapped?** = yes (+map location) / NO. **Conf** = confidence the field 
 |---|---|---|---|
 | SYS12 / SYS13 / SYS14 → `User` | add, remove, value_edit, key_edit | yes — `sysmon.py` | Med-High — **absent pre-v11 Sysmon** on registry events → honest null then. |
 | SEC4657 → `SubjectUserName` | add, value_edit, remove | **NO** (quarantined) | High — the writer's account. |
-| RECMD → `regex1(HivePath, [/\\]Users[/\\]([^/\\]+)[/\\])` | value_edit | yes — `recmd.py` | **Med** — the **hive owner** from a per-user hive path (`Users/<name>`); **system hives → null**. Owner ≠ necessarily the writer. |
+| RECMD → the `<name>` captured from the hive's `...\Users\<name>\...` path | value_edit | yes — `recmd.py` | **Med** — the **hive owner** from a per-user hive path (`Users/<name>`); **system hives → null**. Owner ≠ necessarily the writer. |
 | MEM → `user_from_hive(Hive)` | value_edit | yes — `mappings.py` | **Med** — hive owner from `NTUSER.DAT`/`UsrClass.dat`; system hives → null. Same owner≠writer caveat. |
 | PLREG → `username` / `hive_user_sid` (regex `S-1-5-21-…`) surfaced **native** | key_edit | **NO** (native only) | **GAP-ish** — SID/username are recovered into `_native` for the end-stage user-attribution join, but the canonical `user` column stays null. Promotable via the hive-owner convention. |
 
@@ -169,7 +169,7 @@ Legend: **Mapped?** = yes (+map location) / NO. **Conf** = confidence the field 
 | Source → native field | Action(s) | Mapped? | Conf & caveats |
 |---|---|---|---|
 | SYS12 / SYS13 / SYS14 → `Computer` (only if it contains a dot) | all | yes — `sysmon.py` (`_FQDN`) | Med — claimed **only** when `Computer` is genuinely an FQDN; a bare NetBIOS name → honest null (never faked). |
-| SEC4657 → `regex1(Computer, ^([^.]+\.+)$)` | — | **NO** (quarantined) | Med — same discipline. |
+| SEC4657 → the label of `Computer` up to the first dot | — | **NO** (quarantined) | Med — same discipline. |
 | MEM → `Tcpip\Parameters` Hostname/Domain/DhcpDomain (PIIAT-Mem CAR layer) | value_edit | yes (passthrough, tool-defined) | Med/unknown — the plugin captures `Tcpip\Parameters` for fqdn; whether the CAR layer emits `fqdn` is defined by PIIAT-Mem (passthrough source). |
 | PLREG | — | **NO** | **Honest no-source** — `image_hostname` is a bare name; no domain recorded. |
 | RECMD | — | **NO** | **Honest no-source.** |

--- a/docs/car-provenance/registry.md
+++ b/docs/car-provenance/registry.md
@@ -1,0 +1,225 @@
+# CAR `registry` — Property-Provenance Catalogue
+
+Authoritative, exhaustive map of **every canonical `registry` field → every artefact/source that can supply it** in the DX_DFIR pipeline. "Find once, done." Grounded in repo source, honest about gaps and honest nulls. READ-ONLY analysis.
+
+- Object model (authoritative): `car_data_model.json` → `registry` fields = `data, fqdn, hive, hostname, image_path, key, new_content, pid, type, user, value`; actions = `add, key_edit, remove, value_edit`.
+- Semantics: `third_party/piiat-mitrecar/third_party/car/data_model/registry.yaml`, `.../docs/data_model/registry.md`, OSSEM-CDM `.../OSSEM-CDM/schemas/entities/registry.yml`.
+
+---
+
+## 1. Field & action semantics (grounded)
+
+| Field | CAR meaning (registry.yaml) | OSSEM-CDM analogue |
+|---|---|---|
+| `key` | The registry key path (folder-like). `HKLM\SYSTEM\CurrentControlSet\services\RpcSs` | `key_path` |
+| `value` | Descriptive **name** of the data being stored. `InstalledVersion` | `value_name` |
+| `data` | The **content** of `value`, typically a text string. | `value_data` |
+| `type` | The data type of `value` (`REG_BINARY`, `REG_SZ`, `REG_DWORD`, …). | `value_type` |
+| `hive` | The logical group of keys/subkeys/values. `HKEY_CURRENT_USER` | `hive_path` / `root_key` |
+| `new_content` | Data within the new value, **or** the new name of a key, **after an edit**. | `value_data_modified` / `key_path_modified` |
+| `image_path` | *Inherited from the process that made the access* — the WRITER's binary. | — |
+| `pid` | *Inherited from the process that made the access* — the WRITER's pid. | — |
+| `user` | The user in the context of the process that performed the action. | — |
+| `hostname` | Host short name (no domain). | — |
+| `fqdn` | Fully-qualified host name. | — |
+
+**Action semantics** — `add` (create key/value), `remove` (delete), `value_edit` (edit a value's content), `key_edit` (edit a key's **name**; also used in this repo as the "snapshot" action for a whole-key state). MITRE has no `read` action for registry (a registry read event has **no canonical home** → raw).
+
+**The load-bearing honesty rule** (`docs/CAR-Relations.md`, `car-store` §3, and every map's docstring): `image_path` / `pid` / `user` describe *the process that performed the write*. That process is recorded **only by a live event source** (Sysmon EID 12/13/14; Security 4657). A **dead hive** (Plaso winreg, RECmd, memory hive state) records the *resulting key/value state* but **not who wrote it** → `image_path`/`pid` are **honest nulls** on those sources; `user` is only recoverable as the **hive owner** (from an `NTUSER.DAT`/`UsrClass.dat` path), which is a different semantic (whose hive, not who wrote).
+
+---
+
+## 2. Source universe (every registry-capable source in the repo)
+
+| Code | Source → CAR route | Map file | Actions produced | Status |
+|---|---|---|---|---|
+| **SYS12** | Sysmon EID 12 *RegistryEvent (Object create/delete)* via EvtxECmd `evtx_sysmon` | `piiat-mitrecar/piiat_mitrecar/mappings/sysmon.py` | `add` (Create\*), `remove` (Delete\*) | **ACTIVE** |
+| **SYS13** | Sysmon EID 13 *RegistryEvent (Value Set)* | `sysmon.py` | `value_edit` | **ACTIVE** |
+| **SYS14** | Sysmon EID 14 *RegistryEvent (Key/Value Rename)* | `sysmon.py` | `key_edit` | **ACTIVE** |
+| **SEC4657** | Security **4657** *registry value modified* | `piiat-mitrecar/to-be-validated/evtx_audit.yml` (spec) | `add`/`value_edit`/`remove` (by `OperationType`) | **QUARANTINED — NOT active** |
+| **PLREG** | Plaso `winreg` (all `windows:registry:*` key/value plugins: run, services, userassist, bam, amcache, shellbags, usb, sam, typedpaths, MRU, …) `plaso_registry` | `plaso_registry.py` | `key_edit` (whole-key snapshot) | **ACTIVE** |
+| **RECMD** | EZ-Tools **RECmd** batch (`--json`) `recmd_batch` | `recmd.py` | `value_edit` (live records; `Deleted:true` → raw) | **ACTIVE** |
+| **MEM** | Volatility3 `windows.piiat.registry` (printkey + hivelist, RECmd-style target list) → PIIAT-Mem CAR passthrough | plugin `piiat-mem/plugins/windows/piiat/registry.py`; map `piiat-mem/piiat_mem/mappings.py` | `value_edit` | **ACTIVE** |
+| **AUTORUNS** | Sysinternals Autoruns (`autoruns_13.98`) | — | (MITRE lists add/key_edit/value_edit) | **NO SOURCE in repo** (honest no-source) |
+| **REGRIPPER** | RegRipper | — | — | **NO SOURCE in repo** (honest no-source) |
+| **SEC4663/4660** | Security 4663 (Key access) / 4660 (object deleted) | 4663-File only in `evtx_audit.yml`; Key path → raw | none for registry | **NO registry mapping** (honest — see §5) |
+
+Notes carried from source:
+- **PLREG value/data/type live in a `values` LIST** the declarative marker set cannot index → they stay in `_native.values`; only `key`/`hive`/`image_path`/`hostname` are canonical columns. So PLREG cannot populate `value`/`data`/`type` as columns even though the data is present.
+- **PLREG `image_path`** = the winreg record's `image_path` (present on **service** rows: the configured `svchost`/service binary). This is the *configured* binary, **not** the process that wrote the key — a field-name near-collision; see caveats.
+- **PLREG `key_edit`** is a **semantic overload**: a registry snapshot = the key as it exists at its `LastWrite`, mapped to `key_edit` (not a literal rename). SYS14 `key_edit` *is* a literal rename.
+- **MEM** host identity: PIIAT-Mem's CAR layer stamps `hostname`/`fqdn` from the in-memory `ComputerName` (and `Tcpip\Parameters`) registry values — the plugin deliberately captures those; the memory registry rows themselves carry `Hive/Key/ValueName/ValueType/ValueData/LastWrite` only.
+- **Evidence grounding**: memory sample `data_store/processed/volatility/memdump.mem/plugins/windows.piiat.registry.jsonl` confirms native fields `Hive, Key, ValueName, ValueType, ValueData, LastWrite`. (No live Sysmon-13 / plaso-winreg registry rows in the current sampled processed corpus — field names below are grounded in map code + generated `sources/*.yaml`, which are introspected from the maps.)
+
+---
+
+## 3. Per-field provenance (the catalogue)
+
+Legend: **Mapped?** = yes (+map location) / NO. **Conf** = confidence the field is faithfully populated.
+
+### `key` — the registry key path (the universal strongest field; every source supplies it)
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS12 → `TargetObject` | add, remove | yes — `sysmon.py:_registry_props` (`key: payload("TargetObject")`) | High — full path. |
+| SYS13 → `TargetObject` | value_edit | yes — `sysmon.py:_registry_props` | High, **caveat**: for a value event the path **includes the value-name segment** (KQL shape kept); the bare value is split into `value`. |
+| SYS14 → `TargetObject` | key_edit | yes — `sysmon.py` | High. |
+| SEC4657 → `ObjectName` | add, value_edit, remove | **NO** (quarantined `evtx_audit.yml`) | High once audit enabled. |
+| PLREG → `key_path` | key_edit | yes — `plaso_registry.py` (`key: _R("key_path")`) | High. |
+| RECMD → `KeyPath` | value_edit | yes — `recmd.py` | High. |
+| MEM → `Key` | value_edit | yes — `mappings.py:windows.piiat.registry` | High — in-memory path (may be `\REGISTRY\MACHINE\SYSTEM\…` NT form). |
+
+### `value` — the value name (value-level sources only)
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS13 → `basename(TargetObject)` | value_edit | yes — `sysmon.py` (`with_value=True`) | Med-High — derived by taking the last path segment; EID 13 is always a value so the split is safe. |
+| SEC4657 → `ObjectValueName` | add, value_edit, remove | **NO** (quarantined) | High. |
+| RECMD → `ValueName` | value_edit | yes — `recmd.py` | High. |
+| MEM → `ValueName` | value_edit | yes — `mappings.py` | High — `""` (default value) is a legitimate identity component. |
+| PLREG → in `values` LIST → `_native.values` | key_edit | **NO** (native only) | Honest null-as-column — data present but the marker set can't index a list; not promoted. |
+| SYS12 / SYS14 | — | n/a | Key-level events carry no value. |
+| AUTORUNS → (value) | add/key_edit/value_edit | **NO SOURCE** | MITRE lists Autoruns for `value`; not ingested here. |
+
+### `data` — the content of the value
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS13 → `Details` | value_edit | yes — `sysmon.py` (`with_data=True`) | High. |
+| SEC4657 → `NewValue` | add, value_edit, remove | **NO** (quarantined) | High. |
+| RECMD → `first(ValueData, ValueData2, ValueData3)` | value_edit | yes — `recmd.py` | High — coalesces RECmd's multi-slot value rendering. |
+| MEM → `ValueData` | value_edit | yes — `mappings.py` | High — bytes rendered hex; **truncated to 2048 chars** in the plugin. |
+| PLREG → in `values` LIST → `_native.values` | key_edit | **NO** (native only) | Honest null-as-column (list, unindexable). |
+| SYS12 / SYS14 | — | n/a | No value content on key events. |
+
+### `type` — the value data type (REG_SZ, REG_DWORD, …)
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| RECMD → `ValueType` | value_edit | yes — `recmd.py` (promoted to canonical column) | High. |
+| MEM → `ValueType` | value_edit | yes — `mappings.py` | High. |
+| SEC4657 → `NewValueType` | add, value_edit | **NO** (quarantined) | High. |
+| PLREG → in `values` LIST → `_native.values` | key_edit | **NO** (native only) | Honest null-as-column. |
+| SYS13 | — | **NO** | **Honest no-source** — Sysmon carries no value type (map comment: "type/hive: Sysmon gives neither"). |
+| SYS12 / SYS14 | — | n/a | — |
+
+### `hive` — the logical hive
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| RECMD → `HiveType` | value_edit | yes — `recmd.py` | High — RECmd's normalized hive designation. |
+| MEM → `Hive` | value_edit | yes — `mappings.py` | High — NT form `\REGISTRY\MACHINE\SYSTEM`. |
+| PLREG → `display_name` | key_edit | yes — `plaso_registry.py` | **Med** — this is the **hive FILE path** (Plaso `display_name`), i.e. the containing hive rendered as a file path, not the `HKEY_*` root symbol. |
+| SEC4657 | — | **NO** (quarantined) | 4657's `ObjectName` embeds the root but no separate hive field; quarantine spec does not set `hive` → honest null. |
+| SYS12 / SYS13 / SYS14 | — | **NO** | **Honest no-source** — Sysmon gives no hive (map: `""` placeholder → null). |
+
+### `new_content` — data/key-name after an edit
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS13 → `Details` | value_edit | yes — `sysmon.py` (`new_content = Details`) | High — the row IS the value_edit; `Details` is the written data = exactly `new_content`. |
+| SEC4657 → `NewValue` | value_edit, add | **NO** (quarantined) | High — 4657 explicitly carries `OldValue`→native + `NewValue`→`new_content`. |
+| RECMD → `first(ValueData, ValueData2, ValueData3)` | value_edit | yes — `recmd.py` | Med — snapshot convention: the value's *current* content is treated as `new_content` (parity w/ Sysmon map); "which value changed last is not per-value attributable" caveat rides with the action. |
+| MEM → `ValueData` | value_edit | yes — `mappings.py` | Med — same snapshot convention (resident data = content after the last edit). |
+| SYS14 → `NewName` | key_edit | **NO** (kept **native**, not mapped to `new_content`) | **GAP** — `NewName` is literally the new key name after a rename = the `new_content` key-name semantic; currently surfaced only in `native_extract`. Promotable. |
+| PLREG | — | n/a | Snapshot has no "after" state (no prior value recorded). |
+
+### `image_path` — the WRITER's binary (live-event sources only)
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS12 / SYS13 / SYS14 → `Image` | add, remove, value_edit, key_edit | yes — `sysmon.py:_registry_props` (`image_path: payload("Image")`) | High — the true process that made the registry access. |
+| SEC4657 → `ProcessName` | add, value_edit, remove | **NO** (quarantined) | High — the writer process image. |
+| PLREG → `image_path` | key_edit | yes — `plaso_registry.py` | **LOW / semantic caveat** — populated only on **service** rows, and it is the **configured** service binary (`svchost`/ImagePath value), **NOT** the process that wrote the key. A field-name near-collision; treat as key content, not writer provenance. |
+| RECMD | — | **NO** | **Honest no-source** — dead hive; writer not recorded. |
+| MEM | — | **NO** | **Honest no-source** — in-memory hive state; writer not recorded. |
+
+### `pid` — the WRITER's pid (live-event sources only)
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS12 / SYS13 / SYS14 → `ProcessId` | add, remove, value_edit, key_edit | yes — `sysmon.py` | High. (Also surfaced as `owning_pid`/`owning_guid` tier-1 link.) |
+| SEC4657 → `hex_int(ProcessId)` | add, value_edit, remove | **NO** (quarantined) | High — 4657's ProcessId is hex; quarantine spec converts. |
+| PLREG | — | **NO** | **Honest no-source** — dead hive. |
+| RECMD | — | **NO** | **Honest no-source** — dead hive. |
+| MEM | — | **NO** | **Honest no-source** — memory hive state (no writer). |
+
+### `user` — user context of the writing process
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS12 / SYS13 / SYS14 → `User` | add, remove, value_edit, key_edit | yes — `sysmon.py` | Med-High — **absent pre-v11 Sysmon** on registry events → honest null then. |
+| SEC4657 → `SubjectUserName` | add, value_edit, remove | **NO** (quarantined) | High — the writer's account. |
+| RECMD → `regex1(HivePath, [/\\]Users[/\\]([^/\\]+)[/\\])` | value_edit | yes — `recmd.py` | **Med** — the **hive owner** from a per-user hive path (`Users/<name>`); **system hives → null**. Owner ≠ necessarily the writer. |
+| MEM → `user_from_hive(Hive)` | value_edit | yes — `mappings.py` | **Med** — hive owner from `NTUSER.DAT`/`UsrClass.dat`; system hives → null. Same owner≠writer caveat. |
+| PLREG → `username` / `hive_user_sid` (regex `S-1-5-21-…`) surfaced **native** | key_edit | **NO** (native only) | **GAP-ish** — SID/username are recovered into `_native` for the end-stage user-attribution join, but the canonical `user` column stays null. Promotable via the hive-owner convention. |
+
+### `hostname`
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS12 / SYS13 / SYS14 → `Computer` (first DNS label) | all | yes — `sysmon.py` (`_HOSTNAME`) | High. |
+| SEC4657 → `host_label(Computer)` | — | **NO** (quarantined) | High once enabled. |
+| PLREG → `image_hostname` | key_edit | yes — `plaso_registry.py` (`hostname: _R("image_hostname")`) | High — image identity stamped by the lane. |
+| MEM → in-memory `ComputerName` (PIIAT-Mem CAR layer) | value_edit | yes (passthrough) | Med — sole memory-native host source; depends on the `ComputerName` key being resident (the plugin targets it explicitly). |
+| RECMD | — | **NO** | **GAP / honest null** — `recmd.py` sets no `hostname`; the RECmd record carries no host stamp (would need out-of-band image context). |
+
+### `fqdn`
+
+| Source → native field | Action(s) | Mapped? | Conf & caveats |
+|---|---|---|---|
+| SYS12 / SYS13 / SYS14 → `Computer` (only if it contains a dot) | all | yes — `sysmon.py` (`_FQDN`) | Med — claimed **only** when `Computer` is genuinely an FQDN; a bare NetBIOS name → honest null (never faked). |
+| SEC4657 → `regex1(Computer, ^([^.]+\.+)$)` | — | **NO** (quarantined) | Med — same discipline. |
+| MEM → `Tcpip\Parameters` Hostname/Domain/DhcpDomain (PIIAT-Mem CAR layer) | value_edit | yes (passthrough, tool-defined) | Med/unknown — the plugin captures `Tcpip\Parameters` for fqdn; whether the CAR layer emits `fqdn` is defined by PIIAT-Mem (passthrough source). |
+| PLREG | — | **NO** | **Honest no-source** — `image_hostname` is a bare name; no domain recorded. |
+| RECMD | — | **NO** | **Honest no-source.** |
+
+---
+
+## 4. Coverage matrix — source × action (which sources fire which action)
+
+| Action | SYS12 | SYS13 | SYS14 | SEC4657 | PLREG | RECMD | MEM |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| `add` | ✅ | — | — | ⛔quar | — | — | — |
+| `remove` | ✅ | — | — | ⛔quar | — | ⛔(Deleted→raw) | — |
+| `key_edit` | — | — | ✅(rename) | — | ✅(snapshot) | — | — |
+| `value_edit` | — | ✅ | — | ⛔quar | — | ✅ | ✅ |
+
+✅ = active mapped · ⛔quar = spec exists but quarantined/inactive · ⛔ = deliberately raw · — = source cannot produce that action.
+
+**Best-covered field**: `key` (all 6 active/quarantined sources). **Thinnest actions**: `add` and `remove` — each has exactly **one active source** (SYS12) plus the quarantined 4657.
+
+---
+
+## 5. Honest no-source / deliberately-raw (not gaps to "fix")
+
+- **Registry `read`** — MITRE has no read action for registry. Security **4663 (ObjectType=Key)** and **4656/4658** key-access events therefore have **no canonical home → raw** (the `evtx_audit.yml` 4663 map is gated `ObjectType=='File'`; a Key access falls through). This is correct, not a gap.
+- **4660 (object deleted) for a registry key** — 4660 carries no `ObjectName` (path lives in the paired 4656/4663 by `HandleId`); the quarantine maps 4660 → **file/delete** only. Recovering a registry `remove` from 4660+4663-Key correlation is **not implemented** (and would need the audit subcategory anyway).
+- **RECmd `Deleted:true`** records (recovered from unallocated) → **raw**: the deletion happened but its *time* is unknowable, so `remove` at the key's last-write would assert a time the evidence lacks.
+- **Autoruns / RegRipper** — MITRE's own `registry.yaml` coverage_map credits `autoruns_13.98` for add/key_edit/value_edit, but **neither tool is ingested in DX_DFIR** → honest no-source here.
+- **PLREG value/data/type as columns** — present in evidence but structurally unindexable (`values` list) → native-only by design.
+
+---
+
+## 6. Summary — coverage & ranked UNMAPPED gaps
+
+**Active coverage (what works today):**
+- Live writer events: **SYS12/13/14** give the full live picture including the WRITER (`image_path`/`pid`/`user`) — the only sources that do. SYS13 is the richest single row (`key`,`value`,`data`,`new_content`,`image_path`,`pid`,`user`,`hostname`,`fqdn`).
+- Dead-hive state: **PLREG** (every `windows:registry:*` → `key_edit`, hundreds of thousands of rows on M57), **RECMD** and **MEM** (per-value → `value_edit` with `hive`/`value`/`data`/`type`/`new_content`/`user`).
+- Every field has ≥1 active source **except** those that are honest no-sources per source.
+
+**Ranked UNMAPPED gaps (highest value first):**
+
+1. **Security 4657 (registry value modified) — QUARANTINED, not active.** The single biggest gap. It is the **only non-Sysmon LIVE source of a registry write**, and it supplies the full high-value set with true writer provenance: `key`←ObjectName, `value`←ObjectValueName, `data`/`new_content`←NewValue, `type`←NewValueType, `image_path`←ProcessName, `pid`←ProcessId, `user`←SubjectUserName, and — via `OperationType` 1904/1905/1906 — **`add`/`value_edit`/`remove`** (would more than double `add`/`remove` source coverage). Multiple CAR analytics (CAR-2021-11-002, CAR-2021-11-001, CAR-2022-03-001, CAR-2021-12-002) key on 4657 `ObjectValueName`/`ObjectName`. Blocker: needs a real audit-enabled capture to validate the `OperationType`→action decisions. Spec is complete in `to-be-validated/evtx_audit.yml`. **Promote when validated.**
+
+2. **SYS14 `NewName` → `new_content` (key rename).** Trivial, live, high-confidence. The rename target is already extracted (native `NewName`) but not promoted to the canonical `new_content` column — the exact key-name-after-edit semantic the field is defined for. One-line map change; no new evidence needed.
+
+3. **PLREG `value` / `data` / `type` trapped in the `values` list.** These populate three canonical columns for the largest registry corpus (disk hives), currently native-only because the declarative marker can't index a list. Would require an engine change (list-flattening / per-value row explosion), but the payoff is large (value/data/type columns across all disk registry state).
+
+4. **PLREG `user`** — `hive_user_sid`/`username` are recovered into native but the canonical `user` column stays null. Promotable via the same hive-owner convention RECMD/MEM already use (honest "hive owner, not writer" caveat).
+
+5. **RECMD `hostname`** — null (no host stamp in the RECmd record). Minor; would need image-context injection at ingest, not derivable from the record alone.
+
+6. **`add`/`remove` breadth.** Even with everything above, `add` and `remove` remain **live-event-only** actions (SYS12 active; 4657 once promoted). No dead-hive source can legitimately produce them (a snapshot cannot distinguish creation from edit; a deleted key isn't in the hive). This is a truth of the evidence, not a fixable gap — worth stating so nobody tries to synthesise `add`/`remove` from Plaso/RECmd/memory.
+
+**No-source (correct, do not "fix"):** registry `read` (no CAR action), 4663/4656/4660-Key for registry, Autoruns/RegRipper (not ingested), RECmd `Deleted` records.

--- a/docs/car-provenance/service.md
+++ b/docs/car-provenance/service.md
@@ -1,0 +1,209 @@
+# Property-Provenance Catalogue — MITRE CAR `service`
+
+Authoritative, exhaustive map of every canonical `service` field to every artefact/source
+that can supply it, in the **DX_DFIR** pipeline. "Find once, done." Grounded in the repo
+files cited; honest about no-source.
+
+- **Object semantics**: `third_party/piiat-mitrecar/third_party/car/data_model/service.yaml`
+- **Canonical schema**: `car_data_model.json` (object `service`) — confirmed by the `service`
+  table in `data_store/processed/volatility/memdump.mem/car.db`.
+- **Canonical fields (10)**: `command_line, exe, fqdn, hostname, image_path, name, pid, ppid, uid, user`
+- **Canonical actions (5)**: `create, delete, pause, start, stop`
+
+`car.db` `service` table columns (real, verified): the 10 canonical fields + provenance
+columns (`event_id, timestamp, car_action, guid, owning_pid, owning_offset, owning_guid,
+parent_pid, parent_guid, link_confidence, source_plugin, source_image, native`).
+
+---
+
+## 1. Source universe (who emits a `service` object, and who *could*)
+
+| # | Source (event/artefact) | Extractor / map | CAR object emitted | Action | Wired? |
+|---|---|---|---|---|---|
+| A | **System 7045** (SCM ServiceInstall) | EvtxECmd → `evtx_services` (`evtx_windows.py`) | **service** | create | YES |
+| B | **Security 4697** (service installed, audited) | EvtxECmd → `evtx_services` (`evtx_windows.py`) | **service** | create | YES |
+| C | **System 20003** (UserPnp — driver-service registration) | EvtxECmd → `evtx_more` (`evtx_more.py`) | **service** | create | YES |
+| D | **System 7034** (SCM — service crashed) | EvtxECmd → `evtx_more` (`evtx_more.py`) | **service** | stop | YES |
+| E | **Volatility3 `windows.svcscan`** (memory) | PIIAT-Mem → `windows.svcscan` (`piiat-mem/.../mappings.py`) | **service** | *None* (store-only snapshot, no ts) | YES |
+| F | **Registry `HKLM\SYSTEM\...\Services`** (Plaso winreg) | Plaso → `plaso_registry` (`plaso_registry.py`) | **registry** (NOT service) | key_edit | YES — but wrong object |
+| G | **Registry Services key** (RECmd/EZ-Tools batch) | RECmd → `recmd_batch` (`recmd.py`) | **registry** (NOT service) | value_edit | YES — but wrong object |
+| H | **Autoruns 13.98** (auto-start services) | CAR upstream sensor only | service | create, delete | **NO** (not in engine) |
+
+Notes:
+- **F/G are the big structural point.** Both parse the on-disk **Services** key (the complete
+  service definition — `ImagePath`, `Start`, `Type`, `ObjectName`, `DisplayName`, `ServiceDll`),
+  but the maps emit a **registry** object (key_edit/value_edit). The service facts survive only
+  in `_native` (see §3). **On a dead-disk image the pipeline therefore emits zero `service`
+  objects today** — the whole object is present in the evidence but not reconstructed.
+- **H Autoruns is NOT wired**: `grep autoruns` over `piiat_mitrecar/` and `python/` is empty.
+  The `coverage_map` in `service.yaml` (`create`/`delete` → `["autoruns_13.98"]`) and
+  `sensors/autoruns_13.98.yaml` are **upstream CAR references**, not working sources here.
+- **Sysmon / osquery**: CAR's own `sensors/sysmon_*.yaml` and `sensors/osquery_*.yaml` carry
+  **no** `service` coverage; the repo's `sysmon.py` emits no service object. Sysmon EID 6 is a
+  driver load → `driver` object, not `service`.
+- **amcache**: consumed by `plaso_exec_winreg` as *process/execution* evidence, not service.
+
+---
+
+## 2. Per-field provenance (EVERY field × EVERY source)
+
+Legend for native field → canonical: `[direct]` verbatim · `[derived]`/`[parsed]`
+transformed (basename/exe_path/host_label) · `[coalesced]` first-non-empty of several ·
+`[inferred]` conditional (fqdn only if dotted).
+
+### `name`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| 7045 → `ServiceName`; 4697 → `ServiceName`; 20003 → `ServiceName`; 7034 → `param1`; svcscan → `Name`; registry(F) → `name` *(native only)*; RECmd(G) → subkey/`ValueName` *(native only)*; autoruns → name *(upstream)* | create (A/B/C), stop (D), snapshot (E) | **YES** — A/B `evtx_services`, C/D `evtx_more`, E `windows.svcscan` all set canonical `name` [direct]. F/G carry it but as registry native, not a `service.name`. | HIGH. The one field every emitter fills. 7034 `param1` is the *display name*, not always the registry key name (near-match caveat). |
+
+### `image_path`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| 7045/4697 → `ImagePath`/`ServiceFileName` (parsed via `exe_path`); 20003 → `DriverFileName`; svcscan → `Binary` \| `Binary (Registry)` (parsed); registry(F) → `image_path` *(promoted to registry.image_path, not service)*; RECmd(G) → ImagePath value *(native)*; autoruns *(upstream)* | create (A/B/C), snapshot (E) | **YES** — A/B/C/E set canonical `image_path` [parsed/direct]. F sets it on the **registry** object. | HIGH. `exe_path()` splits the executable out of an ImagePath that embeds args (`svchost.exe -k …`) — a parse, not a guess. svcscan `Binary` is null for STOPPED services → falls back to `Binary (Registry)`. |
+
+### `exe`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| Derived `basename(image_path)` for every image_path source: 7045/4697, 20003, svcscan; autoruns *(upstream)* | create (A/B/C), snapshot (E) | **YES** — A/B/C/E. | HIGH, fully derived. Inherits the STOPPED-service fallback caveat from `image_path`. No independent artefact carries `exe` alone. |
+
+### `command_line`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| 7045/4697 → `ImagePath`/`ServiceFileName` **verbatim** (incl. args); svcscan → `Binary (Registry)` [direct]; registry(F/G) → ImagePath value *(native only)*; autoruns *(upstream)* | create (A/B), snapshot (E) | **YES** — A/B (`_SVC_RAW`), E (`command_line: "Binary (Registry)"`). | HIGH. **Distinct from `image_path`**: `command_line` keeps the raw ImagePath *with* trailing args; `image_path`/`exe` parse the bare path out. **NOT** carried by 20003 (C) or 7034 (D) — honest null there. |
+
+### `user`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| 7045 → `AccountName`; 4697 → `ServiceAccount` (fallback `UserName`); registry(F) → `object_name`/`ObjectName` *(native only)*; autoruns *(upstream)* | create (A/B) | **YES** — A/B only (`user: first(AccountName, ServiceAccount, UserName)`). | MEDIUM-HIGH. This is the **run-as** account (LocalSystem, NT AUTHORITY\…), usually a *name* not a SID. 4697 `SubjectUserName` (who *installed*) is a different entity and is deliberately **not** coalesced here. **NOT** from svcscan/20003/7034. Registry `ObjectName` is the same run-as value but sits in registry native — an unmapped opportunity. |
+
+### `hostname`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| 7045/4697/20003/7034 → `Computer` (first DNS label, `host_label`); registry(F) → `image_hostname` *(on registry object)* | create (A/B/C), stop (D) | **YES** — A/B/C/D [derived]. | HIGH for evtx. **svcscan (E) sets NO hostname** — the memory service map has no host label (honest null; enrichment/`image_context` supplies host at store level). |
+
+### `fqdn`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| 7045/4697/20003/7034 → `Computer` **iff dotted** (`regex1` `^(.+\..+)$`) | create (A/B/C), stop (D) | **YES** — A/B/C/D [inferred]. | MEDIUM. Only populated when `Computer` actually is an FQDN; a bare NetBIOS name is left null rather than faked. **NOT** from svcscan/registry. |
+
+### `pid`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| **svcscan → `PID`** [direct] | snapshot (E) | **YES — svcscan ONLY** | HIGH but single-source. **This is the field only a running-state source can supply.** 7045/4697 do **not**: an install is not a run, and their `ProcessId` column is the *event writer* (services.exe/lsass), not the service — deliberately left null. 7036 (state=Running) *could* carry it but is unmapped (§4). `pid` here is the running host process (often a shared svchost). |
+
+### `ppid`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| — none — | — | **NO — no source** | **Honest no-source.** No wired artefact records a service's parent PID as a service field. (svcscan yields `pid` but not a parent; the SCM `services.exe` is the conceptual parent but no map asserts it.) Structural null. |
+
+### `uid`
+| sources (source → native field) | action(s) | currently mapped? | confidence & caveats |
+|---|---|---|---|
+| *(candidates, all unmapped)*: 4697 `SubjectUserSid` (installer, native); 7045 `UserId` (writer's SID, native); registry(F) `hive_user_sid` (hive owner, not run-as) | — | **NO — no mapped source** | **Honest near-no-source.** `service.uid` per the model = SID of the user who *acted on* the service (e.g. `S-1-5-18`). The only SIDs in the evidence are the *installer* (4697 Subject) or the *record writer* (7045 UserId) — both deliberately kept native, never promoted, because neither is the run-as identity that `user` names. No source cleanly fills `uid`. |
+
+---
+
+## 3. What the registry sources hold but do NOT emit as `service` (the reconstruction gap)
+
+`plaso_registry` (F) surfaces these into `_native` on a **registry/key_edit** row for each
+`windows:registry:service` key — the complete service definition, unused as a service object:
+
+- `name` (service key name), `object_name` (= run-as `ObjectName`), `image_path` (the binary),
+  `start_type` (`Start`), `service_type` (`Type`), `service_dll` (svchost `ServiceDll`),
+  `error_control`, plus the `values` list and `hive_user_sid`.
+
+`recmd_batch` (G) emits one **registry/value_edit** per matched Services value
+(`ValueName`/`ValueData`) — same facts, value-granular, also not a service object.
+
+→ Everything needed for a `service/create` **from a dead disk** (name, image_path,
+command_line via ImagePath, user via ObjectName, start_type, service_dll) is present here but
+lives under the wrong object.
+
+---
+
+## 4. Action coverage & deliberate refusals
+
+| action | mapped source(s) | gap |
+|---|---|---|
+| **create** | 7045 (A), 4697 (B), 20003 (C) | Covered for live/audited installs. Missing dead-disk create (registry F/G) + autoruns (H). |
+| **stop** | 7034 (D) — *crash only* (involuntary) | No *clean/voluntary* stop source (7036 stop-state unmapped). |
+| **delete** | — none — | **No source.** autoruns (upstream) does delete via diff; registry-key-removal is not detected. |
+| **pause** | — none — | **No source anywhere.** No artefact records a service pause. |
+| **start** | — none — | **No mapped source.** 7036 (state → Running) and svcscan `State=Running` are *snapshots*, not start events; deliberately not turned into a `start`. |
+
+**Deliberately NOT mapped (documented honest refusals in the code):**
+- **7040** (start-type changed) — the `service` object has no `modify`/config action, so it
+  stays raw (`evtx_extra.py` header).
+- **7036** (service entered Running/Stopped state) — "no canonical action here"
+  (`evtx_windows.py:290`); mapping a state report to start/stop would over-assert.
+- **svcscan** is `action=None` (store-only): its `State`/`Start`/`Type` native fields carry
+  live status but are **not** promoted to a start/stop action.
+- 7009/7011/7031/7042/7000/4698 — not mapped.
+
+---
+
+## 5. Coverage summary + UNMAPPED gaps (ranked)
+
+**Field coverage of the 10 canonical fields (as `service` objects, today):**
+
+| field | emitted by | verdict |
+|---|---|---|
+| name | A,B,C,D,E | full |
+| image_path | A,B,C,E | full |
+| exe | A,B,C,E | full (derived) |
+| command_line | A,B,E | good (not C/D) |
+| user | A,B | evtx-install only (run-as) |
+| hostname | A,B,C,D | evtx only (not memory) |
+| fqdn | A,B,C,D | evtx only, conditional |
+| **pid** | **E only** | single-source |
+| **ppid** | — | **no source** |
+| **uid** | — | **no mapped source** |
+
+8/10 fields have at least one live source; `ppid` and `uid` are structural no-sources.
+Actions: `create` + (crash-only) `stop` mapped; `delete`/`pause`/`start` unmapped.
+Real-evidence note: the light test set (`car.db`, EvtxECmd `unspecified_host`) contains **0**
+service rows — the `windows.svcscan` plugin wasn't run in the memory image, and the EvtxECmd
+sample carries none of the service EventIds. The maps are real; this evidence set is thin.
+
+**UNMAPPED gaps, ranked by impact:**
+
+1. **Registry `Services` key → the whole `service` object from a dead disk.** *Highest impact.*
+   `plaso_registry` (F) and `recmd_batch` (G) already parse HKLM\...\Services and hold every
+   field in `_native` (name, image_path, command_line, user/ObjectName, start_type,
+   service_type, service_dll) — but emit **registry** objects. A dead-disk image yields **zero**
+   `service` objects. A service-reconstruction map (or an enrichment pass over the registry
+   native) would light up create for offline images.
+
+2. **memory `svcscan` → running state → `start`/`stop` actions (and it is the sole `pid`).**
+   svcscan is store-only (`action=None`). Its `State` (Running/Stopped) and `Start`
+   (Auto/Demand/Disabled) are captured in native but not turned into an action, and it is the
+   **only** source of `service.pid`. Deriving a `start` (or a live `stop`) from `State`, and
+   propagating `pid`, would fill the running-instance gaps that evtx installs cannot.
+
+3. **`delete` / `pause` actions — no source at all.** delete needs autoruns-diff or
+   registry-key-removal detection; pause has no artefact. Genuine coverage holes.
+
+4. **Autoruns (H) not wired.** CAR's canonical service create/delete sensor is absent from the
+   engine; wiring an autoruns adapter would add the only current path to `service/delete`.
+
+5. **`user` from registry `ObjectName`, and `uid`/`ppid`.** The registry run-as `ObjectName`
+   is captured in native (F) but not promoted to `user`; `uid` and `ppid` have no clean source
+   in any wired artefact (honest structural nulls).
+
+---
+
+## 6. File index (grounding)
+
+- Semantics: `third_party/piiat-mitrecar/third_party/car/data_model/service.yaml`
+- Canonical schema: `car_data_model.json` (object `service`); live `car.db` `service` table
+- Maps (emit service): `third_party/piiat-mitrecar/piiat_mitrecar/mappings/evtx_windows.py`
+  (7045/4697), `.../evtx_more.py` (20003, 7034); `third_party/piiat-mem/piiat_mem/mappings.py`
+  (`windows.svcscan`)
+- Maps (hold service facts, emit registry): `.../mappings/plaso_registry.py`, `.../mappings/recmd.py`
+- Refusals: `.../mappings/evtx_extra.py` (7040), `evtx_windows.py:290` (7036)
+- Sources (generated coverage): `sources/evtx_services.yaml`, `sources/evtx_more.yaml`,
+  `sources/memory.yaml`
+- Upstream (not wired): `.../car/sensors/autoruns_13.98.yaml`
+- Relations/analytics: `docs/CAR-Relations.md` (R7 service→process, 20003/7034 counts);
+  `.../car/analytics/CAR-2021-05-012.yaml` (Service:create, image_path),
+  `CAR-2021-02-002.yaml` (service/create/command_line)

--- a/docs/car-provenance/socket.md
+++ b/docs/car-provenance/socket.md
@@ -1,0 +1,149 @@
+# Property-Provenance Catalogue — MITRE CAR `socket`
+
+**Object:** `socket` — *"Socket events are low-level events that may or may not result in a flow. Socket
+listening events in particular can be helpful in detecting malicious activity."*
+**Canonical fields (10):** `family`, `image_path`, `local_address`, `local_path`, `local_port`, `pid`,
+`protocol`, `remote_address`, `remote_port`, `success`
+**Actions (3):** `bind`, `listen`, `close`
+**Repo:** `/opt/github/DX_DFIR` — READ-ONLY audit, evidence as of 2026-09-07.
+
+Grounded in:
+- `third_party/piiat-mitrecar/third_party/car/data_model/socket.yaml` + `docs/data_model/socket.md` (semantics + upstream coverage map)
+- `car_data_model.json` (canonical field/action list — matches the object header above exactly)
+- `third_party/piiat-mitrecar/model/{car,projection}/objects/socket.yml` (reconstructed CAR object + ECS projection)
+- CAR sensors `third_party/piiat-mitrecar/third_party/car/sensors/{osquery_4.6.0,auditd_2.8}.yaml`
+
+---
+
+## TL;DR — the honest state
+
+- **Exactly ONE active socket source ships in this pipeline: MEMORY (Volatility 3 netscan/netstat / `windows.piiat.network`) via PIIAT-Mem → CAR `socket`/`listen`.** It is the primary (only) dead-box socket source.
+- That memory source only produces the **`listen`** action and only the **local-end** fields (`local_address`, `local_port`, `protocol`, `family`, `pid`, `success`) + `image_path` **by enrichment**. It never asserts `remote_*` or `local_path`, and never `bind`/`close`.
+- **Windows Security 5158 (WFP bind) → `socket`/`bind` exists but is INERT** — quarantined in `third_party/piiat-mitrecar/to-be-validated/evtx_audit.yml`, not in the active `mappings/` package.
+- **Sysmon 3, WFP 5156/5157 are mapped to `flow`, NOT `socket`** (deliberate — the connection "as made"). **5031 firewall block is not referenced anywhere in the repo.**
+- No `socket` source exists for **`remote_address`, `remote_port`, `local_path`, or the `close` action** — honest no-source (matches even the upstream CAR coverage map, which leaves `local_path` and `success` empty and has no non-osquery sensor).
+- **The current evidence corpus contains ZERO socket rows** — no netscan/netstat/`piiat.network` output was collected into `data_store/processed/volatility/…`, and the EvtxECmd corpus has only Sysmon 1/5 (no 5158, no Sysmon 3). The capability is present but unexercised.
+
+---
+
+## Source universe (what can, in principle, supply a `socket` row) — status in THIS repo
+
+| Source | Native table/event | → CAR object here | socket status |
+|---|---|---|---|
+| **Volatility 3 `windows.netscan` / `windows.netstat` / `windows.piiat.network`** (PIIAT-Mem) | bound/LISTENING pooled `_TCP/UDP` endpoint objects | **`socket`/`listen`** (via `is_bound_socket` predicate) | **ACTIVE** — `third_party/piiat-mem/piiat_mem/mappings.py` `_SOCKET_MAP` |
+| **Security 5158** (WFP "connection bind allowed") | `SourceAddress/SourcePort/Protocol/Application/ProcessID` | **`socket`/`bind`** | **INERT** — `to-be-validated/evtx_audit.yml` key `security_5158_wfp_bind` |
+| osquery 4.6.0 `socket_events` | (bind/listen/close) | `socket` bind/listen/close **(upstream CAR coverage map only)** | **NOT INGESTED** — no osquery collector or mapping in this repo |
+| Sysmon 3 (NetworkConnect) | `SourceIp/DestinationIp/…/Initiated` | **`flow`/`start`** (`mappings/sysmon.py` EID 3) | routed to flow, **not socket** |
+| Security 5156 / 5157 (WFP conn allowed/blocked) | `SourceAddress/DestAddress/…` | **`flow`** start/message | routed to flow (5156/5157 in the same `to-be-validated` file) |
+| Security 5031 (firewall blocked an app) | — | — | **not referenced anywhere in repo** |
+| Linux auditd `SOCKADDR` / `ss` / `netstat` / `/proc/net` / systemd:journal | `saddr` (AF_UNIX path, AF_INET addr/port) | — | **NOT IMPLEMENTED** — `mappings/plaso_linux.py` emits only `user_session` + `file` |
+| Vol2 `sockscan`/`sockets` | — | — | not used (Vol3 line; superseded by netscan) |
+| Zeek/Suricata | conn/flow records | `flow` / `http` (flow-side) | not socket |
+
+---
+
+## Per-field provenance
+
+Legend — **action**: which socket action the row carries. **mapped?**: `yes+where` / `INERT+where` / `NO`.
+`native → field` is the source column feeding the CAR field.
+
+### `family` — AF_INET / AF_INET6 / AF_UNIX (socket type)
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Vol3 netscan `Proto` → `family()` | listen | **yes** — piiat-mem `mappings.py` `_SOCKET_MAP` (`family("Proto")`) | **Med.** Value form diverges: emits **`ipv4`/`ipv6`** (ECS-style, from `TCPv4`→`ipv4` in `normalize.py`), **not** the CAR-documented `AF_INET`/`AF_INET6`. Consequence: the STIX `_b_socket` `socket-ext` gate (`str(fam).startswith("AF_")` in `stix.py:995`) never fires, so `address_family`/`is_listening` are dropped from the STIX SCO — though the CAR field itself is populated. Windows memory is only ever ipv4/ipv6, **never AF_UNIX**. |
+| Security 5158 WFP | bind | **NO** — 5158 map omits `family` entirely | — |
+| osquery `socket_events` | bind/listen/close | NO (not ingested) | upstream coverage lists osquery for family |
+
+### `image_path` — path to the executable that acted on the socket
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Vol3 netscan (owning process) | listen | **yes (by ENRICHMENT)** — piiat-mem `enrich.py` `_INHERIT` (line 72) fills `image_path` from the owning process | **High.** NOT native to the netscan row (netscan `Owner` = `ImageFileName`, the process **name** only, no path — `plugins/windows/piiat/network.py:17`). Filled from the owner's `image_path`, joined **definitively** on `OwnerOffset` (the kernel `_EPROCESS` pointer), falling back to (reusable) PID. Null if the owning process isn't recovered. |
+| Security 5158 WFP `Application` → `image_path` | bind | **INERT** — `to-be-validated/evtx_audit.yml` (`image_path: Application`) | Native full path when promoted; inert today. |
+| osquery `socket_events` | bind/listen/close | NO (not ingested) | upstream coverage lists osquery |
+
+### `local_address` — IP the socket accepts on (no port)
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Vol3 netscan `LocalAddr` → `local_address` | listen | **yes** — `_SOCKET_MAP` | **High.** `0.0.0.0`/`::` legitimately appears for wildcard listeners (also the `is_bound_socket` trigger). |
+| Security 5158 WFP `SourceAddress` → `local_address` | bind | **INERT** — `to-be-validated/evtx_audit.yml` | High once promoted. |
+| osquery `socket_events` | bind/listen/close | NO (not ingested) | upstream |
+
+### `local_path` — AF_UNIX socket filesystem path (`/tmp/foo`)
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| — | — | **NO SOURCE (honest gap)** | Only a **Linux/AF_UNIX** concept. Would require **auditd `SOCKADDR`** (`saddr` unix path) — not implemented (`plaso_linux.py` has no socket mapping). Windows memory netscan is IP-only; 5158 has no path. **Even the upstream CAR coverage map leaves `local_path` empty for all three actions** (`docs/data_model/socket.md`). The ECS projection reserves `local_path → file.path` (`model/projection/objects/socket.yml`), but nothing feeds it. |
+
+### `local_port` — bound port at the local end
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Vol3 netscan `LocalPort` → `local_port` | listen | **yes** — `_SOCKET_MAP` | **High.** |
+| Security 5158 WFP `SourcePort` → `local_port` | bind | **INERT** — `to-be-validated/evtx_audit.yml` | High once promoted. |
+| osquery `socket_events` | bind/listen/close | NO (not ingested) | upstream |
+
+### `pid` — process that acted on the socket
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Vol3 netscan `PID` → `pid` (+ `owning_pid=PID`, `owning_offset=OwnerOffset`) | listen | **yes** — `_SOCKET_MAP` | **High.** The `pid` value is the heuristic/reusable owner PID (kept for humans); the **definitive** process linkage is `OwnerOffset` (`network.py:16` "reusable PID is only a heuristic"). |
+| Security 5158 WFP `ProcessID` (**decimal**) → `pid` | bind | **INERT** — `to-be-validated/evtx_audit.yml` | Note: WFP `ProcessID` is decimal (unlike hex 4663 `ProcessId`). |
+| osquery `socket_events` | bind/listen/close | NO (not ingested) | upstream |
+
+### `protocol` — TCP / UDP
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Vol3 netscan `Proto` → `transport()` → `TCP`/`UDP` | listen | **yes** — `_SOCKET_MAP` (`transport("Proto")`) | **High.** Clean `TCPv4`→`TCP` extraction (`normalize.py`). |
+| Security 5158 WFP `Protocol` → `protocol` (**raw**) | bind | **INERT** — `to-be-validated/evtx_audit.yml` | **Caveat:** mapped **raw** (numeric IP proto `6`/`17`), *not* normalized — unlike sibling 5156/5157 which apply `map_value(Protocol,{6:tcp,17:udp})`. Fix on promotion. |
+| osquery `socket_events` | bind/listen/close | NO (not ingested) | upstream |
+
+### `remote_address` — IP at the remote end
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| — | — | **NO SOURCE (by design)** | A socket with a live remote end **is a connection → modeled as `flow`, not `socket`** in every producer here. Memory netscan keeps `ForeignAddr` only as `keep` native (never mapped to `remote_address`); non-listening rows route to `_FLOW_MAP`. 5158 `bind` is local-only. The STIX/`_network` plumbing (`stix.py:989`) *reads* `remote_address` if present, but no mapping ever sets it. osquery upstream lists it, but osquery isn't ingested. |
+
+### `remote_port` — port at the remote end
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| — | — | **NO SOURCE (by design)** | Same as `remote_address`: a remote endpoint means it's a `flow`. `ForeignPort` retained as native only. |
+
+### `success` — did the socket op succeed
+| source (native → field) | action | mapped? | confidence & caveats |
+|---|---|---|---|
+| Vol3 netscan → `const(True)` | listen | **yes** — `_SOCKET_MAP` (`"success": const(True)`) | **High-but-inferential.** Not observed — **proven by existence**: "a kernel socket object exists only after a successful bind/listen" (`mappings.py:51`, CHANGELOG). Never `false` (no failure events captured). |
+| Security 5158 WFP → `const(true)` | bind | **INERT** — `to-be-validated/evtx_audit.yml` (`success: const(true)`) | Same existence inference (5158 is the *allowed* bind). A *blocked* bind has no distinct EID mapped. |
+| osquery `socket_events` | — | NO | **Upstream CAR coverage map also leaves `success` EMPTY** — no sensor supplies it upstream either. |
+
+---
+
+## Action coverage
+
+| action | source(s) | mapped? | note |
+|---|---|---|---|
+| **`listen`** | Vol3 memory netscan/netstat/`piiat.network` | **yes (ACTIVE)** — piiat-mem `_SOCKET_MAP action=listen` | A memory snapshot sees the **steady-state** listener → `listen`. This is the entire active socket object. |
+| **`bind`** | Security 5158 WFP | **INERT** — `to-be-validated/evtx_audit.yml` | Schema-grounded, not sample-verified; absent from all corpora. |
+| **`close`** | — | **NO SOURCE** | No producer emits `close`: a memory snapshot can't observe a close transition; no WFP close EID is mapped; osquery upstream has it but isn't ingested. |
+
+Minor: the cascade verb map (`piiat_mitrecar/cascade_relationships.yml:38`) declares only `socket: bind: "bound to"` — the **active `listen`** action falls through to `default_spoke_verb: accessed`. Cosmetic (STIX/relations narration), not a data gap.
+
+---
+
+## Coverage summary
+
+**What ships (active):** memory-only, `listen`-only, local-end-only.
+`socket`/`listen` from Vol3 netscan/netstat/`windows.piiat.network` → `local_address`, `local_port`,
+`protocol`, `family`(as ipv4/ipv6), `pid`, `success`(const) natively + `image_path` by owner-inheritance.
+Windows AF_INET/INET6 only. 4 of 10 fields have **no** active source (`local_path`, `remote_address`,
+`remote_port`, and — for the `bind`/`close` actions — everything).
+
+**What's built but inert:** `socket`/`bind` from **WFP 5158** (`to-be-validated/evtx_audit.yml`) — adds the
+`bind` action + `local_address`/`local_port`/`protocol`/`image_path`/`pid`/`success`.
+
+**What has no source at all:** `local_path` (AF_UNIX / auditd), `remote_address`/`remote_port` (those are
+`flow` by design), the `close` action.
+
+### UNMAPPED gaps, ranked
+
+1. **Memory socket capability ACTIVE but UNEXERCISED in the corpus (collection gap).** `data_store/processed/volatility/memdump.mem/plugins/` contains only `banners`, `mftscan`, `piiat.processes`, `piiat.registry`, `piiat.sessions`, `pslist` — **no `netscan`/`netstat`/`windows.piiat.network` output**. So the *entire* listen/bind socket object is invisible in current evidence. **Fix: run `windows.piiat.network` (or `netscan`/`netstat`) over `memdump.mem`** — the map already handles the output 1:1 (passthrough via `pipeline.py:150`). Highest value, zero code.
+2. **Promote WFP 5158 (`to-be-validated/evtx_audit.yml` → active `mappings/*.py`).** The only path to the **`bind`** action and to socket coverage from Windows event logs. Needs a capture with the *Filtering Platform Connection* auditpol subcategory enabled to validate, then port back (prior impl in git history: `mappings/evtx_audit.py`). **On promotion, fix `protocol` to normalize** (`map_value(Protocol,{6:tcp,17:udp})`) rather than passing the raw numeric, to match the memory source's `TCP`/`UDP`.
+3. **`family` value-form normalization.** Memory emits `ipv4`/`ipv6`; the STIX `socket-ext` gate expects `AF_*` and silently drops the extension. Decide one canonical form (CAR docs say `AF_INET`; ECS projection says `ipv4`) and align emitter + STIX gate.
+4. **`remote_address`/`remote_port` — no socket source (by design).** Only worth revisiting if an *established* (non-listening) endpoint should ever be represented as `socket` rather than `flow`. Currently intentional; low priority.
+5. **`local_path` (AF_UNIX) — true no-source.** Would require **Linux auditd `SOCKADDR`** ingestion (`plaso_linux.py` currently emits only `user_session` + `file`). Even upstream CAR has no source for it. Lowest priority.
+6. **`close` action — no source anywhere.** Would need a lifecycle-observing sensor (osquery `socket_events`, ETW, or auditd) that this pipeline doesn't ingest.

--- a/docs/car-provenance/thread.md
+++ b/docs/car-provenance/thread.md
@@ -1,0 +1,220 @@
+# CAR `thread` — Property-Provenance Catalogue
+
+Authoritative "find once, done" map of every canonical `thread` field to every artefact/source
+in this repo that can supply it. Grounded in the pinned CAR data model, the two live CAR engines
+(EVTX/Sysmon lane = `piiat-mitrecar`; memory lane = `piiat-mem`), and the current processed evidence.
+READ-ONLY analysis.
+
+## Canonical object (authoritative)
+
+Source of truth: `/opt/github/DX_DFIR/car_data_model.json` (lines 337-363) and
+`third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`.
+
+- **Fields (15):** hostname, src_pid, src_tid, tgt_pid, tgt_tid, stack_base, stack_limit,
+  start_address, start_function, start_module, start_module_name, user, uid,
+  user_stack_base, user_stack_limit
+- **Actions (4):** create, remote_create, suspend, terminate
+
+Semantics that drive the whole catalogue (from `thread.yaml`):
+- `src_pid`/`src_tid` = **the CREATOR** — the process/thread that *created* the new thread.
+- `tgt_pid`/`tgt_tid` = **the new thread** — the process it runs in + the new thread's id.
+- `remote_create` = a `create` where `src_pid != tgt_pid` (cross-process = injection).
+- `user` = "the user context in which the **source** thread was running" — impersonation-aware,
+  may differ from the process user.
+- `stack_*` / `user_stack_*` = live TEB/KTHREAD stack bounds — a **runtime memory** concept.
+
+## The two source lanes in this repo
+
+| Lane | Engine | Object/action emitted | Where |
+|---|---|---|---|
+| **Sysmon EID 8 (CreateRemoteThread)** | `piiat-mitrecar` | `thread/remote_create` | `piiat_mitrecar/mappings/sysmon.py` L442-467; source card `sources/evtx_sysmon.yaml` L319-339 |
+| **Memory / Volatility 3** | `piiat-mem` | `thread/create` | plugin `plugins/windows/piiat/threads.py`; map `piiat_mem/mappings.py` L204-222 (+ built-in fallback `windows.thrdscan` L261-272) |
+
+Sysmon EID 8 is the ONLY host/log artefact in the repo that maps to `thread` (all three pinned CAR
+sensor cards — `sysmon_10.4`, `sysmon_11.0`, `sysmon_13` — cover `thread` only via EID 8; no
+osquery/auditd/EDR/ETW thread source exists here). The **Plaso `l2t_winevt` adapter** is an
+*alternate derivation of the same Sysmon EID 8 record* (identical field list —
+`piiat_mitrecar/adapters/winevt.py` L95-98), feeding the same `evtx_sysmon` map; it is not an
+independent source, so it is folded into the Sysmon column below.
+
+### Critical honesty note — the raw Sysmon EID 8 event has NO SourceUser and NO source TID
+
+The upstream CAR sensor `coverage_map` (`thread.yaml` L60-71) and the `sysmon_13.yaml` card claim
+EID 8 supplies `src_tid`, `uid`, and `user` directly. **That overclaims.** The actual Sysmon
+CreateRemoteThread record carries only: `SourceProcessGuid/Id`, `SourceImage`,
+`TargetProcessGuid/Id`, `TargetImage`, `NewThreadId`, `StartAddress`, `StartModule`,
+`StartFunction` (confirmed by both the engine map L453-466 and the Plaso adapter field list
+L95-98). There is **no `SourceUser`** and **no source-thread id** in the event. This repo's engine
+is the honest one: it maps only what is present, and fills `user`/`hostname` via enrichment.
+
+---
+
+## Per-field provenance — action `remote_create` (Sysmon EID 8)
+
+Map: `piiat_mitrecar/mappings/sysmon.py` L448-467. Owner link = `SourceProcessGuid` (tier-1
+definitive). Enrichment inheritance from the owning **source** process: `piiat_mitrecar/
+relationships.yml` L21-29 (`exe, image_path, command_line, user, sid, fqdn, hostname, ppid`).
+
+| field | source → native field | action | currently mapped? (yes+where / NO) | confidence & caveats |
+|---|---|---|---|---|
+| hostname | Sysmon EID 8 → `Computer` (first DNS label) | remote_create | **yes** — sysmon.py L462 `hostname:_HOSTNAME`; also enrich-inheritable | high. Derived (first label of Computer). |
+| src_pid | Sysmon EID 8 → `SourceProcessId` | remote_create | **yes** — sysmon.py L454 `src_pid:payload("SourceProcessId")` | high, direct. The creator/injector process = the ACTING/owner process. |
+| src_tid | — (no source-thread id in EID 8) | remote_create | **NO** | HONEST NO-SOURCE. Sysmon does not record the creating thread. Not recoverable from EID 8. |
+| tgt_pid | Sysmon EID 8 → `TargetProcessId` | remote_create | **yes** — sysmon.py L455 `tgt_pid:payload("TargetProcessId")` | high, direct. The injected (target) process. |
+| tgt_tid | Sysmon EID 8 → `NewThreadId` | remote_create | **yes** — sysmon.py L456 `tgt_tid:payload("NewThreadId")` | high, direct. The new thread's id. |
+| stack_base | — | remote_create | **NO** | HONEST NO-SOURCE for EID 8. Stack bounds are a live-memory (KTHREAD) concept; not in the event. Memory only (see `create`). |
+| stack_limit | — | remote_create | **NO** | HONEST NO-SOURCE for EID 8. Memory only. |
+| start_address | Sysmon EID 8 → `StartAddress` | remote_create | **yes** — sysmon.py L457 `start_address:payload("StartAddress")` | high, direct. THE injection evidence (entry point of the injected thread). |
+| start_function | Sysmon EID 8 → `StartFunction` | remote_create | **yes** — sysmon.py L460 `start_function:payload("StartFunction")` | high, direct. Sysmon resolves the export (e.g. `LoadLibraryA`) — the CAR-2013-10-002 detector key. Present only when Sysmon could resolve it. |
+| start_module | Sysmon EID 8 → `StartModule` | remote_create | **yes** — sysmon.py L458 `start_module:payload("StartModule")` | high, direct. The module the start address resides in. |
+| start_module_name | Sysmon EID 8 → `basename(StartModule)` | remote_create | **yes** — sysmon.py L459 `start_module_name:basename(payload("StartModule"))` | high, derived (basename). |
+| user | Sysmon EID 8 → (NOT in event) → **enrich-inherited** from the SOURCE process (`SourceProcessGuid` owner) | remote_create | **yes (indirect)** — not in map; filled by enrich `_inherit` from owning source process (relationships.yml L25) | medium. NOT from the thread event itself; inherited (definitive link) = the source process's user. Cannot capture thread-level impersonation (semantic gap vs CAR's "source thread's user context"). Null if the source EID 1 create is absent from the same source_host. |
+| uid | — (see caveat) | remote_create | **NO** | GAP. `thread` has `uid` (not `sid`); the Sysmon-lane inherit list carries `sid`, and `thread` has no `sid` field, so nothing fills `uid`. (Contrast the memory lane, which inherits `uid`.) Fixable by adding `uid` to `from_owning_process` or a sid→uid inherit. |
+| user_stack_base | — | remote_create | **NO** | HONEST NO-SOURCE for EID 8. TEB-only → memory. |
+| user_stack_limit | — | remote_create | **NO** | HONEST NO-SOURCE for EID 8. TEB-only → memory. |
+
+**Bonus / relationship (not a canonical field):** `TargetProcessGuid` is surfaced native
+(sysmon.py L466) and consumed by **R5 thread-injection dual-link** (`piiat_mitrecar/enrich.py`
+L488-498; `docs/CAR-Relations.md` L154): owner = source process, and
+`_native.target_process_guid` = the injected target (both definitive by ProcessGuid). This is the
+dual-link that makes the injection edge explicit. `TargetImage` stays native (no CAR thread field).
+
+---
+
+## Per-field provenance — action `create` (Memory / Volatility 3)
+
+Plugin: `third_party/piiat-mem/plugins/windows/piiat/threads.py` (pool-tag scan = finds unlinked /
+hidden threads). Map: `piiat_mem/mappings.py` L204-222. Owner link = `OwnerOffset`
+(`_ETHREAD.Tcb.Process` → owning `_EPROCESS` offset, tier-1 definitive). Enrichment: host identity
+from the image's own registry (`enrich.py` L309-318) + inheritance from the owning process
+(`_INHERIT` incl. `user, sid, uid, hostname` — `enrich.py` L72, L288-291, L377-380).
+
+> The memory lane emits action **`create`**, never `remote_create`: a snapshot records the thread's
+> existence and its OWNING process, but not *who created it* — so `src_pid`/`src_tid` are
+> unknowable from memory. Injection is inferred from an unbacked/wrong-module start, not asserted as
+> a `src_pid`.
+
+| field | source → native field | action | currently mapped? (yes+where / NO) | confidence & caveats |
+|---|---|---|---|---|
+| hostname | Memory → image registry (`ComputerName`) via enrich | create | **yes (enrich)** — enrich.py L309-318 (`_host_identity`) | high per-artefact. Not from the thread record; from the image's own registry. Null if registry evidence absent. |
+| src_pid | — (creator not recorded in a snapshot) | create | **NO** | HONEST NO-SOURCE. Memory records the thread's owner (=target), not its creator. |
+| src_tid | — | create | **NO** | HONEST NO-SOURCE. |
+| tgt_pid | Memory → `PID` (`_ETHREAD.Cid.UniqueProcess`) | create | **yes** — mappings.py L208 `tgt_pid:"PID"` | high, direct. The process the thread runs in = the thread's owner. |
+| tgt_tid | Memory → `TID` (`_ETHREAD.Cid.UniqueThread`) | create | **yes** — mappings.py L208 `tgt_tid:"TID"` | high, direct. |
+| stack_base | Memory → `StackBase` (`_ETHREAD.Tcb.StackBase`, KERNEL stack) | create | **yes** — mappings.py L218; plugin L353 | high, direct. **MEMORY-ONLY field.** Kernel stack bounds from KTHREAD. |
+| stack_limit | Memory → `StackLimit` (`_ETHREAD.Tcb.StackLimit`, KERNEL stack) | create | **yes** — mappings.py L218; plugin L357 | high, direct. **MEMORY-ONLY field.** |
+| start_address | Memory → `Win32StartAddress` (user-mode entry point) | create | **yes** — mappings.py L213; plugin L319 | high, direct. Kernel `StartAddress` is kept native (L221) — Win32 pair is the user-mode truth; mixing address+module across pairs is deliberately avoided (injection false-negative risk, L209-212). |
+| start_function | Memory → `Win32StartFunction` (resolved export at Win32 start) | create | **yes** — mappings.py L217; plugin L322-347 (`_path_and_symbol`, in-memory export table, symbol+disp notation) | medium-high. Resolved from the module's in-memory export table (bare name on exact match, `Name+0x<disp>` otherwise). `NotAvailableValue` for an unbacked start with no export — **that N/A IS the injection signal**, never guessed. |
+| start_module | Memory → `Win32StartPath` (VAD file path of Win32 start) | create | **yes** — mappings.py L214; plugin L327-347 | high. The mapped module holding the user-mode entry point; unbacked = injected (no path). |
+| start_module_name | Memory → `basename(Win32StartPath)` | create | **yes** — mappings.py L215 | high, derived. |
+| user | Memory → enrich-inherited from owning process (`OwnerOffset`) | create | **yes (enrich)** — enrich.py L72 (`_INHERIT` has `user`), L377-380 | medium. The OWNING (target) process's user, not a creator/impersonation context. Well-known SIDs canonicalised (enrich.py L320-324). |
+| uid | Memory → enrich-inherited from owning process (owner SID → `uid`) | create | **yes (enrich)** — enrich.py L72 (`_INHERIT` has `uid`), L377-380 | medium. Owning process's account SID. (Memory lane fills `uid`; the Sysmon lane does not — asymmetry.) |
+| user_stack_base | Memory → `UserStackBase` (`TEB.NtTib.StackBase`, USER stack) | create | **yes** — mappings.py L219; plugin L111-131, L363-366 | high when resident. **MEMORY-ONLY / TEB-ONLY field.** Read through the owner's rebuilt DTB address space; `NotAvailableValue` for a paged-out TEB or dead process (honest null). |
+| user_stack_limit | Memory → `UserStackLimit` (`TEB.NtTib.StackLimit`, USER stack) | create | **yes** — mappings.py L219; plugin L111-131 | high when resident. **MEMORY-ONLY / TEB-ONLY field.** |
+
+**Native evidence kept (not canonical thread fields):** `ExitTime` (only meaningful for TERMINATED
+threads — Win10 unions it with KeyedWaitChain, gated on the cross-thread TERMINATED flag; kept in
+`_native`, plugin L301-312 / map L221), kernel `StartAddress`, kernel `StartPath`, kernel
+`StartFunction`, `Offset` (the `_ETHREAD` reuse-proof identity = the CAR `guid` basis).
+
+**Fallback source:** built-in `windows.thrdscan` (map `mappings.py` L261-272) maps the same
+`tgt_pid/tgt_tid/start_address/start_module/start_module_name` but **no stacks and no user-stack**
+(thrdscan doesn't emit them). It is SUPERSEDED by `windows.piiat.threads` when present
+(`mappings.py` L99-100 `SUPERSEDES`), so it only matters if the custom plugin wasn't run.
+
+---
+
+## Actions `suspend` and `terminate` — no source
+
+| action | source in repo? | notes |
+|---|---|---|
+| suspend | **NONE** | No artefact in the repo emits `thread/suspend`. Sysmon has no thread-suspend event; would require ETW Threat-Intelligence provider (`KERNEL_THREATINT_TASK_SUSPENDTHREAD`) or EDR telemetry — neither ingested. HONEST NO-SOURCE. |
+| terminate | **NONE (as a CAR event)** | No artefact emits a `thread/terminate` event. Memory *observes* thread death via `_ETHREAD.ExitTime`, but the plugin surfaces `ExitTime` only as **native evidence on the `create` record** (plugin L301-312, map keeps it L221) — it does not synthesise a terminate action. So `terminate` is unmapped; the death timestamp is queryable but not a canonical action. |
+
+---
+
+## Coverage summary
+
+**Fields with a real source (11 of 15):** hostname, src_pid, tgt_pid, tgt_tid, start_address,
+start_function, start_module, start_module_name, user, uid, + the four stack fields when memory is
+present. Split by lane:
+
+| field | Sysmon EID 8 (remote_create) | Memory (create) |
+|---|---|---|
+| hostname | yes (direct) | yes (enrich) |
+| src_pid | **yes (only source)** | no |
+| src_tid | no | no |
+| tgt_pid | yes | yes |
+| tgt_tid | yes | yes |
+| stack_base | no | **yes (only source)** |
+| stack_limit | no | **yes (only source)** |
+| start_address | yes | yes |
+| start_function | yes | yes |
+| start_module | yes | yes |
+| start_module_name | yes | yes |
+| user | yes (enrich, source proc) | yes (enrich, owning proc) |
+| uid | **no (lane gap)** | yes (enrich) |
+| user_stack_base | no | **yes (only source)** |
+| user_stack_limit | no | **yes (only source)** |
+
+**Field-level takeaways:**
+- **`src_pid` is Sysmon-EID-8-only** (memory can't name the creator).
+- **`stack_base`, `stack_limit`, `user_stack_base`, `user_stack_limit` are memory-only** (TEB/KTHREAD
+  live state; no log/host artefact carries them). Confirms the task's premise exactly.
+- **`start_address` + `start_module`/`start_function`** are the ONE overlap where both lanes supply
+  the value — Sysmon for the remote (injected) thread, memory for any live thread.
+- **`src_tid` has NO source anywhere** — honest dead field for this repo.
+
+**Action coverage:** `remote_create` (Sysmon) and `create` (memory) are covered; `suspend` and
+`terminate` have no source.
+
+## UNMAPPED gaps, ranked
+
+1. **Memory threads plugin not in the processed store → all live-thread + stack fields currently
+   absent.** The `windows.piiat.threads` plugin (and its `thread/create` rows carrying stacks,
+   user-stacks, live tgt_pid/tid, live start_address/module/function) exists in code but was NOT run
+   against the current memory image: `data_store/processed/volatility/memdump.mem/plugins/` contains
+   only processes, registry, sessions, mftscan, pslist, banners — **no threads output**. This is the
+   single biggest gap: every stack field and every live-thread field depends on running this plugin.
+   *(Highest impact — it is the only source for 4 of the 15 fields and the whole `create` action.)*
+
+2. **No Sysmon EID 8 in the current processed evidence → `remote_create` is entirely unpopulated
+   here.** The only processed EvtxECmd output
+   (`data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json`, Provider
+   Microsoft-Windows-Sysmon) contains **only EID 1 and EID 5** — no EID 8. So the `thread/remote_create`
+   code path has no data to fire on in the LS24 light set. Code is correct; evidence is missing.
+
+3. **`thread.uid` is unmapped in the Sysmon lane (asymmetry bug).** The memory lane inherits `uid`
+   from the owning process; the Sysmon lane's `from_owning_process` inherit list
+   (`piiat-mitrecar/piiat_mitrecar/relationships.yml` L21-29) carries `sid` (which `thread` lacks)
+   but not `uid`, so `thread.uid` stays null on every Sysmon `remote_create`. Low-effort fix: add
+   `uid` to that list, or map the source process SID into the thread `uid`.
+
+4. **`src_tid` — genuinely no source.** Neither Sysmon EID 8 (no source-thread id) nor memory
+   (records the thread's own id, not its creator's) can supply the creating thread id. Only ETW
+   thread providers or an EDR would. Honest permanent null for this repo.
+
+5. **`suspend` / `terminate` actions — no source.** No artefact emits these. Memory holds `ExitTime`
+   (native evidence on the create record) but no terminate event is synthesised. A future
+   enhancement could emit `thread/terminate` from the plugin's gated `ExitTime`, or ingest the ETW
+   Threat-Intelligence provider for both suspend and terminate.
+
+6. **Upstream CAR sensor cards overclaim EID 8.** `thread.yaml` `coverage_map` (L60-71) and
+   `sysmon_13.yaml` list `src_tid`, `uid`, `user` as Sysmon-provided for `remote_create`, but the
+   real event carries none of them directly (`user` is only reachable by inheritance, `uid`/`src_tid`
+   not at all). Documentation-vs-reality mismatch worth noting when trusting the upstream coverage map.
+
+## Key files (absolute paths)
+
+- Canonical model: `/opt/github/DX_DFIR/car_data_model.json` (L337-363);
+  `/opt/github/DX_DFIR/third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`
+- Sysmon EID 8 map: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/mappings/sysmon.py` (L442-467)
+- Sysmon source card: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/sources/evtx_sysmon.yaml` (L319-353)
+- Plaso alt-derivation of EID 8: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/adapters/winevt.py` (L95-98)
+- Sysmon-lane enrich (inherit + R5 dual-link): `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/enrich.py` (L257-260, L488-498); rules `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/relationships.yml` (L21-29)
+- Memory threads plugin: `/opt/github/DX_DFIR/third_party/piiat-mem/plugins/windows/piiat/threads.py`
+- Memory CAR map: `/opt/github/DX_DFIR/third_party/piiat-mem/piiat_mem/mappings.py` (L204-222 piiat.threads, L261-272 thrdscan fallback, L99-104 SUPERSEDES)
+- Memory-lane enrich (host id + inherit): `/opt/github/DX_DFIR/third_party/piiat-mem/piiat_mem/enrich.py` (L72, L288-291, L309-324, L377-380)
+- Injection analytics: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/third_party/car/analytics/CAR-2013-10-002.yaml` (LoadLibrary injection); `.../CAR-2021-05-011.yaml` (remote thread into LSASS)
+- R5 relationship doc: `/opt/github/DX_DFIR/docs/CAR-Relations.md` (L154)
+- Evidence checked (both empty of thread data): `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/plugins/` (no threads jsonl); `/opt/github/DX_DFIR/data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json` (EID 1/5 only)

--- a/docs/car-provenance/user_session.md
+++ b/docs/car-provenance/user_session.md
@@ -1,0 +1,177 @@
+# CAR `user_session` — Property-Provenance Catalogue
+
+Authoritative "find once, done" map of **every canonical field × every artefact/source that can supply it** for the MITRE CAR **`user_session`** object, as implemented in this repo (`/opt/github/DX_DFIR`). Grounded in the pinned CAR data model, the engine mappings, the generated source YAMLs, and real evidence in `data_store/processed/`.
+
+- **Object def (pinned):** `third_party/piiat-mitrecar/third_party/car/data_model/user_session.yaml`; `car_data_model.json` (lines 364–388).
+- **Fields (10):** `dest_ip, dest_port, hostname, login_id, login_successful, login_type, src_ip, src_port, uid, user`
+- **Actions (5):** `lock, login, logout, reconnect, unlock`
+- **OSSEM-CDM:** no `user_session` schema exists (only `network_session.yml`) — nothing to cross-check against there.
+
+## Source universe (what actually feeds `user_session` in this engine)
+
+| # | source key | tool / parser | events | actions produced | map file | source yaml |
+|---|---|---|---|---|---|---|
+| S1 | `evtx_security_sessions` | EvtxECmd (Security channel) *(alt: Plaso winevt via `l2t_winevt` adapter)* | 4624; 4634/4647/4779; 4778 | login/**unlock**(LogonType 7); logout; reconnect | `piiat_mitrecar/mappings/evtx_windows.py` | `sources/evtx_security_sessions.yaml` |
+| S2 | `evtx_rdp` | EvtxECmd (TerminalServices-LocalSessionManager) | 21; 24; 25 | login; logout; reconnect | `piiat_mitrecar/mappings/evtx_extra.py` | `sources/evtx_rdp.yaml` |
+| S3 | `evtx_more` | EvtxECmd (System / Winlogon) | 7001; 7002 | login; logout | `piiat_mitrecar/mappings/evtx_more.py` | `sources/evtx_more.yaml` |
+| S4 | `l2t_utmp` / `l2t_utmpx` | Plaso utmp / utmpx (Linux/macOS login DB, incl. wtmp) | record-type 6/7; 8 | login; logout | `piiat_mitrecar/mappings/plaso_linux.py` | `sources/l2t_utmp.yaml`, `l2t_utmpx.yaml` |
+| S5 | `l2t_text` | Plaso syslog (`syslog:ssh:login`) | sshd "Accepted" | login | `piiat_mitrecar/mappings/plaso_linux.py` | `sources/l2t_text.yaml` |
+| S6 | `windows.piiat.sessions` | Volatility3 (PIIAT-Mem custom plugin) | per-process token LUID | login | `third_party/piiat-mem/piiat_mem/mappings.py` (+ `plugins/windows/piiat/sessions.py`) | `sources/memory.yaml` |
+| S7 | `windows.sessions` | Volatility3 built-in (fallback) | TS session | login | `third_party/piiat-mem/piiat_mem/mappings.py` | — |
+
+**Provenance-tier legend** (as used in the generated `sources/*.yaml`): `[direct]` = 1:1 native field; `[coalesced]` = first-non-null of several; `[inferred]` = value-mapped / regex-filtered; `[derived]` = transformed (e.g. host label); `[asserted]` = a constant the event's existence proves.
+
+---
+
+## Per-field provenance
+
+### `dest_ip` — destination IP of the session (remote/RDP only)
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| **ALL (S1–S7)** | — (none) | — | **NO — honest no-source everywhere** | High. No host-side session artefact records a *destination* address: `Computer` is the destination *host* (→ `hostname`), not an IP. EvtxECmd `evtx_windows.py:154-156` explicitly nulls it; SMB SOCKADDR blobs (`evtx_more.py:158`) are kept native, never faked into `dest_ip`. `dest_ip`/`dest_port` are meaningful only for a *client-side/outbound* RDP session, which none of these logs capture. |
+
+**Verdict:** `dest_ip` is **unmapped for all 5 actions from all 7 sources** — and correctly so; there is no grounded source.
+
+### `dest_port` — destination port (remote/RDP only)
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| **ALL (S1–S7)** | — (none) | — | **NO — honest no-source everywhere** | High. Same as `dest_ip`: no session artefact records a destination port. |
+
+### `hostname` — host of the session, without domain (the machine the session runs ON)
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` | `Computer` → `host_label()` (first DNS label) `[derived]` | login, logout, reconnect, unlock | **YES** — `evtx_windows.py` `_session_props()` | High. |
+| S2 `evtx_rdp` | `Computer` → `host_label()` `[derived]` | login, logout, reconnect | **YES** — `evtx_extra.py` | High. |
+| S3 `evtx_more` (7001/7002) | `Computer` → `host_label()` `[derived]` | login, logout | **YES** — `evtx_more.py` (`_HOST`) | High. |
+| S4 `l2t_utmp`/`utmpx` | `image_hostname` `[direct]` | login, logout | **YES** — `plaso_linux.py` `_session_map()` | High. **Caveat:** this is the *imaged host*, per the vetted view. utmp's own `Record.hostname` field is the login **SOURCE** host and is kept in `_native.hostname` — CAR `user_session` has no `src_hostname` field. |
+| S5 `l2t_text` (sshd) | `image_hostname` `[direct]` | login | **YES** — `plaso_linux.py` | High. Syslog reporter hostname kept native, not used here. |
+| S6 `windows.piiat.sessions` | — | login | **NO (as a `props` field)** | Med. Not set in `props`; the host is carried on the CAR common header `source_host`, not the canonical `hostname` column → canonical `hostname` is an honest null from memory. |
+| S7 `windows.sessions` | — | login | **NO (as a `props` field)** | Same as S6. |
+
+### `login_id` — the Windows LUID; THE join key of the authentication↔user_session cascade (persists until logout)
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` | `first(TargetLogonId, LogonID)` `[coalesced]` | login, logout, reconnect, unlock | **YES** — `evtx_windows.py` `_session_props()` | High. THE designed key. 4624 family uses `TargetLogonId`; the 4778/4779 pair uses `LogonID` (coalesced). Well-known singletons (`0x3e7/0x3e5/0x3e4`) recur per boot → heuristic across multi-boot logs (`docs/CAR-Relations.md` auth §, R1). `0x0`/blank = null session, never a key. |
+| S6 `windows.piiat.sessions` | `LogonId` = `_TOKEN.AuthenticationId` (hex) `[direct]` | login | **YES** — `piiat-mem/mappings.py` | High. This is the *real* LUID (same value 4624 logs as `TargetLogonId`) → **cross-artefact joinable** (evtx 4624 ↔ memory session; `CAR-Relations.md`: 1616/1616, 104 definitive on lonewolf). Verified in evidence: `windows.piiat.sessions.jsonl` rows carry `LogonId:"0x3e7"`. |
+| S7 `windows.sessions` (built-in fallback) | `"Session ID"` (TS session int) `[direct]` | login | **YES, but near-miss** — `piiat-mem/mappings.py` | Low-Med. This is the *terminal-services session number* (0/1/…), **not** the token LUID — so it will NOT join evtx `TargetLogonId`. S6 is preferred precisely to avoid this; S7 is a degraded fallback when the custom plugin is absent. |
+| S2 `evtx_rdp` | — (`SessionID` kept native) | login/logout/reconnect | **NO** | High. TerminalServices carries a TS `SessionID`, not a LUID → `login_id` null; `SessionID` in `_native` (used by R1 lifecycle's by-SID pairing, never promoted). |
+| S3 `evtx_more` (7001/7002) | — (`TSId` kept native) | login/logout | **NO** | High. Winlogon 7001/7002 carry only `UserSid` + `TSId` → `login_id` null. |
+| S4/S5 Linux (utmp/utmpx/sshd) | — (none) | login/logout | **NO — honest null** | High. No Linux LUID analogue; `plaso_linux.py` docstring is explicit: never faked from pid/terminal. |
+
+### `login_successful` — boolean; was the login attempt successful
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` (4624) | `const(True)` `[asserted]` | login, **unlock** | **YES (True only)** — `evtx_windows.py` (`login_successful=const(True)`) | High. A mapped 4624 *is* the successful logon. **Not set** on logout/reconnect (a logoff/disconnect records no login decision) → null there. |
+| S3 `evtx_more` (7001) | `const(True)` `[asserted]` | login | **YES (True only)** — `evtx_more.py` | Med. Winlogon 7001 corroborates a completed logon. Not set on 7002/logout. |
+| S6 `windows.piiat.sessions` | `const(True)` `[asserted]` | login | **YES (True only)** — `piiat-mem/mappings.py` (**recently extended**) | High. Proven by existence: a live access-token bearing the AuthenticationId LUID exists only because LSA completed the logon. |
+| S7 `windows.sessions` | `const(True)` `[asserted]` | login | **YES (True only)** — `piiat-mem/mappings.py` | Med. Same "session with live processes ⇒ logon completed" logic. |
+| S2 `evtx_rdp` | — | login/logout/reconnect | **NO** | Med. Left null — though TS EID 21 is literally "logon succeeded", the map does not assert `True` (design choice: the record is a session-state notice, not an auth decision). Candidate to assert `True` on 21. |
+| S4 `l2t_utmp`/`utmpx` | — | login/logout | **NO** | Med. A USER_PROCESS record implies success but the map does not assert it; failed logins live in **btmp** (not ingested). |
+| S5 `l2t_text` (sshd) | — | login | **NO** | High. `syslog:ssh:login` = an "Accepted" line (implicitly success) but `True` is not asserted; sshd **"Failed password"** lines are a *different* data_type, **not mapped** → no `False`. |
+| **— FAILED LOGINS (`False`) —** | Security **4625** → **authentication/failure** (`core.py`), NOT user_session; sshd "Failed password"; **btmp**; **lastlog** | login | **NO SOURCE PRODUCES `False`** | High, load-bearing gap. Per `evtx_windows.py:14-19` and `CAR-Relations.md` "a failed authentication opens **no** session" — 4625 is deliberately diverted to the `authentication` object. Net effect: **`login_successful` is effectively write-only-`True`** on `user_session`. |
+
+### `login_type` — CAR vocabulary (`interactive` / `local` / `rdp` / `remote`)
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` | `map_value(LogonType, {2→interactive, 3→remote, 10→rdp})` `[inferred]` | login, logout, reconnect, unlock | **YES (partial)** — `evtx_windows.py` `_LOGIN_TYPE` | High. Only the three vetted ints map. Every other `LogonType` (0 system, 4 batch, 5 service, 7 unlock, 8/9 cleartext/new-cred, 11 cached) → **null**, with the raw int kept in `_native.LogonType`. **`local` has no source here** (console feeders like utmp would assert it, but don't). Note: `LogonType 7` drives the **unlock action**, not `login_type`. |
+| S2 `evtx_rdp` | — (deliberately null) | login/logout/reconnect | **NO** | High. EID 21 fires for BOTH console and RDP (only `Address` distinguishes) → asserting `rdp` would be a guess. **Gap:** even a non-`LOCAL` `Address` (proven RDP) does not set `login_type=rdp`. |
+| S3–S7 (Winlogon / Linux / memory) | — | — | **NO — null** | High. utmp record-type ints are NOT the CAR vocabulary → kept native (`plaso_linux.py`); sshd `authentication_method` (password/publickey) is native, not `login_type`; memory carries none. |
+
+### `src_ip` — source IP of the session (remote/RDP only)
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` | `regex1(first(IpAddress, ClientAddress), <not ::1/127.0.0.1/LOCAL>)` `[inferred]` | login, logout, reconnect, unlock | **YES** — `evtx_windows.py` `_session_props()` | High. 4624 `IpAddress` (type 3/10); 4778/4779 `ClientAddress`. Console (type 2) is blank/`-`/`LOCAL` → null. **This is one RDP `src_ip` path.** |
+| S2 `evtx_rdp` | `regex1(userdata("Address"), <not LOCAL>)` `[inferred]` | login, logout, reconnect | **YES** — `evtx_extra.py` | High. **The TerminalServices RDP client IP is mapped.** Console session `Address="LOCAL"` → honest null. |
+| S4 `l2t_utmp`/`utmpx` | `regex1(ip_address, <not 0.0.0.0/127.0.0.1/::1>)` `[inferred]` | login, logout | **YES** — `plaso_linux.py` `_SRC_IP` | High. Remote source of the login; loopback/unset → null. |
+| S5 `l2t_text` (sshd) | `regex1(ip_address, …)` `[inferred]` | login | **YES** — `plaso_linux.py` | High. sshd client IP. |
+| S3 `evtx_more` (7001/7002) | — | login/logout | **NO — null** | High. Winlogon carries no origin address. |
+| S6/S7 memory | — | login | **NO — null** | High. Memory sessions carry no origin address. |
+
+> **Correction to the brief's gap list:** RDP `src_ip` is **NOT a gap** — it is covered twice (S1 Security 4778/4779 `ClientAddress`, and S2 TerminalServices `Address`). What *is* thin on RDP is `src_port` and `login_type` (below).
+
+### `src_port` — source port
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` | `regex1(IpPort, <not 0>)` `[inferred]` | login, logout, reconnect, unlock | **YES** — `evtx_windows.py` | High. 4624 `IpPort`; `0`/`-` → null. Only network logons carry it. |
+| S5 `l2t_text` (sshd) | `port` `[direct]` | login | **YES** — `plaso_linux.py` (`extra_props`) | High. sshd client port. |
+| S2 `evtx_rdp` | — | login/logout/reconnect | **NO — null** | High. TerminalServices records no client port. |
+| S4 `l2t_utmp`/`utmpx` | — | login/logout | **NO — null** | High. utmp carries no port. |
+| S3/S6/S7 | — | — | **NO — null** | High. None carry a port. |
+
+### `uid` — SID / ID of the user
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` | `TargetUserSid` `[direct]` | login, logout, reconnect, unlock | **YES** — `evtx_windows.py` | High. **Caveat:** the 4778/4779 pair carries **no SID** → `uid` null on those records (affects some reconnect/logout rows). |
+| S3 `evtx_more` (7001/7002) | `UserSid` `[direct]` | login, logout | **YES** — `evtx_more.py` | High. This is 7001/7002's *only* identity (no username) → uid-only rows. |
+| S6 `windows.piiat.sessions` | `Sid` (token user SID) `[direct]` | login | **YES** — `piiat-mem/mappings.py` | High. Verified in evidence (`Sid:"S-1-5-18"`). |
+| S2 `evtx_rdp` | — | login/logout/reconnect | **NO — null** | High. TerminalServices has no SID. |
+| S4/S5 Linux (utmp/utmpx/sshd) | — | login/logout | **NO — null** | High. utmp/sshd records carry a *username*, not a numeric POSIX uid → honest null (never faked). |
+| S7 `windows.sessions` | — | login | **NO — null** | Med. Built-in sessions row has no SID column. |
+
+### `user` — the account affiliated with the session
+
+| source | native field → | action(s) | mapped? | confidence & caveats |
+|---|---|---|---|---|
+| S1 `evtx_security_sessions` | `first(TargetUserName, AccountName, UserName)` `[coalesced]` | login, logout, reconnect, unlock | **YES** — `evtx_windows.py` | High. 4778/4779 use `AccountName`; `UserName` (EvtxECmd column) is last-resort. |
+| S2 `evtx_rdp` | `userdata("User")` `[direct]` | login, logout, reconnect | **YES** — `evtx_extra.py` | High. |
+| S4 `l2t_utmp`/`utmpx` | `username` `[direct]` | login, logout | **YES** — `plaso_linux.py` | High. |
+| S5 `l2t_text` (sshd) | `username` `[direct]` | login | **YES** — `plaso_linux.py` | High. |
+| S6 `windows.piiat.sessions` | `User` (SID→SOFTWARE ProfileList basename) `[derived]` | login | **YES** — `piiat-mem/mappings.py` | Med-High. `NotAvailable` when the SID has no profile (service/well-known SIDs). Verified (`User:"systemprofile"`). |
+| S7 `windows.sessions` | `"User Name"` `[direct]` | login | **YES** — `piiat-mem/mappings.py` | Med. |
+| S3 `evtx_more` (7001/7002) | — | login/logout | **NO — null** | High. Winlogon 7001/7002 carry `UserSid` only, no name → `uid`-only (a resolvable-downstream gap: name must come from a SID→name join). |
+
+---
+
+## Coverage matrix (field × action, best available source)
+
+Legend: ✔ mapped · ✔* mapped True-only (asserted) · ~ partial / near-miss · ✘ no source / null. "best source" in parentheses.
+
+| field | login | logout | reconnect | unlock | lock |
+|---|---|---|---|---|---|
+| dest_ip | ✘ | ✘ | ✘ | ✘ | ✘ |
+| dest_port | ✘ | ✘ | ✘ | ✘ | ✘ |
+| hostname | ✔ (S1/2/3/4/5) | ✔ (S1/2/3/4) | ✔ (S1/2) | ✔ (S1) | ✘ |
+| login_id | ✔ (S1, S6 LUID) | ✔ (S1) | ✔ (S1) | ✔ (S1) | ✘ |
+| login_successful | ✔* (S1/3/6/7 True) | ✘ | ✘ | ✔* (S1) | ✘ |
+| login_type | ~ (S1: 2/3/10 only) | ~ (S1) | ~ (S1) | ~ (S1) | ✘ |
+| src_ip | ✔ (S1/2/4/5) | ✔ (S1/2/4) | ✔ (S1/2) | ✔ (S1) | ✘ |
+| src_port | ✔ (S1/5) | ✔ (S1) | ~ (S1 only) | ✔ (S1) | ✘ |
+| uid | ✔ (S1/3/6) | ✔ (S1/3) | ~ (S1: null on 4778) | ✔ (S1) | ✘ |
+| user | ✔ (S1/2/4/5/6/7) | ✔ (S1/2/4) | ✔ (S1/2) | ✔ (S1) | ✘ |
+
+**The `lock` action is a fully empty row — no source fires it (see gap #1).** The `unlock` column is populated only via S1's 4624/LogonType-7 relogon, not by a true lock/unlock event.
+
+---
+
+## Summary
+
+**What is well covered.** The Windows Security 4624-family (S1) is the workhorse: it supplies **8 of 10 fields** (`hostname, login_id, login_successful, login_type, src_ip, src_port, uid, user`) across login/logout/reconnect/unlock, and the LUID (`login_id`) it emits is the designed join key — corroborated cross-artefact by the Volatility memory plugin (S6, `_TOKEN.AuthenticationId`), verified against real evidence (`windows.piiat.sessions.jsonl`, `LogonId:"0x3e7"`). RDP (S2) and Linux utmp/utmpx/sshd (S4/S5) fill `user`/`src_ip`(+`src_port` for sshd) with good confidence. `user` and `hostname` have the broadest source coverage; `src_ip`/`src_port` have solid Windows+Linux coverage. The `login_successful=True` assertion is present on all four "opening" Windows/memory paths (recently extended into PIIAT-Mem sessions).
+
+**UNMAPPED / weak — ranked by impact:**
+
+1. **`lock` action + true lock/unlock events (Security 4800/4801, 4802/4803).** Highest gap. The `lock` action **never fires** from any source; `unlock` fires only as a 4624 LogonType-7 relogon, never from the actual lock/unlock (4800/4801) events, which are deliberately out of `evtx_security_sessions` scope (`evtx_windows.py:18-19, 267`). Two of five canonical actions are effectively uncovered by their proper artefacts. **Fix:** add a Security 4800→`lock` / 4801→`unlock` (and 4802/4803 screensaver) map keyed on `TargetLogonId` for the LUID join.
+
+2. **`login_successful = False` (failed logins) — no source produces it.** `login_successful` is write-only-`True`. Security **4625** is diverted to the `authentication/failure` object (by design, `CAR-Relations.md`: "a failed authentication opens no session"); sshd "Failed password", **btmp**, and **lastlog** failures are not ingested at all. If failed-login visibility on `user_session` is desired, it needs a deliberate decision (map a shadow `login_successful=False` from 4625 / btmp / sshd-failed).
+
+3. **`btmp` and `lastlog` (Linux) — not ingested.** Plaso parses utmp/utmpx/wtmp (successful/logout only). btmp (failed logins) and lastlog (last-login summary) have no source key → no failed-login or last-login `user_session` on Linux.
+
+4. **RDP thinness (NOT `src_ip` — that is covered).** Correcting the brief: RDP `src_ip` **is** mapped twice (S1 4778/4779 `ClientAddress`, S2 TerminalServices `Address`). The real RDP gaps are: `login_type=rdp` is **never asserted** on S2 (left null even when `Address` proves RDP); `src_port`, `login_id`(LUID), and `uid` are all null on the TerminalServices channel; and S2 only handles EIDs **21/24/25** — **23 (logoff), 39/40 (disconnect)** are unmapped (24-disconnect is used as the `logout` proxy). Security 4779 covers RDP disconnect on the S1 side.
+
+5. **`dest_ip` / `dest_port` — no source, correctly.** No host-side session artefact records a session *destination* address/port (these matter only for client-side/outbound RDP). Honest permanent null across all sources.
+
+6. **Winlogon 7001/7002 (S3) name gap.** Carries `UserSid` only → `user` null (uid-only rows); `login_id`(LUID) also null (`TSId` kept native). Resolvable downstream via a SID→name / TSId join, not at map time.
+
+7. **`login_type` partial + no `local`.** Only Windows LogonType 2/3/10 map (→interactive/remote/rdp); the `local` vocabulary value is never emitted by any source, and utmp record-types are (correctly) not force-fit into it.
+
+8. **Security 4964 (special-groups logon), 4648 (explicit-cred issuance) — unmapped.** 4648 is a deliberate honest-null (no outcome in the record); 4964 has no map.
+
+**Evidence caveat:** the processed corpus on hand (`data_store/processed/`) is a light set — the only EvtxECmd export present is Sysmon-only (no Security/System/TerminalServices session events), so S1–S3 wiring is verified by code + generated `sources/*.yaml` rather than by a live session row here. Real `user_session` evidence present: `volatility/.../windows.piiat.sessions.jsonl` (clean S6 rows) and `log2timeline/jsonl/5g-webui.jsonl` (1,398 `linux:utmp:event` — S4; note this particular image parses to junk field values, so it validates field *wiring*, not content).


### PR DESCRIPTION
The "find once, done" reference for §1 per-artefact completeness: a deep per-object audit (one pass per CAR object) of **every canonical field and every DFIR source that can supply it** — grounded in the actual engine maps + PIIAT-Mem + real LS24 evidence, not the upstream CAR sensor cards (which the audit found overclaim).

`docs/car-provenance/`:
- **README.md** — index + per-object coverage snapshot.
- **COMPLETENESS-BACKLOG.md** — the ranked cross-object "squeeze more" work items.
- **13 per-object catalogues** — per-field source tables (`field | sources → native field | actions | mapped? | caveats`).

## Highest-value gaps it surfaced
- **The quarantined audit family** (`to-be-validated/evtx_audit.yml`: 4663/4657/5156/5158) is the single biggest lever — it unlocks file `write`/`read`, live registry writes, and flow/socket **endpoint identity**.
- **Kerberos 4768/4769 + NTLM 4776 → authentication** — EvtxECmd already parses them; zero coverage today (the object has one mapper).
- **The registry `Services` key → whole `service` objects from a dead disk** (the definition is already captured native).
- **timestomp** from $SI/$FN mismatch; **UA parsing** for http; **cross-object hash hydration** (what `crosssource.py` enables).

Honest no-source fields are documented as permanent nulls (never faked). Pure docs — no code touched.

> Targets `main` (DX_DFIR `dev` is diverged + pre-rename). This is the reference the map-completeness work (PIIAT-MitreCar#54, PIIAT-Mem#3) is measured against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)