### PR TITLE
docs(car-provenance): LoneWolf FS-unmined re-check + cross-dataset value hunt

### DIFF
--- a/docs/car-provenance/crosslink/SUMMARY.md
+++ b/docs/car-provenance/crosslink/SUMMARY.md
@@ -1,0 +1,43 @@
+# Cross-dataset value hunt — synthesis (GUIDs, SIDs/users, hosts/IPs, cmdlines, ports/serials)
+
+Grepped unambiguous values across the whole `data_store/processed/` tree to reveal
+(a) the same value in ≥2 artefacts = a convergence key, and (b) values in raw/native
+no CAR field lifted = unmined. Per-class detail: `guids.md`, `identity.md`,
+`host_ip.md`, `cmdlines.md`, `ports_serials.md`.
+
+## Framing fact (all five agents independently)
+`data_store/processed/` is **not one host** — it's a grab-bag of **~5 independent
+images/scenarios**: LoneWolf disk `DESKTOP-PM6C56D` (user jcloudy), Linux `5g-webui`,
+memory `BGP-WS1-CONF` (its own machine SID), evtx+hayabusa `DESKTOP-M913391` (user JDH),
+and Zeek pcaps of the `10.27.33.x` subnet. So cross-**host** convergence is naturally
+absent; real convergence lives **within** each host + at the **network-infra** level.
+(This is why a whole-tree cross-source run finds few host bridges — it's evidence
+hygiene, not a bug. A single-collection run is where convergence pays off.)
+
+## The decisive normalisation finding — the `guid` join key is synthetic-only
+CAR's `guid` is *the* cross-source join key (→ ECS `event.id`/`process.entity_id`,
+per `detect/rules/car-detections/join-keys.yml`). But of **44,327** non-null
+`guid/owning_guid/parent_guid/target_guid` values, **zero are canonical `{8-4-4-4-12}`
+GUIDs** — all are minted synthetic ids (`proc-…`, `file-…`). So **no MachineGuid,
+volume GUID, Sysmon ProcessGuid, task/interface GUID is ever promoted to a queryable
+CAR field** — the natural cross-source keys survive only as text in `native`. And
+`owning_guid` is populated only for `user_session` (registry/file rows NULL).
+
+## Real convergence keys found (all unmined)
+- **Volume GUID `{09931f21-…}`** → 6 data_types (USN, evtx, registry, fs:stat, Google-Drive sync log, MountPoints2) — the single best key on the disk.
+- **`jcloudy` = RID 1001** — the identity spine across ~20 disk data_types + 42k evtx SID refs, while plaso native `username` = `"-"` on **99.999%** of rows.
+- **CloudLog exfil USB** (volume serial `4C36-F4AC`, holds `D:\key.txt`) → LNK ↔ shellbags; **SanDisk USB iSerials** → USBSTOR+setupapi+DeviceClasses (2,470×).
+- **MACs leak from v1 GUIDs** (DLT birth-droids / volume GUID nodes → `ec:f4:bb:48:7f:ed`, `00:1c:c4:2d:f4:0b`) and NetworkList gateway MAC — no MAC field exists anywhere.
+- **Network-infra bridges**: DNS `100.95.95.4` (memory-registry ↔ Zeek), `berylia.org` (5g-webui cert ↔ Zeek), the DNS→IP→flow **C2 chain** (`scoring-c2.berylia.org`→`100.101.0.42`, masscan UA), an SSH-22 pivot chain.
+- **Cross-host pivot**: user `gt` on both the memory Windows host and the 5G Linux host.
+- **S3 Browser exfil tool** seen 6 ways on the disk host; obfuscated `cmd /c` triangulated Sysmon↔Hayabusa and **decoded to a CTF flag**.
+
+## Added backlog (beyond the A-class FS-unmined items)
+- **B1 · promote canonical GUIDs to the CAR `guid`/`host.id` space** — MachineGuid→`host.id`, add a volume-GUID field, map Sysmon Process/Parent/Logon GUID in the evtx→CAR projection (today only synthetic ids fill `guid`), and populate `owning_guid` on registry/file rows. Without this the *one* cross-source join key can't use the real GUIDs.
+- **B2 · normalise network identity** — Zeek (conn/dns/ssl/x509/http) is entirely raw here and memory's static IP config lives only in raw registry strings; lift IPs/domains/SNI/certs into `flow`/`http`, and reconcile the memory host's IP with its name.
+- **B3 · decode v1-GUID node → `mac_address`** (6,218 MAC-bearing GUIDs in LoneWolf) and add **MAC + device-serial CAR fields** (none exist) fed by NetworkList/DLT/USBSTOR/LNK — these are strong device-linkage keys.
+- **B4 · plaso data-loss**: `MountedDevices`/`DefaultGatewayMac`/device bytes are emitted only as `(6 bytes)`/`(224 bytes)` summaries — the raw serial/MAC is dropped before any normalisation could recover it (a lane/parser-config fix).
+- **B5 · a reusable YARA "unnormalised-value" ruleset** — the agents produced ~30 YARA stubs (SID, `\Users\<name>\`, MachineGuid/volume/ProcessGuid/task GUID classes, v1-GUID-embedded MAC, IPv4/IPv6/MAC, volume/USB serial, port, DOSfuscation/C2/LOLBin patterns). Consolidate into one ruleset that flags distinctive values present-but-unnormalised across any future dataset — the user's "use YARA to limit missing non-normalised data", operationalised.
+
+## Through-line
+Two orthogonal gaps: (1) the disk/evtx/zeek lanes don't build CAR here at all (only memory has a `car.db`), and (2) even where CAR is built, the join key is synthetic-only and every natural cross-source key (GUID, MAC, serial, IP, domain) is unnormalised. The A-class PR fixes the per-field disk squeeze; B1–B5 fix the *linkage* layer so the cross-source convergence stage actually has real keys to join on.

--- a/docs/car-provenance/crosslink/cmdlines.md
+++ b/docs/car-provenance/crosslink/cmdlines.md
@@ -1,0 +1,251 @@
+# Command-line cross-artefact linkage hunt — DX_DFIR processed dataset
+
+READ-ONLY analysis. Repo `/opt/github/DX_DFIR`, dataset `data_store/processed/`.
+Command-bearing artefacts extracted by a single streaming pass over the 6.6 GB
+LoneWolf disk timeline plus targeted reads of the Sysmon evtx, Hayabusa timeline,
+Volatility plugins and `car.db`.
+
+---
+
+## 0. The single most important finding: the four sources are FOUR DIFFERENT HOSTS
+
+The task frames the goal as "the SAME execution seen via log + memory + prefetch/amcache
++ tasks". On this dataset that literal cross-vantage convergence is **not physically
+possible across all three of log+memory+disk**, because the command-rich sources come
+from three unrelated machines (plus a Linux box):
+
+| Source file(s) | Host | Command vantage it provides |
+|---|---|---|
+| `log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (LoneWolf.E01 disk, user `jcloudy`) | **DESKTOP-PM6C56D** | Disk artefacts: prefetch, amcache, shimcache, BAM, UserAssist, LNK args, Run keys, Services ImagePath, .job tasks, RunMRU. **No full argv anywhere.** |
+| `windows_logs/unspecified_host/log_EvtxECmd_Output.json` + `signatures/hayabusa/timeline.jsonl` | **DESKTOP-M913391** | Sysmon EID 1 process creation — **full command line with argv**. |
+| `volatility/memdump.mem/plugins/*.jsonl` + `car.db` | **BGP-WS1-CONF** | Memory-resident process command lines (full argv). |
+| `log2timeline/jsonl/5g-webui.jsonl` | **5g-webui** (Linux) | `fs:stat` + `linux:utmp` only — no Windows command artefacts. |
+
+Consequences:
+- **CAR `command_line` is populated ONLY from the memory host (BGP-WS1-CONF).** The disk
+  host's rich execution evidence and the Sysmon host's full cmdlines never enter CAR.
+- The true multi-vantage convergence therefore exists **within** each host, not across
+  them. This report gives the strongest real convergence cluster for each host, and is
+  explicit about which vantage supplies exe-only vs full argv.
+
+---
+
+## 1. Command / distinctive-exe inventory (what each artefact carries)
+
+### DESKTOP-PM6C56D — LoneWolf disk (log2timeline), no argv, not in CAR
+Counts are records extracted from the 4.17 M-line timeline:
+
+| Artefact (`data_type`) | Records | Field carrying command evidence | Argv? |
+|---|---|---|---|
+| `windows:prefetch:execution` | 1,312 | `executable`, `path_hints`, `run_count` | exe + run count only |
+| `windows:registry:amcache` | 604 | `full_path`, `filename`, `sha256`? | full path only |
+| `windows:registry:appcompatcache` (shimcache) | 1,463 | `path` | full path only |
+| `windows:registry:bam` | 76 | `path` (+ last-run time, user SID) | full path only |
+| `windows:registry:userassist` | 153 | `value_name`, `number_of_executions` | path only (GUI launches) |
+| `windows:lnk:link` | 1,639 (350 with args) | `command_line_arguments`, `local_path` | **args present** |
+| `windows:registry:service` | 1,796 (634 with args) | `image_path`, `name` | **args present** (`-k`, `/svc`, `-s …`) |
+| `windows:registry:run` | 27 (31 entries) | `entries` (name→command) | **full command line** |
+| `windows:tasks:job` (.job) | 4 (all with params) | `application` + `parameters` | **args present** |
+| `windows:registry:task_scheduler:task_cache:entry` | 1,454 | `task_name`, `task_identifier` | name only, no args |
+| `windows:registry:mrulistex` (RecentDocs/OpenSaveMRU/CIDSizeMRU) | 65 | `entries` (typed/selected paths) | typed path, no argv |
+| `windows:evtx:record` EID 4688 | 80 | `strings` = image path only | **NO cmdline** (audit-cmdline off) |
+| `windows:evtx:record` EID 4104 (PS ScriptBlock) | 2 | script text | script only |
+
+### DESKTOP-M913391 — Sysmon host (full argv)
+- `EvtxECmd` EID 1 (`Microsoft-Windows-Sysmon/Operational`): `ExecutableInfo` = full argv,
+  `PayloadData6` = `ParentCommandLine`. ~45 process-creation events.
+- `hayabusa/timeline.jsonl`: `Details.Cmdline` + `Details.ParentCmdline` = full argv, plus
+  Sigma `RuleTitle`. RuleTitles present: `Proc Exec` (45), `Proc Terminated` (40),
+  **`Cmd.EXE Missing Space Characters Execution Anomaly` (1)**.
+
+### BGP-WS1-CONF — memory host (full resident argv)
+- `windows.piiat.processes.jsonl`: `CommandLine`, `ImageFileName`, `Path`, `Cwd`, `EnvVars`, SID, integrity.
+- `windows.pslist.jsonl`: `ImageFileName` (exe only), PID/PPID, CreateTime.
+- `car.db → process` (180 rows, **157 with `command_line`**): the **normalized** form of
+  `piiat.processes` (verified: winlogbeat cmdline byte-identical between the two).
+- `car.db → service` table exists with a `command_line` column but is **0 rows** (empty).
+
+---
+
+## 2. Cross-artefact linkage table (real values)
+
+Legend for "supplies": **exe**=binary name only · **path**=full image path, no args ·
+**argv**=full command line with arguments · **args**=arguments only.
+
+| Distinctive command / binary | Host | Artefacts carrying it (+ what each supplies) | In CAR `command_line`? | Convergence use |
+|---|---|---|---|---|
+| **`s3browser-win32.exe`** (`C:\Program Files\S3 Browser\`) — insider S3 exfil tool | DESKTOP-PM6C56D | prefetch (exe `S3BROWSER-WIN32.EXE`, run_count=5, path) · amcache (path `c:\program files\s3 browser\s3browser-win32.exe` + `s3browser-con.exe`) · bam (`\Device\HarddiskVolume4\Program Files\S3 Browser\s3browser-win32.exe` + last-run) · userassist (path, execs=2 & 4) · mrulistex (typed `s3browser-win32.exe`) · lnk/shellitem (shortcut) | **NO** (disk host absent from CAR) | **6-vantage execution proof of one binary** — install + first run + repeated GUI launches. Every vantage is exe/path only; **argv is unrecoverable on this host**. |
+| **`s3browser-7-6-9.exe`** installer (Downloads → Temp `IS-*.TMP`) | DESKTOP-PM6C56D | prefetch (`S3BROWSER-7-6-9.EXE` from `\USERS\JCLOUDY\DOWNLOADS`, then `.TMP` from `\APPDATA\LOCAL\TEMP\IS-SE75Q.TMP`) · amcache (`c:\users\jcloudy\downloads\s3browser-7-6-9.exe`) | NO | Ties the download → temp-extract → install chain; anchors S3 Browser provenance to `jcloudy`'s Downloads. |
+| **`GoogleUpdateSetup.exe` / `GoogleUpdate.exe`** (incl. `\Temp\GUME1E0.tmp\`) | DESKTOP-PM6C56D | prefetch (27) · amcache (28) · shimcache (24) · bam (1) | NO | **4-vantage** disk convergence; shows shimcache+amcache+prefetch agreeing on the same image path across temp + install locations. |
+| **`OneDriveSetup.exe` / OneDrive.exe** | DESKTOP-PM6C56D | prefetch (11) · amcache (14) · shimcache (12) | NO | 3-vantage; also appears as an argv-bearing native command via the Run key (below). |
+| **`chrome.exe`** | DESKTOP-PM6C56D | prefetch · amcache · bam · shimcache · **lnk `--incognito`, `--win-jumplist-action=most-visited http://aws.amazon.com/`** | NO | Disk vantages give exe/path; **only the LNK preserves the argv** (`--incognito`, jumplist URLs) — argv lives solely in unnormalized native. |
+| **obfuscated `cmd /c` env-var payload** (decodes to `flag{UKxhry6MoKCYdLV7RglTI5wEE23terqKVvf2FLdz2GexLeSMQ0jB0cmZPw1ITKn8D8r8vZs6iD1h90GU}`) | DESKTOP-M913391 | EvtxECmd EID1 (`ExecutableInfo` full argv) · hayabusa (`Details.Cmdline` full argv) · **hayabusa Sigma detection** (`Cmd.EXE Missing Space Characters Execution Anomaly`) | n/a (Sysmon host not in CAR) | **3-vantage on one execution, all full argv** — raw evtx ↔ timeline ↔ signature. The canonical "same command seen via log + detection" convergence. |
+| `cmd.exe /c "ver"` , `ipconfig` , `whoami`-style recon | DESKTOP-M913391 | EvtxECmd EID1 (argv) · hayabusa (argv, `Proc Exec`) | n/a | evtx ↔ hayabusa full-argv convergence; classic hands-on-keyboard recon sequence. |
+| `MicrosoftEdgeUpdate.exe /ua /installsource scheduler` | DESKTOP-M913391 | EvtxECmd EID1 (argv) · hayabusa (argv) | n/a | evtx ↔ hayabusa; note same `/ua /installsource scheduler` pattern also appears as a **.job** on the LoneWolf host (DropboxUpdate) — same scheduler idiom, two hosts, two artefact classes. |
+| **`winlogbeat.exe … --environment=windows_service -c …yml --path.home … -E logging.files.redirect_stderr=true`** | BGP-WS1-CONF | piiat.processes (`CommandLine` full argv) · car.db process (`command_line` full argv, **normalized copy**) · pslist (exe only) | **YES** (memory-derived) | **3-vantage memory convergence**: pslist=exe vantage, piiat=raw resident argv, CAR=normalized argv. Demonstrates the one place normalization actually fires. |
+| `scoringbot.exe`, `owncloud_crash_reporter.exe "…\*.dmp"`, `FTK Imager.exe`, `Everything.exe -svc`, `sshd.exe`, `nssm.exe` | BGP-WS1-CONF | piiat.processes (argv) · car.db process (argv) · pslist (exe) | YES | Same 3-vantage memory pattern; `owncloud_crash_reporter` argv reveals a crash-dump path in Temp only visible in the resident cmdline. |
+
+---
+
+## 3. Best multi-vantage execution links on real data (ranked)
+
+1. **S3 Browser on DESKTOP-PM6C56D — 6 disk vantages, 0 argv.**
+   prefetch(run_count=5) + amcache + bam(last-run + SID) + userassist(execs 2→4) +
+   mrulistex(typed) + lnk. This is the strongest *breadth* convergence in the whole
+   dataset and it is the LoneWolf insider's exfil tool. Its lesson: on a disk-only host
+   you can prove *that* a binary ran six different ways yet **never recover its arguments**
+   — the S3 bucket/keys it was pointed at are not in any of these artefacts.
+
+2. **Obfuscated `cmd /c` on DESKTOP-M913391 — 3 vantages, all full argv.**
+   Raw Sysmon EID1 `ExecutableInfo` ↔ Hayabusa `Details.Cmdline` ↔ Hayabusa Sigma hit
+   `Cmd.EXE Missing Space Characters Execution Anomaly`. The `set …&&` alphabet builder
+   and the `%%var%%%%var%%` expansion decode (88 single-char env vars, 86 tokens) to a
+   `flag{…}` string — a DOSfuscation / character-substitution technique. This is the
+   textbook "same execution, log + detection" convergence.
+
+3. **winlogbeat / scoringbot / owncloud on BGP-WS1-CONF — 3 vantages incl. CAR.**
+   pslist(exe) ↔ piiat.processes(argv) ↔ car.db process(argv). Only cluster where a full
+   argv is actually lifted into CAR `command_line`, and proves CAR.process == normalized
+   piiat.processes (identical strings).
+
+---
+
+## 4. Command lines / args sitting in native/raw, NOT lifted to CAR `command_line`
+
+CAR only holds argv for **157 memory processes on one host**. Everything below is real
+command content present in the processed data that **no CAR `command_line` field
+normalises** — quantified with live examples.
+
+| Native source | Records with a command/args | In CAR? | Real examples (verbatim) |
+|---|---|---|---|
+| **Services `image_path`** (`windows:registry:service`) | **634 of 1,796** carry arguments | CAR `service` table = **0 rows** | `%SystemRoot%\System32\svchost.exe -k netsvcs -p` · `"…\DropboxUpdate.exe" /svc` · `"…\GoogleUpdate.exe" /medsvc` · `"…\NVDisplay.Container.exe" -s NVDisplay.ContainerLocalSystem -f "C:\ProgramData\NVIDIA\…log" -l 3 -d "…plugins\LocalSystem"` — the `-k <group>` service-host grouping (the exact `-k netsvcs` flag the task calls out) is only in native. |
+| **Run/RunOnce keys** (`windows:registry:run`) | 31 entries | not in CAR | `Uninstall 18.025.0204.0009: C:\Windows\system32\cmd.exe /q /c rmdir /s /q "C:\Users\jcloudy\AppData\Local\Microsoft\OneDrive\18.025.0204.0009"` · `GrpConv: grpconv -o` · `Dropbox: "…\Dropbox.exe" /systemstartup` · `GoogleDriveSync: "…\googledrivesync.exe" /autostart` |
+| **Scheduled-task `.job`** (`windows:tasks:job`) | 4 (all with params) | not in CAR | `application=…\DropboxUpdate.exe  parameters=/ua /installsource scheduler` · `parameters=/c` |
+| **LNK `command_line_arguments`** (`windows:lnk:link`) | **350** non-empty | not in CAR | chrome `--incognito` · chrome `--win-jumplist-action=most-visited http://aws.amazon.com/` · `AppVLP.exe "C:\Program Files (x86)\…\Office16\DCF\DATABASECOMPARE.EXE"` · `C:\Users\jcloudy\Downloads\rootkey.csv 5` |
+| **RunMRU / OpenSaveMRU / RecentDocs** (`windows:registry:mrulistex`) | 65 (43 RecentDocs, OpenSavePidlMRU per-ext) | not in CAR | typed/selected `s3browser-win32.exe`, `rootkey.csv`, `key.txt`, `Operation 2nd Hand Smoke.pptx`, `The Cloudy Manifesto.docx` |
+| **Prefetch / Amcache / Shimcache / BAM / UserAssist** | 1,312 / 604 / 1,463 / 76 / 153 | not in CAR (CAR `file` table is memory-MFT-derived, not these) | e.g. shimcache-only `C:\Temp\NVIDIA\3DVision\nvStInst.exe`, `C:\Users\jcloudy\…\TempState\Downloads\ChromeSetup.exe` — execution/existence evidence, exe/path only. |
+| **Sysmon EID1 / Hayabusa (DESKTOP-M913391)** | ~45 full argv | not in CAR (host absent from CAR) | the obfuscated `cmd /c`, `cmd /c "ver"`, `ipconfig`, `python.exe -m ipykernel_launcher …`, EdgeUpdate `/ua /installsource scheduler` |
+
+**Net:** the only argv that reaches CAR is the memory host's; **≈1,000+ real command
+fragments across services(634), LNK(350), Run(31), .job(4), RunMRU(65)** — plus every
+Sysmon EID1 argv — are stranded in native artefacts. This confirms and quantifies the
+prior audit flags (LNK args, .job parameters, RunMRU, Services ImagePath args).
+
+---
+
+## 5. YARA rule stubs for high-signal command patterns
+
+Rules target **rendered command-line text** (Sysmon `CommandLine`, memory `CommandLine`,
+LNK args, Run/Service values, plaso `message`). `[O]` = grounded in an observed hit in
+this dataset; `[P]` = proactive stub for the class. Tune before production; several will
+also match on benign strings and are meant as triage leads.
+
+```yara
+/* [O] DOSfuscation: env-var char-substitution alphabet builder.
+   Observed on DESKTOP-M913391: `cmd /c env =set IllllIIIll= &&set ...=<char>&&...`
+   88 single-char SET assignments then %%var%%%%var%% expansion -> flag{...}. */
+rule CMD_EnvVar_CharSub_Obfuscation
+{
+    meta:
+        author = "DX_DFIR car-crosslink hunt"
+        desc   = "DOSfuscation via mass single-char SET vars then %var% expansion"
+        ref    = "DESKTOP-M913391 Sysmon EID1 obfuscated cmd /c"
+    strings:
+        $set_run  = /(&&set [A-Za-z]{6,12}=.){20,}/    // long &&set X=<char> chain
+        $cmd      = "cmd /c" nocase
+        $expand   = /(%%?[A-Za-z]{6,12}%%?){15,}/       // long %var%%var% expansion
+    condition:
+        $cmd and ($set_run or $expand)
+}
+
+/* [O] cmd.exe missing-space / caret / token-concatenation anomaly.
+   Mirrors Hayabusa's "Cmd.EXE Missing Space Characters Execution Anomaly". */
+rule CMD_MissingSpace_TokenConcat
+{
+    strings:
+        $a = /cmd(\.exe)?["' ]{0,2}\/c["' ]{0,2}[%^]/ nocase
+        $b = "&&set " nocase
+        $c = /\^[a-z]/ nocase          // caret-escaped chars
+    condition:
+        $a and ($b or #c > 5)
+}
+
+/* [O] LOLBin / tool executed from user-writable Downloads or Temp.
+   Observed: s3browser-7-6-9.exe from \Users\jcloudy\Downloads then \AppData\Local\Temp\IS-*.TMP;
+   GoogleUpdate from \Temp\GUME1E0.tmp; setup.exe from C:\Temp\NVIDIA. */
+rule Exec_From_User_Temp_Or_Downloads
+{
+    strings:
+        $p1 = /\\Users\\[^\\]+\\Downloads\\[^\\"]+\.(exe|tmp|scr|com|ps1|bat|cmd)/ nocase
+        $p2 = /\\Users\\[^\\]+\\AppData\\Local\\Temp\\[^"]+\.(exe|tmp|dll|scr)/ nocase
+        $p3 = /\\Windows\\TEMP\\[^"]+\.(exe|tmp)/ nocase
+    condition:
+        any of them
+}
+
+/* [P/O] svchost anomaly: svchost with NO -k service group (or unknown group).
+   Legit svchost in this data always carries -k <group>; bare svchost is suspect. */
+rule Svchost_Missing_ServiceGroup
+{
+    strings:
+        $svc      = /svchost\.exe/ nocase
+        $dash_k   = /svchost\.exe"?\s+-k\s+[A-Za-z]/ nocase
+    condition:
+        $svc and not $dash_k
+}
+
+/* [P] Known-bad command flags: encoded/hidden PowerShell, remote download, LOLBin download.
+   Not observed here (this dataset's PS is benign) - proactive triage stub. */
+rule Suspicious_CommandLine_Flags
+{
+    strings:
+        $enc1 = /-e(nc(odedcommand)?)?\s+[A-Za-z0-9+\/=]{40,}/ nocase
+        $enc2 = "-w hidden" nocase
+        $enc3 = "FromBase64String" nocase
+        $dl1  = "DownloadString" nocase
+        $dl2  = "DownloadFile" nocase
+        $dl3  = /Invoke-(Expression|WebRequest)/ nocase
+        $lol1 = /(certutil|bitsadmin|mshta|regsvr32|rundll32)\b.{0,80}(http|\\\\|\/urlcache|javascript:)/ nocase
+    condition:
+        any of them
+}
+
+/* [O] Destructive/uninstall-style cmd wrappers seen in autoruns.
+   Observed Run key: cmd.exe /q /c rmdir /s /q "...\OneDrive\18.025...". Benign here,
+   but the /q /c rmdir /s /q wrapper is a common wiper/cleanup idiom - triage lead. */
+rule CMD_Silent_RecursiveDelete
+{
+    strings:
+        $a = /cmd(\.exe)?\s+\/q\s+\/c\s+rmdir\s+\/s\s+\/q/ nocase
+        $b = /cmd(\.exe)?\s+\/c\s+del\s+\/f\s+\/q/ nocase
+    condition:
+        any of them
+}
+```
+
+---
+
+## 6. Practical takeaways for the CAR normalisation layer
+
+- **Populate CAR `service.command_line` from `windows:registry:service.image_path`** — 634
+  populated ImagePaths (incl. the `-k <group>` grouping) are being dropped today.
+- **Add an autoruns/persistence normalisation** for `windows:registry:run.entries` and
+  `windows:tasks:job` (application+parameters) → `command_line`; these carry real argv
+  (`cmd.exe /q /c rmdir …`, DropboxUpdate `/ua /installsource scheduler`).
+- **Lift `windows:lnk:link.command_line_arguments`** (350 non-empty) — on disk-only hosts
+  the LNK is frequently the *only* artefact that preserves a process's argv (e.g. chrome
+  `--incognito`, `rootkey.csv 5`).
+- **Cross-vantage keying:** on a disk-only host, join prefetch↔amcache↔shimcache↔bam↔
+  userassist on the **normalised image path** (exe basename + folder) to build the
+  "execution proof" cluster; you will get breadth of evidence but must accept that argv is
+  absent. Reserve the "same command across log+memory" convergence for hosts where a
+  process-creation log (Sysmon EID1 / audited 4688-with-cmdline) or a memory capture
+  exists — and note the LoneWolf 4688 events here are argv-less (audit-cmdline disabled).
+
+---
+
+### Artefact-extraction working files (scratchpad)
+`/tmp/claude-0/-opt-github-DX-DFIR/efe5c9e9-eea7-4e0b-98c8-5da8aa5f00db/scratchpad/car-crosslink/`
+— `prefetch.jsonl amcache.jsonl appcompatcache.jsonl bam.jsonl userassist.jsonl lnk.jsonl
+service.jsonl run.jsonl taskjob.jsonl taskcache.jsonl mrulistex.jsonl shellitem.jsonl
+evtx_proc.jsonl` plus `pf_exe.txt am_path.txt shim_path.txt bam_path.txt ua_val.txt`.

--- a/docs/car-provenance/crosslink/guids.md
+++ b/docs/car-provenance/crosslink/guids.md
@@ -1,0 +1,197 @@
+# GUID cross-artefact linkage hunt — DX_DFIR processed dataset
+
+READ-ONLY scan (rg / python sqlite3). Repo `/opt/github/DX_DFIR`, tree `data_store/processed/`.
+
+## Dataset reality: three distinct hosts (linkage is WITHIN a host)
+The processed tree mixes three unrelated images. A GUID converges *inside* one host's
+artefacts; it does not (and should not) cross between them.
+
+| host / identity | lane(s) | anchor evidence |
+|---|---|---|
+| **LoneWolf disk `DESKTOP-PM6C56D`** (user `jcloudy`) | `log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB, plaso) | MachineGuid `8b9b9f31-6016-4b10-83ef-324b62a37898`; Dropbox tasks "Scheduled by DESKTOP-PM6C56D\jcloudy" |
+| **Sysmon host `DESKTOP-M913391`** (user `JDH`, Korean locale) | `windows_logs/unspecified_host/log_EvtxECmd_Output.json`; `signatures/hayabusa/timeline.jsonl` | Sysmon ProcessGuid prefix `a7738ffd-…`; Chrome |
+| **Memory host** (SID base `S-1-5-21-2899045035-919344695-3383792992`, RIDs 500/1000/1001) | `volatility/memdump.mem/plugins/*.jsonl` + `car.db` | FTK Imager 4.7.1 run from `Temp\{787A8B0F-B810-41D6-BA41-4289DB167E05}` |
+| **Linux `5g-webui`** | `log2timeline/jsonl/5g-webui.jsonl` (7.8 GB) | 679 app/5G-NF UUIDs only |
+
+Confirmed isolation: LoneWolf MachineGuid + volume GUID appear **0** times in the memory lane.
+
+## The platform's GUID model (what IS and ISN'T normalised)
+
+**CAR is the normalisation target.** `car.db` (the volatility lane) has 14 CAR tables, every
+one sharing the header `guid, owning_guid, parent_guid` (process adds `target_guid`) plus a
+`native` blob. Per `detect/rules/car-detections/join-keys.yml`, the CAR `guid` is the ONE join
+key: it travels to Elastic as ECS `event.id` on every object and as `process.entity_id` on
+process/its children, and `LOOKUP JOIN car-detections ON event.id|process.entity_id` is the
+whole cross-source convergence contract.
+
+**Decisive finding — the CAR GUID columns hold ZERO canonical GUIDs.** Of **44,327** non-null
+values across `guid/owning_guid/parent_guid/target_guid`, **none** are `{8-4-4-4-12}` shaped.
+Every value is a minted synthetic entity id:
+
+- `proc-800acda8c040` (process, from memory offset), parent link `parent_guid = proc-800ad4095200`
+- `file-…`, `registry-…`, `user_session-…` prefixes for the other objects.
+
+So the only GUIDs the engine *normalises/joins on* are the ones it **mints itself** (offset/uuid5
+entity ids; STIX side uses `uuid5(DX_NAMESPACE 518ade0c-8157-5d44-a810-9563a8af74ef,…)` and the
+SCO namespace `00abedb4-…`). Every **native** canonical GUID — MachineGuid, volume, CLSID,
+interface, task, and even Sysmon ProcessGuid — survives ONLY inside `native`/`value`/`data`/
+`message` text and is invisible to any CAR join. That is the unmined surface.
+
+Worse, the existing `owning_guid` linkage is barely populated in this data: `user_session`
+resolves 9/9 to a process, but **registry (12,171 rows) and file (31,828 rows) carry NO
+owning_guid at all** (`link_confidence = NULL`). So a registry hive value and the process that
+wrote it are not linked even by the synthetic key — and the canonical GUID that could bridge
+them is thrown away too.
+
+## High-value GUID classes
+
+| guid class | example value (real) | artefacts it links (lanes / data_types) | normalised to a CAR field? | convergence opportunity |
+|---|---|---|---|---|
+| **MachineGuid** (host identity) | `8b9b9f31-6016-4b10-83ef-324b62a37898` (LoneWolf, `HKLM\Software\Microsoft\Cryptography`) | plaso `windows:registry:key_value` (3) + `windows:evtx:record` (52) + `fs:stat` (48 — a `\Windows\System32\restore\MachineGuid.txt` was dropped on disk) = **3 data_types** | **No** — only in registry value / evtx payload / filename text | The single per-host join key; should be lifted to `host.id` and stamped on every CAR row for that image |
+| **Volume GUID** (`\\?\Volume{…}`) | `{09931f21-7faf-44a9-81d8-1e73c14b9eaf}` (2,208×, main sys volume; note mixed-case `09931F21…`) | plaso `windows:evtx:record` (1082) + `windows:registry:key_value` (34) + `fs:ntfs:usn_change` (14) + `fs:stat` (12) + `google_drive_sync_log:entry` (5) + `windows:registry:mount_points2` (2) = **6 data_types** | **No** | Best cross-source key on the box — ties USN journal ↔ event log ↔ registry ↔ cloud-sync ↔ mount table. MountPoints2 (`{3869c27a-31b8-11e8-9b12-ecf4bb487fed}`) binds it to HKCU (user) + drive letter + USB |
+| **DLT birth-droid** (LNK object/volume id, v1) | `5c2307d9-3369-11e2-be70-001cc42df40b` (node = MAC **00:1C:C4:2D:F4:0B**) | plaso `windows:lnk:link` (96) + `windows:distributed_link_tracking:creation` (32) = **2 data_types** | Partly — plaso keeps its own `uuid` field, but not into CAR, and the **embedded MAC is never extracted** | File-access provenance: which volume/machine a LNK's target was born on; the v1 node leaks the origin NIC MAC |
+| **Sysmon ProcessGuid** | `a7738ffd-09de-65aa-9f08-000000004900` | EvtxECmd `windows:evtx:record` — links Sysmon EID1↔EID5 (and EID3/7/11/22 in fuller logs); host-boot prefix `a7738ffd` shared by all 50 on `DESKTOP-M913391` | **No** (no evtx→CAR lane here; and CAR process `guid` is the memory `proc-<offset>`, a different id-space) | The native process-lineage key; if an evtx→CAR projection existed it should map ProcessGuid→`process.entity_id`, giving memory↔evtx process identity |
+| **Sysmon ParentProcessGuid** | `a7738ffd-ba54-65a9-0703-000000004900` (Chrome parent → many renderer children) | EvtxECmd EID1 (45) | **No** | Direct analogue of CAR `parent_guid`; native parent/child tree that CAR leaves un-lifted |
+| **Sysmon LogonGuid** | present on 45 EID1 records | EvtxECmd | **No** | Ties a process to its logon session (Security EID4624) — the user_session bridge CAR wants |
+| **Network interface GUID** | `{0397C57D-9E0C-4051-896B-F9C998129138}` (`…\Tcpip\Parameters\Interfaces\{…}`) | plaso registry (Tcpip, DHCP) ↔ NetworkList profiles/signatures | **No** | Binds a NIC/IP/DHCP-lease/SSID-profile together; a network-identity join key |
+| **Scheduled-task GUID** | `{0319D346-9E60-4CE2-B937-EF6C981CC0F1}` (`…\Schedule\TaskCache\Tasks\{…}`) | plaso registry `TaskCache\Tasks` ↔ `TaskCache\Tree` (name→GUID) | **No** | Persistence: links a task's definition, tree entry and action; pairs with the `windows:tasks:job` action rows (Dropbox jobs) |
+| **CLSID / interface IID / TypeLib / AppID** (COM) | `f750e6c3-38ee-11d1-85e5-00c04fc295ee` (118k×); OLE `…-c000-000000000046` family = 1,623 distinct | plaso `pe_coff:file`, `REG_SZ`, `windows:registry:key_value`, `olecf:*` | No | **Background noise** — ubiquitous on every Windows box; suppress from linkage, use only for tool/version fingerprinting |
+| **CAR minted entity id** (already the join key) | `proc-800acda8c040`; `parent_guid=proc-800ad4095200` | `car.db` all tables → ECS `event.id`/`process.entity_id` | **Yes (this IS the CAR guid)** | Working; but registry/file rows lack `owning_guid`, so the tree is incomplete |
+| **Analysis-tool GUID** | `{787A8B0F-B810-41D6-BA41-4289DB167E05}` (FTK Imager 4.7.1 temp dir, memory host BAM) | memory `car.db` registry `native` | No | Anti-forensic / examiner-activity marker; flag but exclude from evidentiary linkage |
+| **Linux app / 5G-NF UUIDs** | `f3050758-9f78-493d-a53f-89ec5ecd6b3c` (92k×) | `5g-webui.jsonl` only (679 distinct) | No (no Linux→CAR lane) | Request/session correlation within the webui; not cross-artefact |
+
+## Top cross-artefact links found on REAL data (the wins)
+
+1. **Volume `{09931f21-7faf-44a9-81d8-1e73c14b9eaf}` → 6 data_types.** Same volume id in the USN
+   change journal, event log, registry, filesystem stat, **Google Drive sync log** (5 rows), and
+   MountPoints2. One `LOOKUP … ON volume_id` would fuse disk activity, cloud exfil-sync and the
+   Windows logs for the LoneWolf case. *No CAR field carries it.*
+2. **MachineGuid `8b9b9f31-…` → registry + evtx + a `MachineGuid.txt` file on disk.** The host
+   identity is provably the same across three artefact types; ideal `host.id` seed.
+3. **DLT droid `5c2307d9-3369-11e2-be70-001cc42df40b` → LNK ↔ DLT.** 96 LNK rows + 32 DLT
+   creations share the id; its v1 node **leaks NIC MAC 00:1C:C4:2D:F4:0B** — origin-machine
+   attribution for files opened via those shortcuts (Windows PowerShell.lnk, …).
+4. **Sysmon ProcessGuid `a7738ffd-…` chains EID1↔EID5**, and ParentProcessGuid
+   `a7738ffd-ba54-65a9-0703-000000004900` is a Chrome parent fanning out to ~dozen renderer
+   children — a native process tree that never reaches CAR. **hayabusa drops ProcessGuid
+   entirely** (0 hits for `a7738ffd` in `timeline.jsonl`) → normalised-away linkage.
+5. **v1 volume GUID `{3869c27a-31b8-11e8-9b12-ecf4bb487fed}` leaks a real Dell MAC
+   `EC:F4:BB:48:7F:ED`**; sibling `{5c3108bb-31c0-11e8-9b10-806e6f6e6963}` uses the synthetic
+   `80:6E:6F:6E:69:63` placeholder — MAC recovery straight from the GUID node.
+6. **SanDisk Extreme USB** (serials `AA010215170355310594`, `AA010603160707470215`) occur **2,470×**
+   across USBSTOR / MountedDevices / EMDMgmt, tying the device to volume GUIDs (device-instance
+   id, not GUID-shaped — the USB↔volume bridge is a serial, and it too is un-normalised).
+
+## Unmined GUIDs (present in raw/native, promoted to NO CAR field)
+
+- **Every canonical GUID class above** — MachineGuid, volume, DLT, ProcessGuid/Parent/Logon,
+  interface, task, CLSID. Confirmed: 44,327 CAR guid-column values, 0 canonical.
+- **1,280 registry rows in `car.db`** carry canonical GUIDs only in `key`/`value`/`data` text
+  (WppRecorder TraceGuids, BFE provider GUIDs, VideoID `{4614AA7F-A256-11ED-…}`, BthAvctp
+  profile GUIDs) — none lifted, and those registry rows also have no `owning_guid`.
+- **LoneWolf plaso**: 60,957 distinct GUIDs / 2.9M occurrences (v4 33,593 · v3 10,293 · v5 6,932 ·
+  **v1 6,218 = the MAC-bearing set** · nil family 12,216 occ). Only the minted `proc-*` ids are
+  queryable; the rest are lexical.
+- **The MAC embedded in every v1 GUID** (DLT + `…-11e2-`/`-11e8-` volume/interface GUIDs) — never
+  decoded into a `mac_address`-style field except in the one DLT data_type.
+- **Linux 5g-webui**: all 679 UUIDs unmined (no Linux CAR lane at all).
+
+## YARA rule stubs (systematically flag these across future datasets)
+
+```yara
+rule GUID_MachineGuid_HostIdentity {
+    meta:
+        desc = "HKLM\\Software\\Microsoft\\Cryptography MachineGuid — per-host identity join key"
+        author = "dxdfir car-crosslink"
+    strings:
+        $k  = "Microsoft\\Cryptography" nocase
+        $v  = "MachineGuid" nocase
+        $re = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+    condition:
+        $k and $v and $re
+}
+
+rule GUID_Volume_MountKey {
+    meta: desc = "\\?\\Volume{GUID} / MountedDevices / MountPoints2 volume identity (case-insensitive)"
+    strings:
+        $vol = /Volume\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}/ nocase
+        $mp2 = "MountPoints2" nocase
+        $md  = "MountedDevices" nocase
+    condition:
+        $vol and ($mp2 or $md or #vol > 1)
+}
+
+rule GUID_V1_MAC_Embedded {
+    meta: desc = "Version-1 (time/MAC) GUID — node bytes leak originating NIC MAC (DLT birth-droid, v1 volume/interface GUIDs)"
+    strings:
+        // 3rd group starts with 1 (v1); excludes the c000-...-46 COM family and the 806e6f6e6963 placeholder
+        $v1 = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-1[0-9a-fA-F]{3}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+    condition:
+        $v1 and not ($v1 matches /-c000-000000000046/)   // pseudo; in practice post-filter node != 806e6f6e6963
+}
+
+rule GUID_Sysmon_ProcessLineage {
+    meta: desc = "Sysmon ProcessGuid / ParentProcessGuid / LogonGuid — native process+logon lineage (map to process.entity_id)"
+    strings:
+        $pg  = "ProcessGuid" nocase
+        $ppg = "ParentProcessGuid" nocase
+        $lg  = "LogonGuid" nocase
+        $re  = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+    condition:
+        any of ($pg,$ppg,$lg) and $re
+}
+
+rule GUID_ScheduledTask_Persistence {
+    meta: desc = "TaskCache\\Tasks|Tree {GUID} — scheduled-task persistence linkage"
+    strings:
+        $tc = "TaskCache" nocase
+        $g  = /\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}/
+    condition:
+        $tc and $g
+}
+
+rule GUID_NetworkInterface_Identity {
+    meta: desc = "Tcpip\\Parameters\\Interfaces\\{GUID} / NetworkList profile GUID — NIC/IP/SSID join key"
+    strings:
+        $if = "Tcpip\\Parameters\\Interfaces" nocase
+        $nl = "NetworkList\\Profiles" nocase
+        $g  = /\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}/
+    condition:
+        ($if or $nl) and $g
+}
+
+rule GUID_AntiForensic_ImagingTool {
+    meta: desc = "Forensic/imaging tool artefacts (FTK Imager temp GUID dir, examiner activity)"
+    strings:
+        $ftk = "FTK_Imager" nocase
+        $ad  = "AccessData" nocase
+        $tmp = /Temp\\\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}/ nocase
+    condition:
+        ($ftk or $ad) and $tmp
+}
+
+// Case-specific HUNT rule — pin the concrete LoneWolf identifiers for retro-sweep across any future acquisition
+rule HUNT_LoneWolf_DESKTOP_PM6C56D {
+    meta: desc = "LoneWolf host DESKTOP-PM6C56D / jcloudy identity constants"
+    strings:
+        $machine = "8b9b9f31-6016-4b10-83ef-324b62a37898" nocase
+        $vol     = "09931f21-7faf-44a9-81d8-1e73c14b9eaf" nocase
+        $droid   = "5c2307d9-3369-11e2-be70-001cc42df40b" nocase
+        $mac     = { 00 1C C4 2D F4 0B }
+        $host    = "DESKTOP-PM6C56D" nocase
+    condition:
+        any of them
+}
+```
+
+### Concrete recommendations for the pipeline
+1. Lift **MachineGuid → `host.id`** and stamp it on every CAR row of that image (the missing
+   per-host anchor).
+2. Add a **volume-GUID join key** (`\\?\Volume{…}`, case-folded) as a first-class CAR field — it
+   already converges 6 data_types on real data.
+3. In any evtx→CAR projection, map **Sysmon ProcessGuid→`process.entity_id`,
+   ParentProcessGuid→`parent_guid`, LogonGuid→a user_session key** (mirrors what CAR already does
+   with minted ids) — and stop hayabusa from dropping ProcessGuid.
+4. **Decode the v1-GUID node into a `mac_address` field** for DLT/volume/interface GUIDs.
+5. Populate **`owning_guid` on registry/file CAR rows** (currently NULL) so the synthetic tree is
+   whole; the canonical GUIDs inside those rows are the bridge material.

--- a/docs/car-provenance/crosslink/host_ip.md
+++ b/docs/car-provenance/crosslink/host_ip.md
@@ -1,0 +1,219 @@
+# Cross-Artefact Linkage Hunt: Hostnames, IPs, MACs & Domains
+
+Dataset: `/opt/github/DX_DFIR/data_store/processed/` (READ-ONLY analysis)
+Scope: plaso (`log2timeline/jsonl/*`), Windows logs (`windows_logs/`), Zeek (`zeek/*`), Volatility memory (`volatility/memdump.mem/plugins/*` + `car.db`).
+
+---
+
+## TL;DR
+
+- **This is a MULTI-HOST, MULTI-SCENARIO dataset — 4 distinctly-named machines + 2 un-attributed network capture identities. NO single hostname value bridges any two named hosts.** Each anchor hostname appears ONLY in its own artefact.
+- The only genuine cross-source bridges are **network-infrastructure identifiers, none of which any normalisation layer (CAR) captures**:
+  1. **DNS resolver `100.95.95.4` / IPv6 `2a07:1181:95:95::4`** links the **memory host `BGP-WS1-CONF`** (registry NameServer) to the **Zeek DFIRdump capture** (DNS `id.resp_h`). Same network, adjacent /25 subnets.
+  2. **Domain `berylia.org`** links the **`5g-webui` Linux disk** (on-disk TLS cert) to the **Zeek capture** (DNS/SSL/HTTP).
+- The memory→disk→log host-identity reconciliation **fails by name**: memory `ComputerName = BGP-WS1-CONF`, disks = `DESKTOP-PM6C56D` / `5g-webui`, logs = `DESKTOP-M913391`. Confirmed the earlier finding — memory host ≠ disk/log host. They can only be tied together (partially) through the shared DNS server and the berylia domain.
+- **CAR normalises host identity only for the memory image, and drops ALL network identity**: `flow`, `socket`, `http`, `email`, `authentication` tables = 0 rows; `user_session.src_ip/dest_ip` all NULL. Every IP/MAC/domain/flow in the dataset is available only in raw/native form.
+
+---
+
+## 1. Multi-Host Map — which artefacts = which machine
+
+| Machine (hostname) | Artefact(s) | Asserting field / evidence | Primary user | Scenario / network |
+|---|---|---|---|---|
+| **DESKTOP-PM6C56D** | `log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (disk `LoneWolf.E01`, Win10) | plaso `image_hostname` | `jcloudy` | "LoneWolf" scenario — **no** berylia domain, **no** 10.27/100.x IPs; isolated from the exercise network |
+| **5g-webui** | `log2timeline/jsonl/5g-webui.jsonl` (disk `5g-image-1.vmdk`, Linux) | plaso `image_hostname`; FQDN from on-disk cert `/srv/certs/5g-webui.sac.baf.10.berylia.org_cert.crt` | root | berylia exercise (`sac.baf.10.berylia.org`) |
+| **BGP-WS1-CONF** | `volatility/memdump.mem/plugins/*.jsonl` + `car.db` (process/file/registry/user_session) | registry `...\Control\ComputerName\ComputerName = BGP-WS1-CONF`; process env `COMPUTERNAME=BGP-WS1-CONF`; CAR `hostname` column | `Administrator` | berylia exercise — static IP **10.27.32.51/25**, GW **10.27.32.1**, DNS **100.95.95.4** |
+| **DESKTOP-M913391** | `windows_logs/unspecified_host/log_EvtxECmd_Output.json` (85 Sysmon recs) | EvtxECmd `Computer` field (all 85 records) | `DESKTOP-M913391\JDH` | Sysmon process telemetry (Chrome activity); EventIDs 1 & 5 only — **no network events**, host never tied to an IP |
+| *(un-named)* `10.27.33.61` / `2a07:1182:27:33::61` | `zeek/DFIRdump_FOR_200_capture_pcap/*` | Zeek `id.orig_h` (C2-beacon source) | — | berylia exercise client, subnet 10.27.33.x (adjacent to BGP-WS1-CONF's 10.27.32.x) |
+| *(un-named)* `100.100.250.37` | `zeek/ME_FOR_1308_pcapng/conn.json` | Zeek `id.orig_h` (large HTTP upload → 100.101.0.162:80) | — | berylia exercise, subnet 100.100.250.x |
+| *(no IP — USB)* | `zeek/keylogging_pcapng/*` | USB link-layer capture (packet-filter install failed: "USB link-layer type") | — | HID keylogging capture; **contains no IP/host data at all** |
+
+**Does any value bridge the named hosts?** No hostname does. Bridges are network-level only: `100.95.95.4`/`2a07:1181:95:95::4` (BGP-WS1-CONF ↔ Zeek DFIRdump) and `berylia.org` (5g-webui ↔ Zeek). LoneWolf `DESKTOP-PM6C56D` and Sysmon `DESKTOP-M913391` are **not bridged to anything** — separate scenarios.
+
+---
+
+## 2. Master linkage table
+
+`| value | artefacts | normalised? | link use |`
+
+| value (host/IP/MAC/domain) | artefacts asserting it | normalised (CAR)? | link use |
+|---|---|---|---|
+| `DESKTOP-PM6C56D` | plaso DESKTOP-PM6C56D.jsonl only | n/a (plaso `image_hostname`) | single-artefact; no cross-link |
+| `5g-webui` | plaso 5g-webui.jsonl only | n/a (plaso `image_hostname`) | anchors Linux disk; FQDN carries berylia bridge |
+| `BGP-WS1-CONF` | memory: pslist/piiat.* + `car.db` process/file/registry/user_session | **YES** — CAR `hostname` (from registry ComputerName + env) | memory host identity; NOT found in any disk/log |
+| `DESKTOP-M913391` | windows_logs EvtxECmd `Computer` (85 recs) | NO | Sysmon host identity; no IP, no cross-link |
+| `5g-webui.sac.baf.10.berylia.org` (FQDN) | 5g-webui disk cert `/srv/certs/*.crt` | NO | ties 5g-webui disk into berylia.org domain |
+| **`100.95.95.4`** (IPv4 DNS) | Zeek conn.json + Zeek dns.json (`id.resp_h`) **AND** memory registry `Tcpip\...\Interfaces\{89b3e14f-...}` NameServer | **NO** (memory reg raw; CAR has 0 IPs) | **CONVERGENCE KEY — memory↔network.** Same DNS for BGP-WS1-CONF and Zeek client 10.27.33.61 |
+| **`2a07:1181:95:95::4`** (IPv6 DNS) | Zeek conn.json (7608 resp) + dns.json **AND** memory registry Tcpip6 Interfaces NameServer | **NO** | **CONVERGENCE KEY — memory↔network** (IPv6 sibling of above) |
+| **`berylia.org`** (+ `scoring-c2`, `dfir-rt-web02`, `*.confidential.baf.27`) | Zeek dns/ssl/http/x509 **AND** 5g-webui disk cert filename | **NO** | **CONVERGENCE KEY — disk↔network** |
+| `100.101.0.42` | Zeek dns (`answers`) + conn + http (`host`=scoring-c2) + ssl (SNI=scoring-c2) | NO | DNS→IP→flow C2 pivot within Zeek (4 log types) |
+| `10.27.32.51` (BGP-WS1-CONF IP) | memory registry IPAddress only | NO | memory host's own IP — **absent from Zeek pcap** (its traffic not captured) |
+| `10.27.32.1` (BGP-WS1-CONF GW) | memory registry DefaultGateway only | NO | not seen elsewhere |
+| `10.27.33.61` / `2a07:1182:27:33::61` | Zeek DFIRdump conn/dns/http/ssl (`id.orig_h`) | NO | C2-beacon client; adjacent subnet to BGP-WS1-CONF |
+| `100.100.250.37` → `100.101.0.162` | Zeek ME_FOR_1308 conn.json | NO | large HTTP upload (exfil pattern) |
+| `144.202.62.192` | Zeek dns (`answers` for whatthecommit.com) + conn | NO | resolved external IP |
+| MAC `00:50:56:89:a2:69`, `00:50:56:89:ab:90` | Zeek conn IPv6 link-local (EUI-64 embedded), e.g. `fe80::250:56ff:fe89:a269` | **NO** (no MAC field anywhere) | VMware OUI `00:50:56` → confirms virtualised (ESXi vNIC) infra |
+
+---
+
+## 3. Cross-source IP / domain links (zeek ↔ registry ↔ memory)
+
+### Link A — DNS resolver bridges MEMORY ↔ NETWORK
+- **Memory (`BGP-WS1-CONF`)** — `windows.piiat.registry.jsonl`, key `\REGISTRY\MACHINE\SYSTEM\ControlSet001\Services\Tcpip\Parameters\Interfaces\{89b3e14f-e403-4965-be04-aaeceb0a4e2f}`:
+  - `IPAddress = 10.27.32.51`, `SubnetMask = 255.255.255.128` (/25), `DefaultGateway = 10.27.32.1`
+  - `NameServer = 100.95.95.4`; Tcpip6 `NameServer = 2a07:1181:95:95::4`; `DhcpServer = 255.255.255.255` (static)
+- **Zeek DFIRdump** — `conn.json`/`dns.json`: `id.resp_h = 100.95.95.4` (118 flows) and `2a07:1181:95:95::4` (7608 flows) on `id.resp_p = 53` — i.e. the **same DNS resolver**.
+- **Inference:** `BGP-WS1-CONF` (10.27.32.51) and the Zeek client (10.27.33.61) are on **adjacent /25 subnets of the same network** and share DNS infrastructure. `10.27.32.51` itself does **not** appear in the pcap, so BGP-WS1-CONF's own traffic was not captured — the bridge is the shared resolver, not host identity.
+
+### Link B — berylia.org bridges DISK ↔ NETWORK
+- **5g-webui disk:** `fs:stat` on `/srv/certs/5g-webui.sac.baf.10.berylia.org_cert.crt` → host FQDN in `berylia.org`.
+- **Zeek DFIRdump:** DNS queries dominated by `dfir-rt-web02.berylia.org` (7912) and `scoring-c2.berylia.org` (15); SSL SNI + HTTP Host = `scoring-c2.berylia.org`; x509 subject `CN=berylia.org`, SAN `*.berylia.org`; also `*.fastedge.cloud.confidential.baf.27.berylia.org`.
+- **Inference:** the 5g-webui disk and the Zeek capture belong to the same `berylia.org` exercise domain (5g-webui in `baf.10`, Zeek DNS traffic in `baf.27` — sibling org segments).
+
+### Link C — DNS→IP→flow C2 chain (within Zeek; not normalised)
+- `scoring-c2.berylia.org` --(DNS A via 100.95.95.4)--> `100.101.0.42` --(conn)--> flows `10.27.33.61 → 100.101.0.42` on ports **22 (SSH), 80 (HTTP), 443 (HTTPS)**.
+- HTTP beacons use `User-Agent: masscan/1.0` POSTing to `/stuffing.php`, `/quintuple.jsp`, etc. → classic scored-C2 beaconing. This full chain is derivable ONLY by manually joining Zeek's raw `dns.answers` ↔ `conn` ↔ `http`; no normaliser ties them.
+
+---
+
+## 4. Un-normalised network identifiers (raw/native — no CAR field carries them)
+
+1. **CAR drops all network identity.** `car.db` tables `flow`, `socket`, `http`, `email`, `authentication`, `driver`, `module`, `service`, `thread` = **0 rows**. Populated: `file` (31828), `registry` (12171), `process` (180), `user_session` (9), `image_context` (163). Even `user_session.src_ip/src_port/dest_ip/dest_port` are **all NULL**. So the CAR schema *has* IP columns but nothing populates them.
+2. **Memory static IP config is buried in raw registry.** `10.27.32.51`, `10.27.32.1`, `100.95.95.4`, `2a07:1181:95:95::4`, subnet `255.255.255.128` live only inside raw `windows.piiat.registry.jsonl` Tcpip Interface `ValueData` strings — never surfaced to a normalised IP field. The memory host is therefore never programmatically tied to its own IP.
+3. **Zeek is entirely raw** (not ingested into CAR at all): every `id.orig_h`/`id.resp_h`, `dns.query`, `dns.answers`, `ssl.server_name`, `http.host`, `x509` subject/SAN is native JSON only.
+4. **DNS answers not tied to flows.** `dns.answers` present in only 21 records; even there, the domain→IP→conn correlation must be done by hand (no join key emitted).
+5. **MAC addresses exist only implicitly.** No artefact emits a MAC field. The only MACs recoverable are EUI-64-embedded in Zeek IPv6 link-locals: `fe80::250:56ff:fe89:a269 → 00:50:56:89:a2:69` and `fe80::250:56ff:fe89:ab90 → 00:50:56:89:ab:90` (VMware OUI 00:50:56). Registry `NetworkAddress`/`PermanentAddress` MAC values: none present in the dumped SYSTEM hive.
+6. **Sysmon host has no network telemetry.** `DESKTOP-M913391` EvtxECmd = EventID 1 (ProcessCreate) & 5 (ProcessTerminate) only; no EventID 3 (NetworkConnect). Host can never be joined to the network graph by IP.
+7. **On-disk TLS cert subject not normalised.** `5g-webui.sac.baf.10.berylia.org` (disk) and Zeek `CN=berylia.org` / SAN `*.berylia.org` are never reconciled to a common domain entity.
+
+---
+
+## 5. YARA rule stubs (IPv4 / IPv6 / MAC / hostname / domain)
+
+```yara
+/*
+   Cross-artefact network-identity anchors — DX_DFIR processed dataset.
+   Real values pulled from Zeek + Volatility memory registry + plaso disks.
+   Intended for sweeping raw/unstructured evidence (memory strings, disk
+   images, pcaps, logs) for the convergence keys the CAR layer never normalised.
+*/
+
+rule DXDFIR_Hostnames_MultiHost
+{
+    meta:
+        author = "car-crosslink hunt"
+        description = "The four named hosts across disk/memory/log artefacts"
+    strings:
+        $h1 = "DESKTOP-PM6C56D" ascii wide nocase   // LoneWolf disk
+        $h2 = "5g-webui"        ascii wide nocase   // Linux disk
+        $h3 = "BGP-WS1-CONF"    ascii wide nocase   // memory dump
+        $h4 = "DESKTOP-M913391" ascii wide nocase   // Sysmon logs
+    condition:
+        any of them
+}
+
+rule DXDFIR_Berylia_C2_Domains
+{
+    meta:
+        description = "berylia.org exercise domains — disk<->network bridge & C2"
+    strings:
+        $d1 = "berylia.org"                 ascii wide nocase
+        $d2 = "scoring-c2.berylia.org"      ascii wide nocase   // C2
+        $d3 = "dfir-rt-web02.berylia.org"   ascii wide nocase
+        $d4 = "5g-webui.sac.baf.10.berylia.org" ascii wide nocase
+        $d5 = "confidential.baf.27.berylia.org" ascii wide nocase
+    condition:
+        any of them
+}
+
+rule DXDFIR_IPv4_Anchors
+{
+    meta:
+        description = "Convergence IPv4s: DNS 100.95.95.4 links memory<->zeek"
+    strings:
+        $ip_dns  = "100.95.95.4"    ascii wide   // DNS: memory reg + zeek
+        $ip_bgp  = "10.27.32.51"    ascii wide   // BGP-WS1-CONF static IP
+        $ip_gw   = "10.27.32.1"     ascii wide   // BGP-WS1-CONF gateway
+        $ip_cli  = "10.27.33.61"    ascii wide   // zeek C2-beacon client
+        $ip_c2   = "100.101.0.42"   ascii wide   // scoring-c2 resolved IP
+        $ip_up   = "100.100.250.37" ascii wide   // ME_FOR_1308 uploader
+    condition:
+        any of them
+}
+
+rule DXDFIR_IPv6_Anchors
+{
+    meta:
+        description = "Convergence IPv6s incl. DNS resolver (memory<->zeek)"
+    strings:
+        $v6_dns = "2a07:1181:95:95::4"     ascii wide nocase   // DNS memory+zeek
+        $v6_cli = "2a07:1182:27:33::61"    ascii wide nocase   // zeek client
+    condition:
+        any of them
+}
+
+rule DXDFIR_VMware_MAC
+{
+    meta:
+        description = "VMware vNIC MACs recovered from zeek IPv6 EUI-64 link-locals"
+    strings:
+        $m1 = "00:50:56:89:a2:69" ascii wide nocase
+        $m2 = "00:50:56:89:ab:90" ascii wide nocase
+        // EUI-64 forms as seen on the wire:
+        $e1 = "fe80::250:56ff:fe89:a269" ascii wide nocase
+        $e2 = "fe80::250:56ff:fe89:ab90" ascii wide nocase
+    condition:
+        any of them
+}
+
+/* ---- Generic pattern rules (regex) for un-anchored discovery ---- */
+
+rule GENERIC_IPv4_Address
+{
+    meta: description = "Any dotted-quad IPv4 (validate octets downstream)"
+    strings:
+        $ipv4 = /([0-9]{1,3}\.){3}[0-9]{1,3}/ ascii wide
+    condition:
+        $ipv4
+}
+
+rule GENERIC_IPv6_Address
+{
+    meta: description = "IPv6 incl. compressed :: forms"
+    strings:
+        $ipv6 = /([0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F:]{1,4}/ ascii wide
+    condition:
+        $ipv6
+}
+
+rule GENERIC_MAC_Address
+{
+    meta: description = "48-bit MAC, colon or hyphen separated"
+    strings:
+        $mac = /([0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}/ ascii wide
+    condition:
+        // guard against date-like false positives (e.g. 24-02-14-06-36-46)
+        $mac
+}
+
+rule GENERIC_Windows_Hostname_NETBIOS
+{
+    meta: description = "DESKTOP-/WS-style NetBIOS names for host discovery"
+    strings:
+        $nb = /\b(DESKTOP|WIN|WS|SRV|BGP)[-][A-Z0-9]{3,15}\b/ ascii wide nocase
+    condition:
+        $nb
+}
+```
+
+---
+
+## 6. Evidence pointers (absolute paths)
+
+- Memory static IP / DNS (BGP-WS1-CONF): `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/plugins/windows.piiat.registry.jsonl` — Tcpip Interface `{89b3e14f-e403-4965-be04-aaeceb0a4e2f}`; ComputerName under `...\Control\ComputerName\ComputerName`.
+- Memory COMPUTERNAME env: `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/plugins/windows.piiat.processes.jsonl` (EnvVars `COMPUTERNAME=BGP-WS1-CONF`).
+- CAR normalised host / empty network tables: `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/car.db`.
+- Zeek DNS/flow/C2: `/opt/github/DX_DFIR/data_store/processed/zeek/DFIRdump_FOR_200_capture_pcap/{conn,dns,http,ssl,x509}.json`; second capture `/opt/github/DX_DFIR/data_store/processed/zeek/ME_FOR_1308_pcapng/conn.json`.
+- 5g-webui FQDN cert: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/5g-webui.jsonl` (`berylia` matches → `/srv/certs/5g-webui.sac.baf.10.berylia.org_cert.crt`).
+- Sysmon host: `/opt/github/DX_DFIR/data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json` (`Computer = DESKTOP-M913391`).
+- LoneWolf host: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (`image_hostname = DESKTOP-PM6C56D`).

--- a/docs/car-provenance/crosslink/identity.md
+++ b/docs/car-provenance/crosslink/identity.md
@@ -1,0 +1,151 @@
+# Identity-Linkage Hunt: SIDs & Usernames as Cross-Artefact Convergence Keys
+
+Dataset: `/opt/github/DX_DFIR/data_store/processed/` — READ-ONLY hunt. All values below are real, pulled from the processed data.
+
+## TL;DR
+
+- The processed dataset contains **FOUR distinct hosts**, each with its own machine SID — the single most important cross-artefact discovery. Identity keys let you (a) prove which artefacts belong to the same account/host, and (b) expose that ~100% of disk-artefact identity is never lifted into a normalised CAR field.
+- The **only** CAR store that exists (`volatility/memdump.mem/car.db`) is built solely from the **memory** image. Nothing from the disk (plaso/EvtxECmd/hayabusa) or network (zeek) is normalised into any CAR table — so 100% of those artefacts' identity is unmined by definition.
+- On the disk plaso timeline the native `username` field is `"-"` for **4,169,732 of 4,169,774** records (**99.999%**), yet SIDs and `\Users\<name>\` paths are everywhere.
+
+---
+
+## The four hosts (machine-SID ↔ RID ↔ username reconciliation, real values)
+
+| Host | Source artefacts | Machine SID | RID → username (real) |
+|---|---|---|---|
+| **DESKTOP-PM6C56D** (evtx hostname `WIN-1M3263ACE5D`, pre-rename; computer acct `WIN-1M3263ACE5D$`) | `log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (disk, 6.6GB) | `S-1-5-21-2734969515-1644526556-1039763013` | **1001→jcloudy** (login 15/23), **1000→defaultuser0** (login 2), 500→Administrator, 501→Guest, 503→DefaultAccount, 504→WDAGUtilityAccount, 513→(Domain Users group) |
+| **memdump.mem** | `volatility/memdump.mem/` (memory → `car.db` + piiat plugins) | `S-1-5-21-2899045035-919344695-3383792992` | **500→Administrator**, **1000→gt** (`C:\Users\gt`), **1001→scoringbot** (`C:\Users\scoringbot`) |
+| **DESKTOP-M913391** | `windows_logs/unspecified_host/log_EvtxECmd_Output.json` + `signatures/hayabusa/timeline.jsonl` | `S-1-5-21-3081547798-3199192215-1922722758` | **100137→JDH** (`DESKTOP-M913391\JDH`, `C:\Users\JDH`) |
+| **5g-webui** (Linux) | `log2timeline/jsonl/5g-webui.jsonl` (7.8GB, `linux:utmp:event`, `syslog:ssh:login`) | n/a (Linux, no NT SID) | usernames: **root**, **LS23_BT10**, **gt**, **_mcs**, LOGIN |
+
+Zeek network artefacts (`zeek/*/*.json`): **zero SIDs, zero `\Users\`** — as expected, no identity to mine.
+
+### THE identity spine (DESKTOP-PM6C56D / jcloudy) — the canonical reconciliation chain
+
+```
+SAM  (windows:registry:sam_users)           Username: jcloudy   RID: 1001   Login count: 15
+   +  ProfileList machine SID                S-1-5-21-2734969515-1644526556-1039763013
+   =  full SID                               S-1-5-21-2734969515-1644526556-1039763013-1001
+   -> ProfileList ProfileImagePath           C:\Users\jcloudy
+   -> HKU\<SID> hive / UserAssist (HKCU)      per-user execution
+   -> evtx SubjectUserSid (record 4728)       jcloudy (-1001) added to group -513 (Domain Users), subject S-1-5-18
+   -> BAM  (defaultuser0, RID 1000)           program-execution attribution
+   -> google_drive_sync_log (app self-binds): "Using SID PySID:S-1-5-21-2734969515-1644526556-1039763013-1001
+                                                for account 'DESKTOP-PM6C56D\jcloudy'"
+```
+A single derivation of `...-1001 = jcloudy = C:\Users\jcloudy` attributes **every** row in the convergence table below.
+
+---
+
+## Convergence keys — same SID/user across ≥2 artefacts
+
+| value (SID / user) | artefacts it appears in | normalised to CAR user/uid/sid? | link / convergence use |
+|---|---|---|---|
+| **jcloudy** = `S-1-5-21-2734969515-1644526556-1039763013-1001` | `\Users\jcloudy` path in ~20 disk data_types: fs:stat (92 909), registry:key_value (28 057), chrome:cache (21 636), google_drive_sync_log (18 700), chrome:cookie (8 863), chrome:history (2 293), pe_coff:file (1 323), msie:webcache (921), chrome:autofill (802), shell_item/shellbags (782), evtx (690), lnk:link (597), distributed_link_tracking (160), userassist (151), olecf:dest_list/jumplist (72), registry:mrulistex (65), registry:bagmru (60), openxml:metadata (55), chrome downloads (42). **SID (RID 1001)** in: evtx (42 838), fs:stat (2 448), registry (917), ntfs:usn_change (268), google_drive (133), prefetch (118), bam (64), task_scheduler (6), deleted_item (5). SAM RID 1001, ProfileList. | **NO** (disk → no CAR store; native `username`=`-`). Real value only in `windows:registry:sam_users` message + 10 evtx/task records. | **Primary convergence spine.** One derivation links web history + shellbags + LNK + jumplists + prefetch + evtx logons + file ownership + Drive sync to the same human. |
+| **defaultuser0** = `...-1039763013-1000` | SAM (`sam_users`, RID 1000, login 2), ProfileList, **BAM** `UserSettings\<SID>` execution (message: `[S-1-5-21-2734969515-1644526556-1039763013-1000]`), `\Users\defaultuser0` (10 348 path hits) | **NO** — BAM `username`=`-`, SID only in message string | Ties OOBE/first-boot program execution (BAM) to the staged default profile; distinguishes automated vs. interactive (jcloudy) activity. |
+| **gt** | memory host RID 1000 = `C:\Users\gt` (piiat.registry ProfileList) **AND** 5g-webui Linux utmp `username=gt` | Memory: partial (process/session `User` set); Linux: native `username` populated; **no CAR store for either → not in CAR** | **Cross-host username convergence** — same operator/account name `gt` on the memory Windows host and the 5G Linux host; candidate pivot linking the two captures. |
+| **Administrator** = `...-3383792992-500` (memory host) | car.db `process` (38 rows, sid+uid+user set), `user_session` (login_id `0x3697b`), piiat ProfileList `C:\Users\Administrator` | **YES (memory only)** — process.sid/uid/user + user_session.uid populated | Links running processes ↔ logon session ↔ profile on the memory host. |
+| **JDH** = `S-1-5-21-3081547798-3199192215-1922722758-100137` | EvtxECmd `UserName=DESKTOP-M913391\JDH` (69), hayabusa `Details`/`Users\JDH` (25), SID in EvtxECmd Payload (4) + hayabusa (2) | **partial** — EvtxECmd `UserName` field set, but `UserId` field = `S-1-5-18` only (JDH's SID `-100137` sits in raw Payload, not lifted); hayabusa has **no** user/sid field at all | Confirms EvtxECmd export and hayabusa signatures are derived from the **same** evtx (host DESKTOP-M913391). |
+| **S-1-5-18 / S-1-5-19 / S-1-5-20** (well-known) | disk evtx (84 464 lines w/ 18/19/20), memory car.db process (18→81, 19→29, 20→11) + user_session, EvtxECmd UserId (85) | Memory: **YES**; disk/EvtxECmd: mostly raw | Baseline system-account noise; used to separate service from interactive activity. |
+| **`...-1039763013-513`** (Domain Users group) | disk evtx (58) e.g. record 4728 group-membership | **NO** | Group-membership convergence: shows jcloudy's group context at account creation. |
+
+---
+
+## Dataset-wide count of UN-normalised user/SID occurrences, by artefact
+
+**Disk plaso `DESKTOP-PM6C56D.jsonl` — records whose raw line carries a full `S-1-5-21-…-RID` SID while CAR user/uid/sid = null (no CAR store exists for disk, so 100% unnormalised):**
+
+| data_type (artefact) | records carrying an S-1-5-21 SID | native `username` |
+|---|---|---|
+| windows:evtx:record | 48 230 | `-` (SID lives in `strings` / `xml_string` array) |
+| windows:registry:key_value | 4 282 | `-` (SID in `key_path`/message, e.g. HKU\<SID>, ProfileList) |
+| fs:stat | 2 544 | `-` (owner SID in NTFS security descriptor) |
+| fs:ntfs:usn_change | 268 | `-` |
+| windows:prefetch:execution | 133 | `-` |
+| google_drive_sync_log:entry | 123 | `-` (app log self-binds SID↔`DESKTOP-PM6C56D\jcloudy`) |
+| windows:registry:bam | 72 | `-` (SID = `UserSettings\<SID>` key) |
+| windows:registry:task_scheduler:task_cache:entry | 6 | `-` |
+| windows:metadata:deleted_item | 5 | `-` |
+
+Native `username` field across the **entire** 4 169 774-record disk timeline: `"-"` on **4 169 732** (99.999%). The only real values (42 records total): `windows:registry:sam_users` (jcloudy×9, WDAGUtilityAccount×6, Administrator/Guest/DefaultAccount/defaultuser0 ×3 each), `windows:tasks:job`/`trigger` (`DESKTOP-PM6C56D\jcloudy` ×10), and 5 stray evtx records.
+
+**Memory CAR store `car.db` (the only populated CAR db) — identity-field coverage of populated tables:**
+
+| CAR table | rows | user | uid | sid / owner | verdict |
+|---|---|---|---|---|---|
+| `process` | 180 | 159 | 164 | sid 164 | **normalised** (only well-behaved table) |
+| `user_session` | 9 | 4 | 9 | login_id 9 | uid always set; `user` null for font-driver-host SIDs (S-1-5-90/96-*) |
+| `file` (MFTScan) | 31 828 | **0** | **0** | owner 0 / owner_uid 0 | **0% — every identity column null** |
+| `registry` | 12 171 | **2** | — | — | **~99.98% null** |
+| `authentication`,`driver`,`email`,`flow`,`http`,`module`,`service`,`socket`,`thread` | 0 | — | — | — | empty (no source data mapped) |
+
+So even inside the CAR store, only `process` (and mostly `user_session`) actually normalise identity; `file` and `registry` — 44k rows — carry none. `image_context` (163 rows) is raw plugin passthrough.
+
+**EvtxECmd export:** `UserName` populated (`DESKTOP-M913391\JDH`, `NT AUTHORITY\SYSTEM`) but `UserId` = `S-1-5-18` on 85 records only — JDH's SID `-100137` remains in the raw Payload, unlifted. **Hayabusa:** schema has **no** user/uid/sid field; identity exists only inside free-text `Details`.
+
+---
+
+## YARA rule stubs — sweep for unmined identity in raw/native artefacts
+
+```yara
+rule DFIR_Windows_SID_Any
+{
+    // Any Windows SID (well-known + domain/machine with RID). Hunts SIDs buried in
+    // evtx <strings>/xml, registry key_paths (HKU\<SID>, BAM UserSettings\<SID>),
+    // fs:stat security descriptors, and app logs (e.g. Google Drive "Using SID ...").
+    meta:
+        author = "dxdfir car-crosslink identity hunt"
+        purpose = "flag identity keys that no CAR user/uid/sid field normalises"
+    strings:
+        $sid_domain    = /S-1-5-21-[0-9]{6,}-[0-9]{6,}-[0-9]{6,}-[0-9]{1,7}/ ascii wide
+        $sid_wellknown = /S-1-5-(18|19|20)\b/ ascii wide
+    condition:
+        $sid_domain or $sid_wellknown
+}
+
+rule DFIR_Case_MachineSIDs
+{
+    // The four hosts' anchors in THIS dataset — pin an artefact to a specific host.
+    meta:
+        note = "PM6C56D=jcloudy disk; 2899045035=Administrator/gt/scoringbot memory; 3081547798=JDH evtx"
+    strings:
+        $h_desktop_pm6c56d = "S-1-5-21-2734969515-1644526556-1039763013" ascii wide
+        $h_memdump         = "S-1-5-21-2899045035-919344695-3383792992"  ascii wide
+        $h_m913391         = "S-1-5-21-3081547798-3199192215-1922722758"  ascii wide
+    condition:
+        any of them
+}
+
+rule DFIR_Windows_UserProfilePath
+{
+    // \Users\<name>\ profile paths — the disk-side convergence key (shellbags, LNK,
+    // jumplists, chrome, google-drive, fs:stat). Excludes noise dirs to cut FPs.
+    strings:
+        // real named profiles seen in this case
+        $case_users = /\\Users\\(jcloudy|defaultuser0|Administrator|gt|scoringbot|JDH)\\/ nocase ascii wide
+        // generic profile-dir catch (validate hits: strip Public/Default/desktop.ini noise)
+        $any_user   = /[\\\/]Users[\\\/][A-Za-z][A-Za-z0-9_.\- ]{1,32}[\\\/]/ nocase ascii wide
+        $not_public = /\\Users\\(Public|Default|All Users)\\/ nocase ascii wide
+    condition:
+        $case_users or ($any_user and not $not_public)
+}
+
+rule DFIR_Linux_Identity
+{
+    // 5g-webui host: usernames appear in utmp/wtmp/ssh, not SIDs.
+    strings:
+        $u = /\b(root|LS23_BT10|gt|_mcs)\b/ ascii
+        $ssh = "syslog:ssh:login" ascii
+    condition:
+        $ssh and $u
+}
+```
+
+---
+
+## So what (analyst use)
+
+1. **`jcloudy` = `S-1-5-21-2734969515-1644526556-1039763013-1001`** is the case spine: one derivation attributes ~185k disk records (web history, shellbags, LNK, jumplists, prefetch, evtx logons, NTFS ownership, Drive sync) to one human — none of which the pipeline currently normalises.
+2. **`gt`** is a cross-host pivot (memory Windows host RID 1000 ↔ 5G Linux utmp) worth confirming as the same operator.
+3. **Biggest normalisation gap:** the disk (4.17M records) and the 44k `file`+`registry` CAR rows carry identity only in raw fields (`strings`, `key_path`, `native`, security descriptors) — a derivation lifting SID→username via SAM+Profilea spine would populate the null `user`/`uid`/`sid` CAR columns wholesale.

--- a/docs/car-provenance/crosslink/ports_serials.md
+++ b/docs/car-provenance/crosslink/ports_serials.md
@@ -1,0 +1,173 @@
+# Ports & Serials as Cross-Artefact Linkage Keys — DX_DFIR processed dataset
+
+**Scope:** READ-ONLY hunt across `data_store/processed/` for serial numbers (volume/USB/disk), MAC
+addresses, and port numbers usable as cross-artefact device/flow linkage keys, plus an audit of which
+of these reach a normalised CAR field.
+
+**Key structural finding first:** the processed dataset is **heterogeneous — several independent source
+images**, not one host. This bounds what "convergence" can mean:
+
+| Source image | Artefact(s) | Host / user |
+|---|---|---|
+| LoneWolf.E01 (disk) | `log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB) | DESKTOP-PM6C56D / jcloudy |
+| 5g-image-1 (disk) | `log2timeline/jsonl/5g-webui.jsonl` (7.8 GB) | Linux 5G-core VM |
+| memory dump | `volatility/memdump.mem/plugins/*.jsonl` + **`car.db`** | BGP-WS1-CONF |
+| pcaps | `zeek/*/{conn,ssh,...}.json` | 10.27.33.x subnet |
+| evtx / hayabusa | `windows_logs/.../log_EvtxECmd_Output.json`, `signatures/hayabusa/timeline.jsonl` | DESKTOP-M913391 / JDH |
+
+Because these are different machines, **the strongest genuine device convergences are WITHIN the LoneWolf
+image** (a device seen across its LNK + shellbag + registry). Cross-image port matches (22, 53, 135, 443…)
+are shared-service coincidences, not the same host.
+
+**CAR normalisation state (the headline gap):** `car.db` is built **only from the memory dump**
+(`windows.mftscan`, `windows.piiat.registry/processes/sessions`). It **never ingests** plaso LNK/shellbags,
+zeek, or evtx. Its `socket(local_port,remote_port)` and `flow(src_port,dest_port)` columns exist but are
+**empty (0 rows)** — no netscan plugin was run. `file` has **no serial column**; there is **no MAC column
+anywhere** in the schema. Verified: LoneWolf USB serials, volume serials, and MACs are **absent** from CAR
+(the only `USBSTOR`/`SanDisk` hits in the CAR registry table are the memory host's *service* key
+`\...\Services\USBSTOR` and a storahci device-compat string — no device serial; `4C36`/`74EE` "file" hits
+are coincidental SHA-1 substrings). **Every serial/MAC below, and every port below, is un-normalised today.**
+
+---
+
+## Master linkage table
+
+`| value (serial/port/MAC) | artefacts | normalised? | link / device-convergence use |`
+
+| value | artefacts (source) | normalised into CAR? | link / device use |
+|---|---|---|---|
+| **Vol serial `4C36-F4AC`** (dec `1278669996`, LE bytes `AC F4 36 4C`), label **CloudLog**, drive_type **2 = REMOVABLE** | LNK `drive_serial_number` (LoneWolf) ×18; same device's file `D:\key.txt` in **shellbags** ×12 | **No** — no CAR serial field | **CONVERGENCE.** The removable "CloudLog" USB volume holding `key.txt`, seen across BOTH access artefacts (LNK carries the serial; shellbag carries the same `D:\key.txt` path). Strongest device chain. |
+| **Vol serial `AA92-0881`** (dec `2861697153`, LE `81 08 92 AA`), drive_type 3 = FIXED (C:) | LNK `drive_serial_number` (LoneWolf) ×637 | **No** | C: system-volume serial; links all C:-resident LNK targets (rootkey.csv, DemGun.jpg, DemLogic.jpg, Cloudy thoughts…docx) to one volume. |
+| **Vol serial `74EE-2D73`** (dec `1961766259`, LE `73 2D EE 74`), label **OSDisk**, drive_type 3 | LNK `drive_serial_number` (LoneWolf) ×96 | **No** | Second C:/OSDisk volume serial (PowerShell LNKs). |
+| **USB serial `AA010215170355310594`** (SanDisk Extreme) | **USBSTOR** instance key, **setupapi** device-install (`WPDBUSENUM\...USBSTOR#Disk&Ven_SanDisk&Prod_Extreme#AA0102...`), **DeviceClasses / WPDBUSENUM** — 1104 combined refs w/ its twin | **No** — CAR has no serial column | **CONVERGENCE.** Physical USB stick seen across device-enum (USBSTOR) + install-log (setupapi) + device-interface classes. iSerialNumber-style unique key. |
+| **USB serial `AA010603160707470215`** (SanDisk Extreme) | same as above (USBSTOR / setupapi / DeviceClasses) | **No** | Second SanDisk Extreme unit (or re-enumeration) — same convergence pattern. |
+| **Volume GUID `{3869c27a-31b8-11e8-9b12-ecf4bb487fed}`** (node = MAC `ec:f4:bb:48:7f:ed`) | **MountedDevices** (`\DosDevices\D:` = 224 B, matches this GUID) + DeviceClasses volume class | **No** | Ties drive-letter **D:** → the removable volume; GUID node embeds a host NIC MAC (see below). |
+| **MAC `ec:f4:bb:48:7f:ed`** | **distributed_link_tracking:creation** `mac_address` (98 recs) **AND** MountedDevices volume-GUID node `...ecf4bb487fed` | plaso normalises `mac_address` on DLT; **CAR: No MAC field** | **CONVERGENCE.** Same NIC MAC appears in file-creation ObjectIDs (DLT) and in the volume-GUID minted by that host — links created files to the physical machine. |
+| **MAC `28:e3:47:01:77:77`** | distributed_link_tracking `mac_address` (117 recs) | plaso: yes; CAR: **No** | Most-frequent creator MAC in LNK/ObjectID droids. |
+| **MAC `00:1c:c4:2d:f4:0b`** | distributed_link_tracking (32) — PowerShell.lnk etc., uuid `5c2307d9-3369-11e2-be70-001cc42df40b` | plaso: yes; CAR: **No** | Creator NIC MAC of PowerShell shortcuts. |
+| **MAC `ec:0e:c4:20:7f:0e`** | distributed_link_tracking (7) | plaso: yes; CAR: **No** | Additional creator NIC MAC. |
+| **Gateway MAC `5c:8f:e0:2a:1c:68`** | `windows:registry:network` — NetworkList profile (Wireless), rendered in message; DefaultGatewayMac REG_BINARY (6 B, truncated) | **No** | Links LoneWolf host to a specific Wi-Fi gateway; the network the machine joined. |
+| **MACs `00:50:56:89:b3:ff`, `00:50:56:89:34:cf`** (VMware OUI) | 5g-webui.jsonl (5G-core Linux VM) | **No** | VM NIC MACs for the 5G image. |
+| **Port 22 (SSH)** | zeek `conn.json` (19) + `ssh.json` | schema has `flow.src/dest_port`, `socket` — **empty, so No** | **CONVERGENCE (flow).** SSH pivot chain: `10.27.33.11` (OpenSSH_for_Windows_8.1 / Renci.SshNet) → `10.27.33.61:22` (Ubuntu) → `100.101.0.42:22` (Debian, Go client), auth_success=true. Links conn↔ssh logs. |
+| **Port 53 / 80 / 135 / 443** | zeek conn.json (53=7726, 80=17, 135=3, 443=12) | **No** (empty flow/socket) | DNS/HTTP/RPC/TLS service flows. |
+| **Firewall ports 3702,1900,2177,2869,135,445,3540,5355,5357-8,137-8,23554-6,9955,68/67,546/547** | LoneWolf registry `FirewallPolicy\FirewallRules` REG_SZ (9 rule-bearing records; pipe-delimited `|LPort=/|RPort=`) | **No** — buried inside a REG_SZ string, no CAR port field | Host firewall posture; ports embedded in rule strings, invisible to any structured port field. |
+
+---
+
+## Best device-linkage chains (real LoneWolf values)
+
+### Chain A — the removable "CloudLog" USB and `key.txt` (volume-serial convergence)
+```
+LNK      : local_path "D:\key.txt"  drive_serial_number 1278669996 (0x4C36F4AC → 4C36-F4AC)
+           drive_type 2 (DRIVE_REMOVABLE)  volume_label "CloudLog"      [windows:lnk:link]
+shellbag : shell_item_path "<My Computer> D:\key.txt"                   [windows:shell_item:file_entry]  ×12
+MountedDv: \DosDevices\D:  → 224-byte binary == Volume{3869c27a-...-ecf4bb487fed}
+```
+=> One removable volume (serial **4C36-F4AC**, label **CloudLog**) proven across **access-by-shortcut (LNK)**
+and **folder-browse (shellbag)**; the serial is the only field that names the *device* — the shellbag alone
+would just say "D:". This is the classic "the exfil/keying file lived on this specific stick" convergence.
+
+### Chain B — SanDisk Extreme USB stick (USB-serial convergence across 3 registry/log artefacts)
+```
+setupapi     : "Device Install (Hardware initiated) - SWD\WPDBUSENUM\_??_USBSTOR#Disk&Ven_SanDisk&
+                Prod_Extreme&Rev_0001#AA010215170355310594&0#{53f56307-b6bf-11d0-94f2-00a0c91efb8b} - SUCCESS"
+USBSTOR key  : HKLM\System\ControlSet001\Enum\USBSTOR\Disk&Ven_SanDisk&Prod_Extreme&Rev_0001\AA010215170355310594&0
+DeviceClasses/WPDBUSENUM: same serial across GUID_DEVINTERFACE_DISK / WPD interfaces  (1104 refs w/ twin AA010603160707470215)
+```
+=> USB iSerialNumber **AA010215170355310594** (and **AA010603160707470215**) is the device key tying the
+first-insert timeline (setupapi) to the enumerated device (USBSTOR) to the device-interface registrations.
+
+### Chain C — creator-host NIC MAC (MAC convergence: DLT ObjectID ↔ volume GUID)
+```
+DLT      : mac_address ec:f4:bb:48:7f:ed  (distributed_link_tracking:creation, 98 recs)
+MountedDv: \??\Volume{3869c27a-31b8-11e8-9b12-ecf4bb487fed}   (node = ec f4 bb 48 7f ed)
+```
+=> The MAC baked into file-creation ObjectIDs is the *same* MAC used to mint the D: volume GUID — links
+created files to a physical NIC and to the drive-letter mapping.
+
+---
+
+## Serials / ports / MACs present in raw/native that NO CAR field normalises (quantified)
+
+| class | value(s) | native location | count | why unnormalised |
+|---|---|---|---|---|
+| Volume serial | 4C36-F4AC, AA92-0881, 74EE-2D73 | LNK `drive_serial_number` (int) | 751 LNK recs | `file`/`registry` CAR tables have no serial column |
+| USB iSerial | AA010215170355310594, AA010603160707470215 | USBSTOR key path, setupapi msg, DeviceClasses | 6 USBSTOR-instance recs, 6 setupapi installs, 1104 total refs | no CAR device/serial field |
+| Creator MAC | ec:f4:bb:48:7f:ed, 28:e3:47:01:77:77, 00:1c:c4:2d:f4:0b, ec:0e:c4:20:7f:0e | DLT `mac_address`; also GUID nodes | 254 DLT recs | no CAR MAC column |
+| Gateway MAC | 5c:8f:e0:2a:1c:68 | `windows:registry:network` NetworkList / DefaultGatewayMac (REG_BINARY, truncated to "(6 bytes)") | 6 network recs | no CAR MAC column; **binary itself dropped** to a byte-count |
+| MountedDevices binary | volume-serial/disk-signature bytes for `\DosDevices\{C,D,E}:` | registry REG_BINARY | 3 letters | plaso emits only "(224 bytes)" — **raw hex not preserved**, so serial is un-extractable downstream |
+| Firewall ports | 3702,1900,135,445,5355,23554-6,9955,68/67,… | REG_SZ `FirewallRules` string `|LPort=/|RPort=` | 9 records | ports inside an opaque pipe-delimited string; `socket`/`flow` empty |
+| Zeek flow ports | 22,53,80,135,443 (+ full 5-tuple) | zeek conn/ssh JSON | conn 7821 recs | zeek not ingested into CAR; `flow`/`socket` = 0 rows |
+
+Two secondary gaps worth flagging: (1) **NetworkList DefaultGatewayMac** and (2) **MountedDevices** device
+bytes are emitted by plaso only as `(N bytes)` summaries — even the raw value is lost before any
+normalisation could occur, so the on-disk volume serial in MountedDevices can't be recovered from the JSONL.
+
+---
+
+## YARA rule stubs (hunt these raw values in images / carved artefacts)
+
+```yara
+rule DXDFIR_LoneWolf_VolumeSerial_CloudLog
+{
+    // Removable "CloudLog" volume serial 0x4C36F4AC, holding key.txt
+    meta:
+        author = "DX_DFIR car-crosslink"
+        desc   = "NTFS/FAT volume serial 4C36-F4AC (removable CloudLog) — LNK + shellbag + MountedDevices"
+    strings:
+        $le   = { AC F4 36 4C }              // little-endian 4-byte serial as stored in LNK/registry binary
+        $ascii1 = "4C36-F4AC" nocase          // human/tool rendering
+        $ascii2 = "CloudLog" wide ascii        // volume label co-marker
+        $dec  = "1278669996"                   // plaso decimal rendering (JSONL/CSV)
+    condition:
+        $le or $ascii1 or ($ascii2 and any of ($dec,$le))
+}
+
+rule DXDFIR_LoneWolf_VolumeSerials_Fixed
+{
+    strings:
+        $s1_le = { 81 08 92 AA }   $s1_a = "AA92-0881"  $s1_d = "2861697153"   // C: AA92-0881
+        $s2_le = { 73 2D EE 74 }   $s2_a = "74EE-2D73"  $s2_d = "1961766259"   // OSDisk 74EE-2D73
+    condition:
+        any of them
+}
+
+rule DXDFIR_LoneWolf_USB_SanDisk_Serial
+{
+    // SanDisk Extreme USB iSerialNumbers — USBSTOR / setupapi / DeviceClasses
+    strings:
+        $u1 = "AA010215170355310594" ascii wide nocase
+        $u2 = "AA010603160707470215" ascii wide nocase
+        $ven = "Ven_SanDisk&Prod_Extreme" ascii wide nocase
+    condition:
+        any of ($u*) or ($ven and any of ($u*))
+}
+
+rule DXDFIR_LoneWolf_Creator_and_Gateway_MAC
+{
+    // MACs from DLT ObjectIDs, volume GUID nodes, and NetworkList gateway
+    strings:
+        $m1_txt = "ec:f4:bb:48:7f:ed" nocase   $m1_raw = { EC F4 BB 48 7F ED }
+        $m2_txt = "28:e3:47:01:77:77" nocase   $m2_raw = { 28 E3 47 01 77 77 }
+        $m3_txt = "00:1c:c4:2d:f4:0b" nocase    $m3_raw = { 00 1C C4 2D F4 0B }
+        $m4_txt = "ec:0e:c4:20:7f:0e" nocase    $m4_raw = { EC 0E C4 20 7F 0E }
+        $gw_txt = "5c:8f:e0:2a:1c:68" nocase    $gw_raw = { 5C 8F E0 2A 1C 68 }  // NetworkList gateway
+        $volguid = "3869c27a-31b8-11e8-9b12-ecf4bb487fed" ascii wide nocase
+    condition:
+        any of them
+}
+
+rule DXDFIR_Firewall_and_Flow_Ports
+{
+    // Un-normalised ports: firewall REG_SZ rule strings + notable flow ports
+    strings:
+        $fw_l = /\|LPort=(3702|1900|2177|2869|135|445|3540|5355|5357|5358|23554|23555|23556|9955)\b/
+        $fw_r = /\|RPort=(1900|2177|2869|3702|137|138|547|67)\b/
+        $ssh  = ":22" ascii            // SSH pivot 10.27.33.11 -> .61:22 -> 100.101.0.42:22
+    condition:
+        $fw_l or $fw_r or $ssh
+}
+```
+
+*(MAC raw byte order: DLT/volume-GUID nodes store the MAC big-endian as the trailing 6 bytes of the GUID, so
+the `{ EC F4 BB 48 7F ED }` form matches both the GUID node and a raw NetworkList/DHCP MAC blob.)*

--- a/docs/car-provenance/lonewolf-fs-recheck/BACKLOG.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/BACKLOG.md
@@ -1,0 +1,83 @@
+# Unmined filesystem-artefact backlog — all 13 CAR objects (LoneWolf-grounded)
+
+A "find once, done" sweep of every CAR object for Windows filesystem/disk artefacts
+the pipeline does NOT yet turn into the right CAR row — grounded in the real
+LoneWolf Win10 image (`DESKTOP-PM6C56D`, plaso 4.17M events, VSS included).
+Per-object detail: `<object>.md` in this dir. The first-round catalogues
+(`car-provenance/`) and the LS24-corrective (`car-provenance-lonewolf/`) are the
+priors this builds on.
+
+## The five recurring patterns (this is the real finding)
+Almost every gap is one of five shapes — and most are **cheap re-emits of data plaso
+already parsed**, not new tooling:
+
+1. **Right data, WRONG object.** Disk evidence is parsed but emitted as `registry`/`file`
+   and the CAR identity is parked in `_native`:
+   - `Services` key → `registry`, not **`service`** (1,796 rows / 618 services; a dead disk yields **0 service objects** today).
+   - amcache `InventoryDriverBinary` + SYSTEM `Services` Type 1/2 → `registry`/`file`, not **`driver`** (352 unique .sys, 6/11 fields fillable).
+   - `pe_coff` DLL/.sys (150k / 4,643) → `file`, not hydrated onto **`module`/`driver`**.
+   - RecentApps / AppCompatFlags\Store / `.job` (winjob, *entirely raw*) → not **`process`** (and `.job` carries a real user).
+   - Save/Open MRU (RecentDocs/OpenSave/LastVisited) → `registry`, not **`file`/read** (the actual accessed files).
+   - SAM `Last Login` + ProfileList → `registry`, not **`user_session`/login** or **`authentication`/success**.
+   - Firewall rules → `registry`, not **`socket`/bind** (895 inbound-port rules / 40 apps).
+2. **`user` is in the path, never mined.** Across process/file/registry/user_session/service,
+   `user`/`uid` is null because maps read a native `username` that is `"-"`, while the account is
+   right there — `\Users\<name>\` paths, hive `display_name`, SIDs (RID + the machine SID
+   `S-1-5-21-2734969515-1644526556-1039763013` from ProfileList), service `object_name`.
+   **`recmd.py` already does it** (`regex1(HivePath, …Users\<name>…)`); nothing else does. #1 win.
+3. **Over-narrow data_type predicate.** A working map rejects real rows: `l2t_firefox_places`
+   gates Firefox-only so **all Chrome/Edge history** (2,293 visits + 42 downloads) is rejected;
+   IE `WebCache` is routed to the SRUM-only predicate and dropped.
+4. **Value trapped in an unindexable LIST.** 1.35M registry rows carry `value`/`data`/`type` in a
+   `values` list the marker set can't index; same shape hides service `ImagePath`/`ObjectName`
+   and every firewall-rule string. RECmd flattens these; plaso_registry doesn't.
+5. **Parser output produced then binned.** The Zimmerman lane RUNS SBECmd / AmcacheParser /
+   AppCompatCacheParser, but `pipeline.py` ROUTES consumes **none** of them (only RECmd) —
+   shellbags/amcache/shimcache EZ output is written and silently dropped. Chrome cache
+   (`.L2tChromeCache`) has no route; `.job` (winjob), olecf doc-summary, openxml metadata unrouted.
+
+## Cheap code fixes (data already in-store — routing/derivation only)
+- **A1 · user-from-path** in `plaso_registry`, `plaso_exec` (userassist), `plaso_shellitem`,
+  `l2t_lnk`, `l2t_recyclebin` (+ resolve BAM/recycle/ProfileList SID→name via SAM). Names 100%
+  of userassist/shellbag/registry activity. Retire the dead `hive_user_sid` regex (matches 0%).
+- **A2 · Services key → `service/create`** (re-emit; `object_name`→user, `ServiceDll`→real binary
+  for svchost hosts; expand `%SystemRoot%`; dedupe the 3× VSS inflation).
+- **A3 · amcache SHA-1 bug** — every amcache map reads `sha1`/`Record.sha1` but the SHA-1 lives in
+  `file_identifier`/`DriverId` (`0000`+40hex); amcache's hash reaches **no** object today. Plus
+  amcache `company_name`→`file.company` dropped. One-liners.
+- **A4 · amcache `InventoryDriverBinary` + Services Type 1/2 → `driver`**; **prefetch `mapped_files`
+  → `module/load`**; **`pe_coff` → `module`/`driver` hash** via a `crosssource.py` fix (add
+  module/driver to the content-hash collapse — today the bucket is object-scoped so only process
+  collapses into file; add a `module_path`↔`file_path` key).
+- **A5 · LNK "Not a time" drop** — `l2t_lnk` sends non-time variants to `default: None`, dropping
+  931/1,639 shortcuts incl. their `link_target`/`command_line_arguments`/`working_directory` (the
+  case-defining Desktop `.lnk`s). Emit a `file`/access row regardless.
+- **A6 · flatten the registry `values` list** → `value`/`data`/`type` (1.35M rows); surface the
+  dropped `network` fields (ssid/gateway MAC/dns_suffix).
+- **A7 · Chrome/Edge history** — widen `l2t_firefox_places`'s predicate (it already derives the
+  exact fields incl. `from_visit`→referrer) → `http`; route `.L2tChromeCache`; webmail address
+  (`jimcloudy1@gmail.com`) → could seed `email.src_address`.
+- **A8 · route the Zimmerman EZ output** (SBECmd/amcache/appcompatcache) in `pipeline.py` ROUTES —
+  compute already spent.
+- **A9 · winjob `.job` → `process`** (uniquely carries a real native user); RecentApps + AppCompatFlags\Store → `process`.
+- **A10 · Firewall rules → `socket/bind`** (config confidence, `success` null); `Svc=`→service join.
+- **A11 · WebCache `response_headers` → `http`** (the ONLY on-disk source of `response_status_code`/`http_version`).
+
+## Collection-lane / new-parser gaps (epic #134 — not map defects)
+- **$MFT absent** (`fs:ntfs:mft`=0): blocks `timestomp`, `previous_creation_time`, resident `$DATA` content, `$I30` deleted names, and NTFS `$Secure` owner/ACL — 5 `file` fields at once. The `l2t_mft` map is already well-formed; the disk lane just isn't extracting `$MFT`.
+- **SRUM empty** (`windows:srum:*`=0): SRUDB.dat is a dirty ESE db libesedb skips + the Zimmerman SRUM step is unwired → the only disk source of `flow` in/out bytes yields nothing.
+- **New parsers, artefacts present but unread:** ActivitiesCache.db / Win10 Timeline (richest process source: exe+cmdline+user+title+duration; `windows_timeline` fired 0), mail stores (`store.vol`+`HxStore.hxd` present; also PST/OST via `pff`) → the whole `email` object (0/21 today), minidumps/`.dmp` (the only disk `thread` stack/start source), WMI `OBJECTS.DATA`, WER, ADS/Zone.Identifier (download provenance), `.cat` CatRoot (true `signature_valid`).
+
+## Honest no-sources (document, never fake)
+- **thread**: near-total — a runtime/ETW object; only minidump bodies (+ the `<image>.<pid>.dmp` filename PID) offer anything from disk.
+- **socket**: mostly runtime — only firewall *config* (a policy, not an observed bind).
+- **flow**: the wire 5-tuple / `content` / `packet_count` / `tcp_flags` / `proto_info` / L7 — a dead disk can't hold them.
+- Per-field structural nulls: `base_address`/`pid`/`tid` (module/driver/thread), `env_vars`/`parent_*`/`integrity_level`/`command_line`(mostly) (process), `login_id`/`login_type`/`src_*` (user_session), `response_time`/`method`/`decision_reason` (authentication), the delivery-verdict actions + wire ports (email), `md5` (disk gives SHA-1/256), `signer`/`signature_valid` (need Authenticode/.cat verification, no parser).
+
+## Bottom line
+On a Windows dead-box image *full* of user-attributable execution, access, service, driver, and
+web evidence, the pipeline today emits CAR rows with null `user` and misses whole objects
+(`service`/`driver`/`email` = 0 from disk). The bulk of the fix is **re-emitting data plaso already
+parsed to the correct object + deriving `user` from the path** — cheap, and it lights up the whole
+image. The rest is collection-lane extraction ($MFT, SRUM, mail stores, ActivitiesCache) tracked
+under epic #134.

--- a/docs/car-provenance/lonewolf-fs-recheck/authentication.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/authentication.md
@@ -1,0 +1,273 @@
+# CAR `authentication` — FILESYSTEM/disk provenance audit
+
+**Scope of THIS pass:** what a **dead disk image** (registry hives, Credential Manager,
+scheduled tasks — no live event stream) can genuinely contribute to the CAR
+`authentication` object, and which of it the pipeline has **not mined**. READ-ONLY.
+
+**Object:** `authentication` — "a user or process attempts to access a privileged
+system resource" (logon / privilege elevation). Actions: `success` · `failure` · `error`.
+**19 fields:** ad_domain, app_name, auth_service, auth_target, decision_reason, fqdn,
+hostname, method, response_time, target_ad_domain, target_uid, target_user,
+target_user_role, target_user_type, uid, user, user_agent, user_role, user_type.
+
+**The headline honesty finding (read first):**
+Authentication is fundamentally an **event** — a request, a decision, a response. A
+disk image records **none of that decision flow**. It records **residual state** left
+behind by past authentications. Exactly **one** disk artefact carries a
+*dated authentication outcome*: the **SAM hive's per-user "Last Login Time" + login
+count** (a genuine `success` with a timestamp, user, and RID). Everything else on
+disk is either an **identity hint** (who logged on last / by default), a **join key**
+(SID↔name), or **encrypted state Plaso does not crack** (LSA secrets). The event-only
+fields — `method`, `auth_service`, `response_time`, `decision_reason` — are **honest
+nulls from disk**. The one disk path that *does* fill the object today is the
+**on-disk `Security.evtx`** parsed by EvtxECmd → the existing 4624/4625/4672 mapper;
+that is the event log living on disk, **not a hive/registry artefact**, and is
+covered by the prior event-log audit (`docs/car-provenance/authentication.md`).
+
+**Ground truth inspected (real evidence):**
+- `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` — **LoneWolf Win10**,
+  a **workgroup** host (`DESKTOP-PM6C56D`, no AD). 27 `windows:registry:sam_users`
+  rows, 12 `windows:registry:winlogon`, full `SOFTWARE\...\ProfileList`, LSA policy
+  keys, `windows:tasks:job`. This is the authoritative "what the pipeline actually
+  sees from a disk image" corpus.
+- Engine maps: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_registry.py`
+  (every `windows:registry:*` → **registry** `key_edit`, sam/profile fields kept
+  `_native`), `mappings/core.py` (the ONLY `authentication` mapper — evtx Security).
+- Routing: `piiat_mitrecar/pipeline.py:62` (`.L2tWinreg → plaso_registry`),
+  `sources/*.yaml` — **only `evtx_security.yaml` declares `data_model_coverage:
+  authentication`.** No plaso/registry/disk source routes to `authentication` at all.
+- Governing law: `docs/CAR-Extraction-Rules.md` §1 (extract every field the artefact
+  can supply) & §3 (one authoritative artefact per object, tied to identity);
+  `docs/CAR-Relations.md` §14 (authentication ← Security 4624/4625, identity =
+  `Computer`+`Channel`+`EventRecordId`).
+
+---
+
+## 1. What disk feeds `authentication` today: **nothing from hives.**
+
+`grep authentication sources/*.yaml` → the object is declared by **`evtx_security`
+only** (4624/4625/4672). The disk registry family is routed by `plaso_registry.py`
+to the **`registry`** object as `key_edit` snapshots; `sam_users`' auth-bearing
+fields (`username`, `account_rid`, `login_count`) are surfaced into **`_native`**
+and **never reach `authentication`**. So every row below is **NOT mined for auth**
+today — by construction, not by oversight.
+
+The only *disk-resident* path that reaches `authentication` is **`Security.evtx`
+on the image → EvtxECmd → `evtx_security`/`core.py`** — i.e. the event log that
+happens to live on the disk. No hive, no snapshot, no credential store contributes.
+
+---
+
+## 2. Per-field provenance — FILESYSTEM/disk artefacts only
+
+Legend — **action**: which CAR action the disk fact would support. **mined?**: is it
+routed to `authentication` today (disk sources: **NO** everywhere — auth is
+event-log-only today). Native field shown as `artefact → NativeField`.
+
+### uid — SID of the subject/initiating context
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM `sam_users` → `account_rid` (500/501/1001…) | success | **NO** (→ registry `_native.account_rid`) | MED. **RID only, not a full SID.** Needs the machine SID (from SOFTWARE ProfileList, or SAM `Domains\Account` V-value) to become `S-1-5-21-…-<RID>`. On a *local* logon the subject ≈ the account itself. |
+| SOFTWARE `ProfileList\<SID>` → key basename | — | **NO** | HIGH as a **join key**, not an auth event. Supplies the machine SID + SID→name that upgrades the SAM RID to a real `uid`. |
+
+### user — name of the initiating user (subject)
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM `sam_users` → `username` | success | **NO** (`_native.username`) | HIGH string. Local account name (`jcloudy`, `Administrator`). For a local interactive logon subject≈target. |
+| SOFTWARE `ProfileList\<SID>` → `ProfileImagePath` basename | — | **NO** | HIGH — SID→name resolver (already used by piiat-mem `enrich.py` for the memory lane). |
+| Winlogon `DefaultUserName` (autologon) | success | **NO** | LOW — identity hint, and **not set** in the real sample (only WinSxS component-store noise matched); trapped in the `values` list → `_native`. |
+| LogonUI `LastLoggedOnUser` / `LastLoggedOnSAMUser` | success | **NO** | LOW — last interactive user hint; **no dedicated Plaso plugin** (generic `key_value` → unindexed `values` list); not present as a real value in this sample. |
+
+### target_uid — SID of the account being authenticated
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM `sam_users` → `account_rid` (+ machine SID) | success | **NO** | MED — same RID→SID caveat as `uid`. On the SAM record the account **is** the target. |
+| LogonUI `SelectedUserSID` | success | **NO** | LOW — hint; not surfaced (no plugin; not in sample). |
+
+### target_user — name of the account being authenticated
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM `sam_users` → `username` | success | **NO** (`_native.username`) | HIGH string — the local principal whose "Last Login" this row records. **The single strongest disk-native auth field.** |
+
+### user_type — type of initiating user (Administrator/Standard/Guest)
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM `sam_users` → `account_rid` well-known RID | success | **NO** | LOW-MED — **derivation** from RID: 500=Administrator, 501=Guest, 503=DefaultAccount, 504=WDAGUtility(service). Real sample shows all of these. Not recorded, not currently derived. |
+| SAM account control flags (F-value ACB bits: disabled/locked/normal) | success/failure | **NO** | LOW — the ACB flags are in the SAM F-value but **Plaso's `sam_users` plugin does not emit them** (see §5). |
+
+### target_user_type — type of target account
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM `sam_users` → `account_rid` well-known RID | success | **NO** | LOW-MED — same RID derivation (target≈subject on a SAM row). |
+
+### hostname — origin host the request was made from
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM/ProfileList row → `image_hostname` (`DESKTOP-PM6C56D`) | success | **NO** | MED — this is the **image identity** (the host the hive came from = where the local logon happened), stamped by the lane. Legitimate for a *local* logon (origin=target=this host); it is **not** a remote-origin hostname. |
+
+### ad_domain / target_ad_domain — AD domain (subject / target side)
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SECURITY hive `LSA\Cache` (`NL$1`…) cached **domain** logon | success | **NO** | **NO in-pipeline source.** Cached-cred entries carry the last domain logons but are **DPAPI/LSA-encrypted**; **Plaso winreg does not decrypt LSA secrets** (only LSA *policy* keys surface — Credssp, MSV1_0, `Kerberos\Domains` empty). Would need a secretsdump/creddump-class tool (not in repo). |
+| SECURITY `Policy\Secrets\$MACHINE.ACC` / domain-join secret | success | **NO** | Same — encrypted, not decrypted; no parser. |
+| SOFTWARE `…\Group Policy\History` / `Tcpip\Parameters\Domain` / `ComputerName` | success | **NO** | LOW — domain membership hint only; **this host is a workgroup** so empty here anyway. |
+| Winlogon `DefaultDomainName` | success | **NO** | LOW — identity hint; not set in sample (WinSxS noise only). |
+
+### auth_service · method · response_time · decision_reason
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — | — | **NO** | **Honest null from disk.** These describe the *live authentication exchange* (which SSP validated, NTLM vs Kerberos, how long it took, why it was denied). No hive/snapshot records them. Only the live event (Security 4624/4625/4776/4768…) carries them. `response_time` has no DFIR source at all. |
+
+### app_name — application that made the request
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — (Winlogon autostart `Userinit`/`Shell` describes the shell, not the auth caller) | — | **NO** | Effectively no disk source — the calling process of a past logon is not persisted in a hive. |
+
+### user_agent
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — | — | **NO** | No disk artefact records a logon user-agent (web/IdP-only field). |
+
+### auth_target — machine authenticated TO
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM row → `image_hostname` | success | **NO** | LOW-MED — for a **local** SAM logon the target machine *is* this host; degenerate but true. No record of a *remote* auth_target on a local hive. |
+
+### fqdn
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — | — | **NO** | Host-identity inheritance only; `image_hostname` is a bare NetBIOS name (no domain on this workgroup host). |
+
+### user_role / target_user_role
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| SAM group membership (RID 544 Administrators via the SAM `Aliases`/`Members`) | success | **NO** | LOW — reconstructable in principle from SAM alias membership, but **Plaso does not parse SAM aliases/group membership** (only `sam_users`). IPAM-role semantics are external. Not derivable in-pipeline today. |
+
+---
+
+## 3. The ONE real unmined disk auth record — SAM `Last Login Time`
+
+The `windows:registry:sam_users` plugin emits, per local account, events tagged
+`timestamp_desc` ∈ {**Last Login Time**, Last Password Set Time, Content Modification
+Time} carrying `username`, `account_rid`, `login_count`, `fullname`, `comments`.
+
+**Real LoneWolf `Last Login Time` rows (decoded):**
+
+| username | RID | login_count | last_login (UTC) |
+|---|---|---|---|
+| jcloudy | 1001 | 2 | 2018-03-27 09:19:58 |
+| defaultuser0 | 1000 | 2 | 2018-03-27 12:13:28 |
+| jcloudy | 1001 | 15 | 2018-04-04 04:30:48 |
+| jcloudy | 1001 | 23 | 2018-04-06 12:26:27 |
+
+(Multiple jcloudy rows = successive hive/transaction-log versions Plaso replayed —
+the login count climbing 2→15→23 gives *dated snapshots* of successful-logon
+accrual.) Built-ins Administrator(500)/Guest(501)/DefaultAccount(503)/
+WDAGUtility(504) all show `login_count 0` — **never logged in** (a defensible
+"no successful auth" signal).
+
+**Why this is a genuine — but qualified — `authentication.success`:** it is the only
+disk fact with a **timestamp + outcome + principal**: "account `jcloudy` (RID 1001)
+successfully logged on interactively at 2018-04-06 12:26:27, for the 23rd time." That
+fills `success` + `user`/`target_user` + `uid`/`target_uid` (RID→SID via ProfileList)
++ `hostname`/`auth_target` (this host). `login_count` is decision *context* (no CAR
+field — keep native). **Caveats that must ride with it:**
+- It is **console/interactive local logon only** (the SAM F-value counter); network/
+  RunAs/service logons don't touch it.
+- It is a **snapshot state, not an event** — it has no CAR-Relations §14 event
+  identity (`EventRecordId`); its natural identity is the hive-key snapshot, which is
+  why it currently lands as a `registry` `key_edit`. Emitting it as `authentication`
+  would be a **second authoritative artefact** for the object (tension with
+  Extraction-Rules §3) — defensible because it's the *only* disk auth outcome, but it
+  must be marked snapshot-derived and never merged onto a real 4624's identity.
+- **Overlaps `user_session/login`** — the memory lane's `windows.piiat.sessions`
+  already resolves `User` via ProfileList for login events; the SAM last-login is
+  arguably a `user_session/login` too. Pick one canonical home (auth vs session) to
+  avoid a double count.
+
+---
+
+## 4. Ranked UNMINED disk opportunities
+
+1. **SAM `sam_users` "Last Login Time" → `authentication.success`** (with `user`/
+   `target_user`←`username`, `uid`/`target_uid`←`account_rid`+machine-SID,
+   `hostname`/`auth_target`←`image_hostname`, ts←the Last-Login event). **The only
+   dated auth outcome a disk image yields.** Already parsed and sitting in
+   `plaso_registry` `_native` (`username`/`account_rid`/`login_count`); needs a
+   dedicated auth variant (or a downstream promotion) that fires **only** on the
+   `Last Login Time` timestamp_desc. Low incremental cost; honest snapshot caveat.
+2. **SOFTWARE `ProfileList` SID↔name + machine-SID join** — not an auth event, the
+   **enabler**: turns SAM's bare RID into a full `S-1-5-21-…-<RID>` SID and resolves
+   SID→username. Real machine SID present (`S-1-5-21-2734969515-1644526556-1039763013`,
+   RIDs 1000/1001). The join logic already exists for the memory lane
+   (`piiat-mem/enrich.py` `_PROFILELIST_SID`); reuse it disk-side. Ship with #1.
+3. **SAM well-known-RID → `user_type` / `target_user_type` derivation**
+   (500=Administrator, 501=Guest, 503=DefaultAccount, 504=service). Pure derivation
+   from a field already captured (`account_rid`); the same coarse-assertion class as
+   the existing 4672→`user_role=administrator`. Ship with #1.
+4. **`login_count == 0` on built-ins as a "never-authenticated" signal** — keep as
+   native context on the success/`user_session` row (no CAR field); useful for the
+   downstream cascade, cheap.
+
+Everything above is **one artefact family (SAM + ProfileList)**, already parsed and
+already in `_native` — the work is *routing/derivation*, not new evidence.
+
+---
+
+## 5. Honest nulls / non-sources from disk (do NOT try to fake)
+
+- **SAM `failed-count` / `last-failed-logon` → `failure`.** The task hypothesised
+  this; **it is not available.** The SAM F-value *does* hold bad-password-count and
+  last-incorrect-password time, but **Plaso's `windows_sam_users` plugin does not
+  parse or emit them** — confirmed empirically: the only `timestamp_desc` values seen
+  are Last Login / Last Password Set / Content Modification, and no `fail`/`incorrect`/
+  `bad-password` field exists on any of the 27 rows. So **disk yields a `success`
+  source but NO `failure` source.** (Failure remains Security **4625**-only; btmp on
+  Linux — both event logs, not hives.)
+- **SECURITY hive LSA cached creds / domain secrets → `ad_domain`.** Encrypted
+  (`NL$KM`/`Cache\NL$x`/`Policy\Secrets`); **Plaso winreg does not decrypt LSA
+  secrets** — only LSA *policy* keys surface (Credssp/MSV1_0/FipsAlgorithmPolicy/
+  `Kerberos\Domains` empty). No secretsdump/creddump-class tool in the repo. Honest
+  no-source in-pipeline (and this host is a workgroup — no domain regardless).
+- **Winlogon `DefaultUserName`/`DefaultDomainName`/`AutoAdminLogon`.** Identity hints
+  at best (autologon config), not an auth event; **not set** in the real sample (the
+  matches were WinSxS component-store `wcm://…metadata\elements\DefaultUserName`
+  noise). Also structurally trapped in the `values` list → `_native`. Near-null.
+- **LogonUI `LastLoggedOnUser`/`LastLoggedOnSAMUser`/`SelectedUserSID`.** Last-user
+  hint, not an outcome; **no dedicated Plaso plugin** (generic `key_value` → unindexed
+  `values` list); the value isn't in this sample's LogonUI extract. Weak.
+- **Credential Manager / DPAPI blobs / Vault.** Encrypted; enumerate *accounts*, not
+  auth outcomes; **no parser in the repo**, no evidence. No-source.
+- **Scheduled-task author SID.** No structured field: `windows:tasks:job` → `author =
+  None`, `task_scheduler:task_cache:entry` carries only `task_identifier`/`task_name`/
+  `username`. The **creator principal IS present but only as an unstructured string**
+  in the `.job` message (`Scheduled by: DESKTOP-PM6C56D\jcloudy` observed on the real
+  Dropbox tasks) — a name, no SID, and only via regex on the message. Weak signal
+  regardless (task *creation* is not an authentication event). Treat as effectively
+  no-source for `authentication`.
+- **`auth_service`, `method`, `decision_reason`, `response_time`, `app_name`,
+  `user_agent`.** Event-only by nature; a disk snapshot never records the live
+  exchange. Permanent honest nulls from any hive/disk artefact.
+- **On-disk `Security.evtx`.** Not a new disk source — it *is* the existing
+  `evtx_security`/`core.py` mapper's input (EvtxECmd over the image's evtx files).
+  De-emphasised here; covered by the event-log audit.
+
+---
+
+## 6. Summary
+
+- **Disk contributes to `authentication` today: nothing from hives** — the object is
+  wired to `evtx_security` (4624/4625/4672) alone; every `windows:registry:*` row
+  (SAM included) is routed to the **registry** object with its auth-bearing fields
+  parked in `_native`.
+- **The one real disk auth record is SAM `Last Login Time`** — a dated, principal-
+  bound **`success`** (user, RID→SID, host, timestamp, count). It is a **snapshot
+  state, not an event**, overlaps `user_session/login`, and is **success-only**.
+- **SAM gives NO failure** (Plaso drops the bad-password/last-incorrect fields), and
+  **LSA cached-cred `ad_domain` is unreachable** (encrypted, no decryptor in repo).
+- **Best unmined lever:** promote SAM `sam_users`(Last Login) + SOFTWARE `ProfileList`
+  (SID/machine-SID join) + RID→user_type derivation — all already parsed and sitting
+  in `_native`, needing only routing/derivation, marked snapshot-derived.
+- **Honest nulls from disk:** auth_service, method, decision_reason, response_time,
+  app_name, user_agent (event-only); failure record; ad_domain via LSA; Credential
+  Manager; scheduled-task author.

--- a/docs/car-provenance/lonewolf-fs-recheck/driver.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/driver.md
@@ -1,0 +1,102 @@
+# MITRE CAR `driver` — FILESYSTEM / disk provenance pass
+
+**Object:** `driver` — "software that runs in the operating system kernel."
+**Canonical fields (11):** `base_address`, `fqdn`, `hostname`, `image_path`, `md5_hash`, `module_name`, `pid`, `sha1_hash`, `sha256_hash`, `signature_valid`, `signer`
+**Actions (2):** `load`, `unload`
+
+**Scope of THIS pass.** The prior catalogue (`docs/car-provenance/driver.md`, LS24) proved the driver object is produced by only two mapped sources — **Sysmon EID 6** (identity + hashes + signature) and **memory `windows.modules`** (base_address + path + name) — and flagged disk `.sys` hashes as an *unwired enrichment*. This pass audits the **FILESYSTEM/disk** artefacts exhaustively, grounded in the real LoneWolf Win10 plaso timeline, to enumerate what a *dead disk alone* can put on the driver object.
+
+**Grounded in:** `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (LoneWolf `LoneWolf.E01`, 4,169,774 plaso events, incl. VSS shadow copies VSS1/VSS2). Engine maps: `piiat_mitrecar/mappings/plaso_registry.py`, `plaso_fs_extra.py`, `plaso_exec.py`, `sysmon.py`; sources `sources/plaso_*.yaml`.
+
+> **Headline.** No filesystem source emits a `driver` object today — the ONLY producer of `object: driver` in the whole engine is `sysmon.py` (`sysmon_driver_load`, EID 6). Every disk `.sys` artefact that exists in the real image is currently routed to **`registry`**, **`file`** or a dropped **`process`** row, with the driver identity buried in `_native`. Yet the disk carries, for **352 unique kernel/FS drivers on this one image**, enough to fill **6 of 11** driver fields — `image_path, module_name, sha1_hash, sha256_hash, signer, signature_valid` — with *zero* Sysmon or memory evidence. This is the single largest unmined driver supply in the pipeline.
+
+---
+
+## Filesystem source universe (what a disk can produce for a `driver` row)
+
+| Src | Artefact (disk) | Plaso parser → data_type | Real-data volume (LoneWolf) | Currently routed to | Driver object today |
+|---|---|---|---|---|---|
+| **D1** | **Amcache `\Root\InventoryDriverBinary\<path.sys>`** (`Amcache.hve`) | `winreg/amcache` → `windows:registry:key_value` | **702 subkeys → 352 UNIQUE `.sys`**; all carry DriverId(SHA1)+DriverSigned=1 | `registry`/key_edit (values in `_native`) **+** a null `process`/create (dropped) | **NO** |
+| **D2** | **SYSTEM hive `…\Services\<name>` with `Type`=1 (kernel) / 2 (filesystem) driver** (`SYSTEM` hive) | `winreg/windows_services` → `windows:registry:service` | **1048 driver-type rows → 361 UNIQUE** (937 Type-1, 111 Type-2, dedup incl. ControlSet+VSS) | `registry`/key_edit (`image_path`/`service_type`/`start_type`/`name` in `_native`) | **NO** |
+| **D3** | **PE `.sys` on disk** (`\System32\drivers`, `\WinSxS`, `\DriverStore`) | `pe` → `pe_coff:file` | **4643 `.sys` rows**; ALL have `sha256_hash`+`imphash`+`pe_type="Driver (SYS)"`; 1172 have `export_dll_name` | `file`/create (timestamp-less), `pe_type` kept native but **unused as a router** | **NO** |
+| **D4** | **Amcache `InventoryApplicationFile` for app-bundled `.sys`** (Defender/NVIDIA installers) | `winreg/amcache` → `windows:registry:amcache` | ~36 `.sys` rows; `file_identifier`=SHA1, `company_name`, `file_version` | `file`/create (+ Link-Time entity) — but reads `Record.sha1` (null here) so SHA1 **lost** | **NO** |
+| **D5** | **`$MFT` / filestat of `\drivers\*.sys`** | `filestat` → `fs:stat` | **4836 rows** (Creation/Content-Mod/Last-Access per `.sys`) | `file` (fs_stat lane) | **NO** (path+size+times only; no hash/signer) |
+| **D6** | **Prefetch `mapped_files` naming `.sys`** (`DRVINST.EXE`→WUDFRD.SYS/TEEDRIVERW8X64.SYS; SMSS/CSRSS→WIN32K*.SYS) | `prefetch` → `windows:prefetch:execution` | present, sparse | `process`/create (`.sys` in `_native.mapped_files`) | **NO** (and correctly so — not a load) |
+| **D7** | **Appcompat / shimcache of `.sys`** | `winreg/appcompatcache` → `windows:registry:appcompatcache` | **0 `.sys`** (1463 rows, all `.exe`) | `process`/create | **NO — empty on disk** |
+| **D8** | **Catalog DB `.cat` (CatRoot) → true Authenticode `signature_valid`** | *no plaso parser* | — | — | **NO — no parser exists** |
+
+All D1–D6 rows in this image are duplicated ×2–3 by VSS shadow copies (`VSS1:`/`VSS2:` display-name prefixes) and by `ControlSet001`/`ControlSet002` for Services — dedup on `.sys` path/basename is required downstream.
+
+---
+
+## Per-field provenance (FILESYSTEM sources)
+
+Legend — **mined?**: does any FILESYSTEM source write this column to a **`driver`** row today. (All are **NO** — no disk source emits a driver object at all.)
+
+| field | fs artefact → native field | action | mined? | confidence & caveats |
+|---|---|---|---|---|
+| **base_address** | **none** (runtime-only) | load | **NO — honest null** | High. A load address is a *runtime* fact (where the kernel mapped the image); the disk never records it. Memory `windows.modules` is the sole source (prior pass). Disk `driver` rows leave it null — correct. |
+| **fqdn** | D1/D2/D3 → plaso `image_hostname` = `DESKTOP-PM6C56D` (NetBIOS, no dot) | load | **NO** | Med. The image identity is a bare NetBIOS name (`DESKTOP-PM6C56D`), not dotted → no honest FQDN. `fqdn` stays null from disk (never fake a dot). Same rule as the Sysmon `_FQDN` guard. |
+| **hostname** | **D1/D2/D3/D5** → `image_hostname` (`DESKTOP-PM6C56D`), lane-stamped on every plaso row | load | **NO** (available, unrouted) | High. Every disk row already carries the host; a disk-driver row would stamp `hostname` trivially. Free the moment a driver object is emitted. |
+| **image_path** | **D1** key_path tail `\Root\InventoryDriverBinary\c:/windows/system32/drivers/1394ohci.sys`; **D2** Service `image_path` `\SystemRoot\System32\drivers\iagpio.sys`; **D3** PE `display_name` `\Windows\System32\drivers\wfplwfs.sys`; D5 filestat path | load | **NO** | High. FOUR independent disk sources give the driver's own `.sys` full path. D2 also surfaces `\…\DriverStore\FileRepository\…\CompositeBus.sys`. Caveat: a handful of built-in kernel drivers have Service `image_path=None` (e.g. `Beep`) — honest null. |
+| **md5_hash** | **none** | load | **NO — honest null** | High. Plaso `pe` emits `sha256` only (`md5_hash` null in data); amcache stores only SHA1 (DriverId). No disk artefact carries the driver's MD5 → Sysmon-only field. |
+| **module_name** | **D1** `DriverName`=`1394ohci.sys` / `Service`=`1394ohci`; **D2** Service key `name`=`iagpio` (+`Service`); **D3** PE `export_dll_name` (internal name) / basename; D5 basename | load | **NO** | High. Multiple disk sources. D1 `Service` and D2 `name` are the SCM service/module name; PE `export_dll_name` is the binary's internal name — both are legitimate `module_name` fills (basename of `image_path` is the fallback). |
+| **pid** | **none** | load / unload | **NO — honest no-source** | High. Kernel loads drivers, not a user process; no disk artefact records an initiating PID (matches Sysmon EID 6 and memory `windows.modules`, both PID-less). Structural null. |
+| **sha1_hash** | **D1** `DriverId`=`0000cabc55b4…93f1` → strip 4-char `0000` prefix ⇒ SHA1; **D4** `file_identifier`=`00005a53…` (same encoding) | load | **NO** | High. **352 drivers carry a SHA1 on disk via amcache DriverId** — a hash with no Sysmon/memory needed. CAVEAT: current amcache map reads `Record.sha1` (NULL in this plaso build — the hash lives in `DriverId`/`file_identifier`), so the SHA1 is *lost even on the existing file object*. The `0000` prefix must be stripped. |
+| **sha256_hash** | **D3** PE `sha256_hash` (the `pe` parser hashes every `.sys`; e.g. `wfplwfs.sys`=`bad5292a…9802`) | load | **NO** | High. **4643 `.sys` PE rows, all with sha256.** This is the disk's SHA-256 supply for drivers (Sysmon supplies it only where EID 6 fired). Join to D1/D2 on `.sys` basename to hydrate. `md5`/`signature` null from the PE parser. |
+| **signature_valid** | **D1** `DriverSigned`=`1` (⇒ True) — 702/702 signed in this image | load | **NO** (proxy only) | Med. `DriverSigned=1` is amcache's *recorded* signed-state (catalog or embedded) at inventory time, **not** a fresh Authenticode verification like Sysmon `SignatureStatus=Valid`. Map to `True` only on `=1`, caveat native; never assert `False`. TRUE signature verification (**D8**, `.cat` CatRoot) has **no plaso parser** — real `signature_valid` from disk is unavailable. |
+| **signer** | **D1** `DriverCompany`=`Microsoft Corporation` / `Intel Corporation` / `NVIDIA Corporation` (+`Product`); D4 `company_name` | load | **NO** (proxy) | Med. `DriverCompany` is the PE CompanyName / INF provider — a signer *proxy*, not the Authenticode signer subject CN that Sysmon's `Signature` gives. Reasonable fill with a caveat; distinct from the true signer. Distribution: Microsoft 584, Intel 26, Mellanox/Avago/NVIDIA/LSI/AMD/QLogic the rest. |
+
+**Disk-only coverage:** 6/11 fields fillable from a dead disk — `image_path, module_name, sha1_hash, sha256_hash` (strong) + `signer, signature_valid` (proxy, caveated). `hostname`/`fqdn` are free host-identity. `base_address, pid, md5_hash` and **action `unload`** have **no disk source**.
+
+---
+
+## Per-action coverage (disk)
+
+### `load`
+The three primary disk sources are **complementary** and join on the `.sys` path/basename — together they out-cover either Sysmon or memory alone for identity+integrity (they lack only the runtime `base_address`):
+
+- **D1 amcache InventoryDriverBinary** → `image_path, module_name, sha1_hash, signer(proxy), signature_valid(proxy)` + kernel-mode flag + version/compile-stamp (native). *The richest single disk source — 352 drivers.*
+- **D2 SYSTEM Services (Type 1/2)** → `image_path, module_name` + the **load configuration itself**: `start_type` (0 boot / 1 system / 2 auto / 3 demand) and `service_type` (1 kernel / 2 filesystem). This is the persisted *instruction that the driver is to be loaded* — the closest a disk gets to a load event.
+- **D3 PE `.sys` "Driver (SYS)"** → `sha256_hash` (+ imphash, export name). *The only disk SHA-256.*
+
+**Action semantics.** None of these is a timestamped load *event* — the row stamps are key-write / PE compile-link / file-MFT times, i.e. *presence/recorded* times, never the moment the kernel mapped the driver. So the honest treatment mirrors the pipeline's existing amcache/appcompatcache convention (`native.execution_inferred=True`, `native.time_meaning=…`): action `load` under a **presence-implies-installed/loaded inference**, with the time labelled for what it is. A Services `Start`=0/1/2 (boot/system/auto) is stronger load evidence than `Start`=3 (demand).
+
+### `unload`
+**ZERO disk source** — same structural dead-end as the prior pass. A disk is a snapshot; it cannot witness an unload. `.sys` presence + Services registration prove installation/load-intent, never removal. Honest no-source (not merely unmapped).
+
+---
+
+## Cross-source join (the enrichment this pass unlocks)
+
+All disk sources key on the driver's `.sys` **path/basename** (and D1/D3 also share **SHA1↔SHA256** once both are on one object). A single reconciled disk driver — e.g. `1394ohci.sys` — assembles:
+
+- D2 Services → `image_path \SystemRoot\System32\drivers\1394ohci.sys`, `module_name 1394ohci`, `start_type 3`, `service_type 1` (kernel)
+- D1 amcache → `sha1 cabc55b4b36a990e0a1f770aa82bf7727cd193f1`, `signer Microsoft Corporation`, `signature_valid True`, `DriverIsKernelMode 1`, `DriverVersion 10.0.16299.15`
+- D3 PE → `sha256 …`, `imphash …`, `export_dll_name …`
+
+`crosssource.py` already treats `driver ∈ _HASHED ∩ _IMAGED`, so once disk driver rows exist they converge with each other **and** with Sysmon/memory driver rows on hash or basename — the disk fills exactly the gaps Sysmon-less / memory-less evidence leaves (the prior pass's "enrichment join" recommendation, now with a concrete disk supply on a real image).
+
+---
+
+## Ranked UNMINED opportunities
+
+1. **Amcache `InventoryDriverBinary` → a driver object from a dead disk (HIGH — biggest win).** `winreg/amcache` `key_value` rows under `\Root\InventoryDriverBinary\<path.sys>` give **352 unique drivers** with `image_path` (key tail), `module_name` (`DriverName`/`Service`), `sha1_hash` (`DriverId`, strip `0000`), `signer` (`DriverCompany`, proxy), `signature_valid` (`DriverSigned=1`, proxy), plus kernel-mode flag/version natively. Today these land only on `registry`/key_edit with everything buried in `_native.values`. A dedicated variant emitting `object: driver, action: load` (presence-inferred) is the single highest-value addition. **Bonus bug:** the *existing* amcache→file map reads `Record.sha1`, which is NULL in this plaso build — the SHA1 lives in `DriverId`/`file_identifier` (0000-prefixed); this hash is currently dropped even on the file object.
+
+2. **SYSTEM `Services` Type=1/2 → the driver object from the install record (HIGH).** `winreg/windows_services` (`service_type` ∈ {1,2}) — **361 unique** — is the authoritative on-disk record that a kernel/filesystem driver is *installed to load*, carrying `image_path` (incl. DriverStore paths), `module_name` (`name`/`Service`) and the **load-order config** (`start_type`, `service_type`) that no other source has. Currently → `registry`/key_edit only. A driver-object emit (or a driver↔registry link on `service_type`∈{1,2}) recovers it. Note: this is a *different* source from the prior pass's 7045/20003 (those are event-log service installs → `service`); this is the dead-hive Services key.
+
+3. **PE `pe_coff:file` where `pe_type="Driver (SYS)"` → sha256 for the driver object (MEDIUM-HIGH).** The `pe` parser already hashes **4643 `.sys`** with `sha256_hash`+`imphash`+`export_dll_name`, and already tags them `pe_type="Driver (SYS)"` — a ready-made router that the current map keeps *native but unused*. Either dual-emit a `driver` row from the "Driver (SYS)" PE, or (cheaper) let a `driver↔file` cross-source join on `.sys` basename hydrate `sha256` onto the driver object. This is the ONLY disk source of the driver SHA-256.
+
+4. **amcache `InventoryApplicationFile` `.sys` (D4) — secondary hash source (LOW-MEDIUM).** ~36 app-bundled `.sys` (Defender `wdboot.sys`/`wdfilter.sys`, NVIDIA installer `.sys`) with `file_identifier`(SHA1)+`company_name`+`file_version`. Overlaps D1/D3; useful mainly for third-party drivers outside `\System32\drivers`. Same `file_identifier` SHA1-extraction fix applies.
+
+5. **True Authenticode `signature_valid` from CatRoot `.cat` (LOW — needs a new parser).** D1's `DriverSigned`/`DriverCompany` are *proxies*. A real signature verdict + signer CN would require parsing `\Windows\System32\CatRoot\…\*.cat` catalogs (or Authenticode over each `.sys`) — **no plaso/EZ parser exists in the pipeline**, and plaso's `pe` parser leaves `signature`/`signature_status` null on every `.sys`. Genuine disk `signature_valid` is therefore currently unattainable; the amcache proxy is the honest best.
+
+## Honest no-sources (disk)
+
+- **`base_address`** — runtime-only; a disk never records where the kernel mapped an image. Memory-only (prior pass).
+- **`pid`** — kernel-loaded; no initiating user process, and no disk artefact records one. Structural null on every source.
+- **`md5_hash`** — plaso `pe` emits sha256 only; amcache stores only SHA1. No disk MD5. Sysmon-only.
+- **action `unload`** — a disk snapshot cannot witness a removal; `.sys` presence + Services registration prove install/load-intent, never unload. Structural dead-end.
+- **`appcompatcache`/shimcache of `.sys` (D7)** — exists but empty here: 0 of 1463 shimcache rows name a `.sys` (shimcache records executed `.exe`). Not a driver source on this image.
+
+**Bottom line.** The disk holds a large, honest, currently-unmined driver supply: **352 drivers** identifiable from a dead LoneWolf image with `image_path + module_name + sha1 + sha256 + signer/signature (proxy)` — 6/11 fields, no live telemetry required — split today across `registry`, `file` and dropped `process` rows. The three ranked additions (amcache InventoryDriverBinary, SYSTEM Services Type 1/2, PE "Driver (SYS)") would let the pipeline reconstruct the driver object from disk alone and converge it (via existing `crosssource.py` hash/basename joins) with any Sysmon/memory driver rows. `base_address`, `pid`, `md5_hash` and `unload` remain genuine disk no-sources; true Authenticode `signature_valid` awaits a `.cat` catalog parser that does not yet exist.

--- a/docs/car-provenance/lonewolf-fs-recheck/email.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/email.md
@@ -1,0 +1,106 @@
+# CAR `email` — FILESYSTEM / disk provenance audit (unmined mail stores)
+
+Deep-audit of the MITRE CAR `email` object against **on-disk mail artefacts** — the
+class the pipeline has *never* touched. Companion to the network-focused
+`docs/car-provenance/email.md` (LS24: only `zeek_smtp`, STARTTLS → empty).
+Grounded in the real LoneWolf Win10 image and the engine's actual routing.
+**READ-ONLY audit — no code changed.**
+
+## Headline
+
+**`email` yields nothing from disk today, and that is a whole-source gap, not an honest null.**
+The only email mapper in the engine is `zeek_smtp` (network; STARTTLS → 0 rows).
+**No mail-store parser is wired anywhere** — confirmed three ways:
+
+- `piiat_mitrecar/mappings/` and `sources/*.yaml` contain **no** pff / PST / OST / mbox / EML / MSG / ESE-mail / HxStore adapter.
+- `pipeline.py` `ROUTES` (the filename→map dispatch): the only email route is `("smtp.json", ["zeek_smtp"])`. `.L2tEsedb` routes **only** to `l2t_srum`; `.L2tOlecf` → `plaso_olecf` (→ `file`). No pff/mbox/HxStore/store.vol route exists.
+- `mappings/core.py` docstring, verbatim: *"email: principles documented; no artefact feeds it yet … so no map — an empty table is honest."*
+
+On the LoneWolf disk the mail genuinely lives in **two on-disk stores and the Gmail
+webmail cache**, and plaso recorded all of them as **`fs:stat` only** (path + size +
+MFT timestamps) — their *contents* are never parsed, so **0 of 21 `email` fields are
+populated from disk**.
+
+## Ground truth — LoneWolf `DESKTOP-PM6C56D.jsonl`
+
+Source: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+(6.6 GB, 4,169,774 rows). User = **`jcloudy` (Jim Cloudy)**. Mail client = **Windows 10
+Mail app** (`microsoft.windowscommunicationsapps` / `Comms.Apps.Messaging` / `Unistore.dll`),
+**not** classic Outlook.
+
+**Plaso data_type distribution — ZERO mail data_types.** `grep '"data_type": "(pff|msg|mbox|eml|outlook|thunderbird)'` → **no matches**. The emitted types are `fs:stat` (1.97 M), `windows:registry:*`, `windows:evtx:record`, `pe_coff:file`, `chrome:cache:entry` (21.6 k), `chrome:history:page_visited` (2.3 k), `chrome:cookie:entry` (8.9 k), `chrome:autofill:entry` (802), `msie:webcache:*`, `olecf:*`, etc. **Plaso never ran its `pff` (PST/OST), `mbox`, or `msg` parser** — because none of those file types is on the disk, and the stores that *are* present are formats plaso has no mail plugin for.
+
+**On-disk mail stores actually present (recorded as `fs:stat`, contents UNPARSED):**
+
+| artefact on disk | path (LoneWolf) | size | what it holds | plaso saw it as |
+|---|---|---|---|---|
+| **Win10 Mail ESE store** `store.vol` (Unistore) | `\Users\jcloudy\AppData\Local\Comms\UnistoreDB\store.vol` | 6,291,456 B | message/contact/calendar **metadata**: from/to/subject, submit/delivery times, read-state, folder | `fs:stat` (file existence + MAC times) |
+| **HxStore** `HxStore.hxd` | `\Users\jcloudy\AppData\Local\Packages\microsoft.windowscommunicationsapps_8wekyb3d8bbwe\LocalState\HxStore.hxd` | 4,194,304 B | full messages: **body + transport headers + attachments** (also present in a **VSS2 shadow copy** → historical state) | `fs:stat` only |
+| **Gmail webmail cache** | Chrome `Cache` / `History` / `Autofill` / cookies | — | account address, message URLs, cached fragments/titles | `chrome:cache:entry` / `history` / `autofill` → routed to **`http`**, never `email` |
+
+**Recoverable account identity (a real `src_address` sitting unused in the store):**
+`jimcloudy1@gmail.com` (2,032 occurrences), `JimCloudy@outlook.com` / `jimcloudy@outlook.com` (20), plus webmail hosts `mail.google.com` (162), `outlook.office*` (33), `outlook.live.com` (24). These land in `chrome:autofill:entry` / URLs / cookies, which the engine ingests via `plaso_web.py` **into the `http` object** — the address is never promoted to `email.src_address`.
+
+**Absent on this disk (checked, honestly negative):** no PST/OST files (the `Outlook.File.ost.15` / `.pst` hits are HKLM file-type *registrations*, not data files); no loose `.eml`/`.msg` under `\Users`; no Thunderbird profile / `global-messages-db.sqlite`; no `Content.Outlook` / INetCache attachment temp; no classic Outlook-profile registry key. The `.dbx` files present are **Dropbox** SQLite, not Outlook Express. `FPEXT.MSG` is a SharePoint/FrontPage stub, not mail.
+
+## Per-field provenance — filesystem mail stores
+
+Legend for "mail-store artefact → native field": **PST/OST** = Outlook personal store via libpff (`pff`); **store.vol** = Win10 Mail Unistore ESE; **HxStore** = `HxStore.hxd`; **.eml/.msg** = loose RFC5322 / MAPI message files; **mbox+Gloda** = Thunderbird mbox + `global-messages-db.sqlite`; **webmail** = browser cache/history/autofill; **reg}** = mail-account registry. `mined?` is **NO** for every row — **no mail parser is wired** (see Headline). Actions per MITRE: block, delete, deliver, quarantine, redirect.
+
+| field | mail-store artefact → native field | action(s) | mined? | conf & caveats |
+|---|---|---|---|---|
+| **from** | PST/OST `PR_SENDER_NAME`/`PR_SENDER_EMAIL_ADDRESS`; store.vol sender col; HxStore From; .eml/.msg `From:`; mbox `From `; Gloda `messenger`/`identity` | deliver | **NO** (no mail parser) | High as a value; **forgeable** (MITRE says so). Display sender, never attribution. |
+| **to** | PST/OST `PR_DISPLAY_TO`; store.vol recipient row; HxStore To; .eml `To:`; mbox; Gloda | deliver | **NO** | High. Header To — a **display list, ≠ real recipients**; CC/BCC not represented here either. |
+| **dest_address** | PST/OST recipient table (`PR_SMTP_ADDRESS`/`PR_RECEIVED_BY_*`); store.vol recipient EntryIDs; HxStore; .eml `To`/`Delivered-To` | deliver | **NO** | Med-High. A client store keeps **header/MAPI** recipients, not the SMTP-envelope RCPT — so this is "resolved recipient", not envelope-authoritative (that authority is only on the wire/server). |
+| **src_address** | PST/OST `PR_SENDER_SMTP_ADDRESS`/`PR_SENT_REPRESENTING_SMTP_ADDRESS`; store.vol; HxStore; .eml `From`/`Sender`; mbox; Gloda; **webmail account** (`jimcloudy1@gmail.com`) from browser autofill/cache/cookies; reg} Mail-app / Outlook-profile SMTP address | deliver | **NO** | High. **Strongest value ALREADY on this disk** — the signed-in webmail account. For a received message the "sender" is the correspondent; for the account owner it's the webmail/profile address. |
+| **src_domain** | `domain_of(src_address)` from any of the above | deliver | **NO** | High — mechanical derivation; inherits `src_address` forgeability. |
+| **subject** | PST/OST `PR_SUBJECT`/`PR_NORMALIZED_SUBJECT`; store.vol subject col; HxStore; .eml `Subject`; mbox; Gloda `subject`; webmail cached page **titles** | deliver | **NO** | High. Cleartext on disk (unlike STARTTLS on the wire). |
+| **date** | PST/OST `PR_CLIENT_SUBMIT_TIME` / `PR_MESSAGE_DELIVERY_TIME`; store.vol submit/delivery timestamps; HxStore; .eml `Date:`; mbox `Date`; Gloda `date` | deliver | **NO** | High as a header/MAPI value. Client `Date:` is **forgeable** and ≠ the store's own MAC timestamp; distinguish submit vs delivery time. |
+| **message_body** | PST/OST `PR_BODY`/`PR_HTML`/`PR_RTF_COMPRESSED`; **HxStore.hxd body**; .eml body part; mbox; Gloda indexed body text; webmail cached message fragments | deliver | **NO** | High — **THE reason a disk source matters**: Zeek can't see the body under STARTTLS; a mail store holds it in cleartext. On this disk it is inside `store.vol`/`HxStore.hxd`. |
+| **message_links** | Derived from body (all body sources above); **webmail message URLs** in `chrome:history`/`cache` | deliver | **NO** | Med. Derive after a body exists, or lift from the browser URL rows the engine already parses. |
+| **message_type** | Body part `Content-Type` — PST/OST `PR_MSG_EDITOR_FORMAT` (html/plain/rtf); .eml part `Content-Type`; mbox; Gloda | deliver | **NO** | Med. Projects to ECS `email.content_type`. |
+| **return_address** | PST/OST `PR_REPLY_RECIPIENT_ENTRIES` / `Reply-To` transport header; .eml `Reply-To:` / `Return-Path:`; mbox `Return-Path` | deliver | **NO** | Med. Phishing tell — Reply-To/Return-Path ≠ From is signal, not identity. |
+| **server_relay** | **`Received:` chain** stored verbatim: PST/OST `PR_TRANSPORT_MESSAGE_HEADERS`; HxStore transport headers; **.eml raw headers**; mbox headers | deliver | **NO** | Med-High. **KEY insight: a stored message recovers a wire/server artefact the client-STARTTLS network view never gives.** The full relay chain (each hop IP+host+time) is in the message's own transport headers. |
+| **attachment_name** | PST/OST `PR_ATTACH_LONG_FILENAME`/`PR_ATTACH_FILENAME`; HxStore attachment; .eml `Content-Disposition` filename; .msg `__attach_*` stream; **extracted attachment temp files** (`Content.Outlook`/INetCache) visible as `fs:stat` | deliver | **NO** | Med-High. Temp-extracted attachments are already `fs:stat`-visible (name) even with no mail parser → an attachment↔file bridge could seed this. |
+| **attachment_size** | PST/OST `PR_ATTACH_SIZE`; HxStore; .eml part length; mbox; extracted temp file `fs:stat.file_size` | deliver | **NO** | Med. ECS `email.attachments.file.size` wants bytes; MAPI gives bytes directly. |
+| **attachment_mime_type** | PST/OST `PR_ATTACH_MIME_TAG`; HxStore attachment part `Content-Type`; .eml/.msg part `Content-Type`; mbox | deliver | **NO** | Med. This is the **declared** MIME (per MITRE) — less trustworthy than libmagic; a stored message only has the declared value. |
+| **smtp_uid** | PST/OST `PR_INTERNET_MESSAGE_ID` / `PR_SEARCH_KEY`; .eml `Message-ID:`; mbox `Message-ID` | deliver | **NO** | Low-fit. A client store has the **RFC Message-ID (a proxy)**, not the server-local queue/transaction id CAR actually means. True `smtp_uid` needs a mail-SERVER log. |
+| **src_ip** | Only via the stored `Received:` chain (first hop) or an `X-Originating-IP` header — same header sources as `server_relay` | deliver | **NO** | Med **only through header parse**; otherwise a **wire artefact absent from a client store**. |
+| **dest_ip** | Only via the last `Received:` hop in the stored header chain | deliver | **NO** | Low. Same caveat — recoverable only from the transport-header chain, else **honest null from disk**. |
+| **src_port** | — (pure wire 5-tuple; never stored in a mail file) | — | **NO** | **Honest null from any disk mail store.** |
+| **dest_port** | — (wire 5-tuple; a client "port" would be the IMAP/993 pull port, not the SMTP delivery port CAR means) | — | **NO** | **Honest null from disk** for CAR's meaning. |
+| **action_reason** | At most a **Junk-folder placement** flag (store.vol folder id / HxStore spam flag); the *reason string* is a mail-SERVER/gateway verdict (Exchange DLP, O365/Defender `ThreatTypes`, Proofpoint/Mimecast) — **not on a client disk** | quarantine/block | **NO** | Low. A client store shows *that* a message was junked, never *why*. **Honest near-null from disk.** |
+
+### Actions from a disk store
+
+- **deliver** — every received message *in* the store IS a delivered message; the store's contents attest `deliver`. Fully derivable once any store is parsed.
+- **delete** — Deleted Items folder / store soft-delete flag (store.vol/PST), mbox `X-Mozilla-Status` deleted bit, webmail Trash label, Recycle Bin / USN-journal entry for a message file. Recoverable from folder/flag + the USN we already ingest.
+- **block / redirect / quarantine** — mail-**server / gateway** security verdicts. A client disk store gives at most a weak Junk-folder proxy for *quarantine*; `block`/`redirect` leave **no client-disk trace**. These + `action_reason` are the by-design no-source set for disk (they need Exchange/O365/gateway logs).
+
+## Ranked UNMINED opportunities (filesystem)
+
+1. **`store.vol` (Win10 Mail Unistore/ESE) + `HxStore.hxd` — PRESENT ON THIS EXACT EVIDENCE, 6 MB + 4 MB, plus a VSS2 shadow copy.** Currently `fs:stat` only. A Unistore/ESE mail plugin (metadata: from/to/subject/date/read-state/folder) + an HxStore parser (body/headers/attachments) would take `email` from **0 rows to a populated table on the flagship disk image**. Highest value because it is the real mail on the real evidence. *Caveat:* `HxStore.hxd` is a proprietary/undocumented format (hard; may need dedicated tooling); `store.vol` is ESE — plaso can open ESE but ships **no mail-aware plugin** for Unistore today, so a new plugin/adapter is required either way.
+2. **Outlook PST/OST via the `pff` parser (libpff).** The canonical, best-documented mail-store path — fills *every* content field plus the **full `Received:` chain** (transport headers → `server_relay`, and `src_ip`/`dest_ip` via the hops). Not on this disk, but the primary parser to wire for the general case; once a plaso run emits `pff:*` data_types, a routing entry + map is low-cost. This is the single biggest coverage lever across hosts.
+3. **Webmail account → `email.src_address` (already-ingested data).** `jimcloudy1@gmail.com` is sitting in `chrome:autofill:entry` / cookies / URLs that the engine **already parses** (`plaso_web.py`) — but routes to `http`. An email-account extractor over those rows (or the Mail-app/Outlook-profile registry) is the **cheapest possible win** to make `email.src_address`/`src_domain` non-empty. Signed-in identity, not forgeable header.
+4. **`Received:`-header chain → `server_relay` (+ `src_ip`/`dest_ip`/`date`).** From **any** stored message (PST `PR_TRANSPORT_MESSAGE_HEADERS`, `.eml` raw headers, HxStore). The forensic point: **a disk store recovers server/wire artefacts (the relay chain) that the STARTTLS-encrypted network capture can never yield.**
+5. **Loose `.eml` / `.msg` + extracted attachment temp.** `.msg` is an OLE compound file — plaso's `olecf` plugin *sees* it but only emits `summary_info → file`, never the MAPI mail fields; needs a real MSG/EML mail parser. Attachment temp files (`Content.Outlook`/INetCache) are already `fs:stat`-visible (name/size) → an **attachment↔file bridge** could seed `attachment_name`/`attachment_size` even before a full parser. (None present on *this* disk, but a standard artefact class.)
+6. **Thunderbird mbox + `global-messages-db.sqlite` (Gloda).** mbox = raw RFC5322 (all header + body fields); Gloda = a full-text index (from/to/subject/body/date). Standard parser to add for cross-platform coverage. (Not present on this disk.)
+
+## Honest no-sources from a client disk store
+
+- **`src_port` / `dest_port`** — pure wire 5-tuple; never written to a mail file. Honest null.
+- **`dest_ip` (and `src_ip` beyond the first Received hop)** — wire artefacts; recoverable *only* by parsing the stored `Received:` chain, otherwise null.
+- **`action_reason` + the `block` / `redirect` / `quarantine` verdicts** — mail-SERVER/gateway security decisions (Exchange transport-rule/DLP, O365/Defender, Proofpoint/Mimecast). A client disk store records at most Junk-folder placement, never the reason. These need a server/gateway security-log parser, which no disk artefact can substitute for.
+- **`smtp_uid` (server queue/transaction id)** — a client store has only the RFC `Message-ID` (a semantic-mismatch proxy). The true value is a mail-server log field.
+
+## Bottom line
+
+Email is a **whole-source gap on disk**: the pipeline ingests the LoneWolf image down to
+1.97 M `fs:stat` rows and full browser cache/history, yet routes **none** of it to `email`
+— no mail-store parser exists. The mail that is demonstrably present — `store.vol` (6 MB) +
+`HxStore.hxd` (4 MB, with a shadow copy) and the Gmail webmail account `jimcloudy1@gmail.com`
+— is recorded only as file metadata and web history. Wiring **(a)** a Unistore/ESE +
+HxStore reader for this Win10-Mail evidence, **(b)** the `pff` PST/OST parser for the general
+case, and **(c)** a trivial webmail-account extractor over already-parsed browser rows would
+move `email` from a structurally-empty table to a populated one, and — via stored
+`Received:` chains — even recover the relay/IP fields the STARTTLS network capture never could.

--- a/docs/car-provenance/lonewolf-fs-recheck/file.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/file.md
@@ -1,0 +1,306 @@
+# CAR `file` — FILESYSTEM / disk-artefact provenance, deep sweep (LoneWolf)
+
+Second-pass, filesystem-focused re-audit of the CAR **file** object. Builds on
+`scratchpad/car-provenance-lonewolf/file.md` (which covered LNK / shell items /
+jump-list shell-items / USN / Recycle Bin / filestat, the user-from-path gap, the
+LNK "Not a time" drop, and the $MFT-absent finding). This pass hunts the
+**disk/filesystem artefacts that could fill `file` properties but the pipeline is
+NOT mining** — the $MFT metafiles, ADS/Zone.Identifier, $Secure/$SDS, PE/OLE/
+OOXML document metadata, amcache hashes+company, jump-list DestList, and the
+save/open MRU strings.
+
+Everything is grounded in the REAL plaso output
+`data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+(LoneWolf Win10, **4,169,774 rows**, whole-file counts below) and the live maps in
+`third_party/piiat-mitrecar/piiat_mitrecar/mappings/`. READ-ONLY.
+
+---
+
+## 0. What LoneWolf actually contains — file-bearing data_types (whole-file, grounded)
+
+| data_type | count | map today | → CAR object | mined for `file`? |
+|---|---:|---|---|---|
+| `fs:stat` (filestat) | **1,968,065** | `l2t_filestat` (plaso_linux.py:351) | file | YES (path/mac/sha256) |
+| `windows:registry:key_value` | 1,506,720 | `plaso_registry` | registry | n/a (registry) |
+| `fs:ntfs:usn_change` | **359,999** | `l2t_usnjrnl` (plaso_linux.py:356) | file | YES (bare-leaf path) |
+| **`pe_coff:file`** | **150,708** | `plaso_pecoff` (plaso_fs_extra.py:188) | file | **YES — NEW** (path+sha256+imphash) |
+| `windows:evtx:record` | 116,494 | evtx maps | (events) | n/a |
+| `windows:shell_item:file_entry` | 2,069 | `plaso_shellitem` | file | YES |
+| `windows:lnk:link` | 1,639 | `l2t_lnk` | file | PARTLY (Not-a-time drop) |
+| `windows:registry:appcompatcache` | 1,463 | `plaso_exec_winreg` | process | n/a |
+| `windows:prefetch:execution` | 1,312 | `plaso_exec_prefetch` | process | n/a |
+| **`olecf:summary_info`** | **276** | `plaso_olecf` (plaso_fs_extra.py:197) | file | **YES — NEW** (author→owner,sha256) |
+| `windows:distributed_link_tracking:creation` | **254** | — | — | **NO — unmapped** |
+| **`openxml:metadata`** | **223** | — | — | **NO — unmapped** |
+| `windows:registry:userassist` | 153 | `plaso_exec_winreg` | process | n/a |
+| `windows:registry:bam` | 76 | `plaso_exec_winreg` | process | n/a |
+| **`olecf:dest_list:entry`** | **72** | — | — | **NO — unmapped** |
+| `windows:registry:mrulistex` | 65 | `plaso_registry` | registry | **file NOT surfaced** |
+| `windows:registry:bagmru` | 62 | `plaso_registry` (+shell items) | registry/file | shell-item half only |
+| **`olecf:document_summary_info`** | **49** | — | — | **NO — unmapped (has `company`!)** |
+| `windows:registry:mrulist` | 17 | `plaso_registry` | registry | **file NOT surfaced** |
+| `windows:metadata:deleted_item` | 5 | `l2t_recyclebin` | file | YES |
+| `fs:ntfs:mft` | **0 — ABSENT** | `l2t_mft` (plaso_linux.py:354) | file | **NO INPUT** |
+| `windows:srum:*` | **0 — ABSENT** | `l2t_srum` (plaso_srum.py) | flow/process | **NO INPUT** |
+
+**Two structural absences reconfirmed (they gate half the sweep):**
+
+1. **No `$MFT`.** `fs:ntfs:mft` = 0; the `mft` parser did not run. So there is
+   **no `$SI`/`$FN` pair** (`attribute_name`/`STANDARD_INFORMATION`/`$FILE_NAME`
+   line-hits = **0**), **no resident `$DATA`** (`:$DATA` hits = 0), **no `$I30`**
+   (0), and **no MFT security descriptor** (`security_descriptor` key = 0). The
+   on-disk timeline is filestat + USN only. **This is the single biggest unmined
+   file source and it is a COLLECTION-lane gap, not a map gap** (see §3.1).
+
+2. **No ADS / Zone.Identifier.** `Zone.Identifier` line-hits = **0**; there is no
+   `windows:zone_identifier` data_type and filestat emits no `:streamname` ADS
+   rows on this image. So mark-of-the-web / download-provenance (HostUrl,
+   ReferrerUrl) has **no source here** — also a collection/parser gap (§3.6).
+
+**Metafiles present as paths only (no content parser):** `$Secure` 16, `$ObjId`
+16, `$LogFile` 16, `$I30` 0, `$SDS` 0 — these are just filestat rows for the NTFS
+metafiles; plaso has no parser that decodes `$Secure:$SDS` (owner SID/ACL),
+`$LogFile` (transactions) or `$ObjId`. `thumbcache` (782 hits) and `IconCache`
+(1,266 hits) are likewise just the `.db` file paths — **no thumbcache/iconcache
+parser exists**, so the deleted-file thumbnails/paths inside them are unmined.
+
+---
+
+## 1. Per-field provenance matrix — filesystem/disk artefacts (LoneWolf-grounded)
+
+Legend: **Y** mapped & populated · **Y·NEW** newly mapped since the prior pass ·
+**Y·null** mapped but null on this evidence · **PARTIAL** some source mapped,
+a richer one unmined · **N** no source · **UNMINED** a real source is present
+and is NOT mapped to this field.
+
+| field | fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|---|
+| **company** | `olecf:document_summary_info.company` (49); `windows:registry:amcache.company_name` (564/604) | create | **UNMINED** | **The ONLY on-disk sources for `company`, and BOTH are dropped.** doc-summary carries `company="Microsoft"` verbatim; amcache carries the binary's `company_name`. High-value, fully grounded. See §3.2/§3.3. |
+| **content** | (MFT resident `$DATA`) | create/write | **N** | No `$MFT` → no resident small-file content; no carving. Honest null (blocked by §3.1). |
+| **creation_time** | filestat/usn/shellitem/lnk `Timestamp` on create rows | create | **Y** | Present. Unchanged from prior pass. |
+| **extension** | all file maps, `ext(path)` | all | **Y** | Universal (incl. pe_coff/olecf/openxml NEW). |
+| **file_name** | all file maps, `basename(path)` | all | **Y** | Universal. |
+| **file_path** | filestat `filename`; usn bare-leaf `filename`; **pe_coff `display_name`**; **olecf `display_name`**; lnk/shellitem/recyclebin (prior); **UNMINED: `olecf:dest_list:entry.path`, mrulistex/mrulist `entries`** | all | **PARTIAL** | pe_coff/olecf paths now mapped (NEW). USN still bare-leaf (needs MFT join). Jump-list DestList `path` (72) and the save/open MRU `entries` file strings are NOT surfaced as file rows (§3.4/§3.5). |
+| **fqdn** | `olecf:dest_list:entry.hostname` (33/72, e.g. `desktop-pm6c56d`) | read | **UNMINED (weak)** | DestList records the host the file lived on — it is the imaged host here, so it maps to `hostname`, not a remote fqdn. Honest: no true fqdn source on disk. |
+| **gid** | filestat `group_identifier` | c/d/m/r | **Y·null** | 0 of 1.97M fs:stat rows carry it (NTFS, no POSIX block). |
+| **group** | — | — | **N** | No name resolution; no gid here anyway. |
+| **hostname** | all maps `image_hostname` = `DESKTOP-PM6C56D` | all | **Y** | Universal. |
+| **image_path** | — | — | **N** | Files at rest have no acting process image. |
+| **link_target** | lnk `link_target` (prior) | c/m/r | **Y** (see prior §1b) | Lost on 328 "Not a time" LNK rows (prior finding, still open). |
+| **md5_hash** | filestat `md5_hash` | create | **Y·null** | Mapped; **0** of 1.97M filestat rows carry md5 (only sha256 hasher ran). |
+| **sha1_hash** | filestat `sha1_hash`; **amcache `file_identifier` (the program SHA-1)** | create | **PARTIAL / UNMINED** | filestat sha1 = 0 rows. **amcache: the SHA-1 IS present (604 rows, `file_identifier` = `0000`+40hex) but the map reads a non-existent `sha1` key → file.sha1_hash resolves NULL.** Grounded bug, §3.3. |
+| **sha256_hash** | filestat `sha256_hash` (1,641,661); **pe_coff `sha256_hash` (150,708)**; **olecf/openxml `sha256_hash`** | create | **Y·NEW (big)** | filestat 83% coverage. **pe_coff added 150k file hashes + 104k imphashes (native).** olecf/doc-summary/openxml each carry the document's own sha256. Strong. |
+| **mime_type** | — | — | **N** | No host MIME computation. |
+| **mode** | filestat `mode` | c/d/m/r | **Y·null** | 0 of 1.97M (NTFS, no POSIX mode). No `$Secure` ACL decode either. |
+| **owner** | `olecf:summary_info.author` → owner (mapped); `openxml` creator (UNMINED); (MFT/$Secure owner SID) | create | **PARTIAL** | OLE `author`→`owner` is mapped (NEW). openxml `creator`/`lastModifiedBy` NOT mapped (§3.2). True NTFS owner (SID via `$Secure:$SDS` / MFT SD) has **no source** (§3.1). |
+| **owner_uid** | filestat `owner_identifier`; (MFT/$Secure owner SID) | c/d/m/r | **Y·null / N** | filestat: 0 of 1.97M. NTFS owner SID would come from `$Secure:$SDS` / MFT security descriptor — **absent** (§3.1). |
+| **pid / ppid** | — | — | **N** | No acting process on a file-at-rest artefact. |
+| **previous_creation_time** | (MFT `$SI` vs `$FN`) | create/timestomp | **N** | No `$MFT` → no `$SI`/`$FN` pair to diff. Blocked by §3.1. |
+| **signature_valid** | (Authenticode / catalog `.cat` / amcache) | create | **N** | pe_coff carries **0** signer/signature keys (plaso `pe` does not verify Authenticode); catroot `.cat` not parsed; amcache here has no signer field. Only the **Sysmon EVTX** map fills this (event-log, not disk). §3.6. |
+| **signer** | (Authenticode / catalog / amcache publisher) | create | **N** | Same as signature_valid — no on-disk producer. §3.6. |
+| **uid** | Recycle Bin `$Recycle.Bin\S-1-5-21-…-<RID>` SID in path (prior, still UNMINED) | delete | **UNMINED** | Prior finding: the SID is verbatim in the artefact path, unextracted. |
+| **user** | all maps `username` = `"-"`; identity in the artefact PATH (prior) | all | **UNMINED** | Prior #1 gap: `username` null 100%, `\Users\<name>\` in the path not mined. Unchanged. |
+
+---
+
+## 2. What is NEWLY mined since the prior pass (credit where due)
+
+Three maps that did not exist / were not exercised in the first pass now pull
+disk-file evidence — worth recording so the backlog does not re-flag them:
+
+- **`plaso_pecoff` (plaso_fs_extra.py)** — **150,708** `pe_coff:file` rows → a
+  timestamp-less `file/create` each, carrying `file_path` + the binary's own
+  **`sha256_hash`**, with **`imphash`** (104,460), `pe_type`, `export_dll_name`
+  (93,624) and `section_names` native. This is now the largest single source of
+  executable hashes on the image. (Correctly time-free: every PE stamp is a
+  compile/link time, not a host event — here all 150k are `timestamp_desc="Not a
+  time"` so only the placeholder variant fires.)
+- **`plaso_olecf` (plaso_fs_extra.py)** — **276** `olecf:summary_info` rows → file
+  with `author`→**`owner`**, the document's `sha256_hash`, and title/application/
+  last_saved_by native. Legacy Office (.doc/.xls) authoring metadata.
+- **`l2t_srum` map exists** but SRUM is still **0 rows** (parser not wired) — so
+  it fires on nothing (matches the prior backlog #7; unchanged).
+
+---
+
+## 3. Ranked UNMINED opportunities (value × groundedness, filesystem-only)
+
+### 3.1 `$MFT` metafiles — the master blocker (COLLECTION-lane fix) — HIGHEST
+The `mft` parser did not run (`fs:ntfs:mft` = 0). Extracting `$MFT` unlocks, in
+one stroke, five things nothing else on a Windows image can give:
+- **`previous_creation_time` + action `timestomp`** — the `$SI` creation vs `$FN`
+  creation diff (the classic `$SI < $FN` timestomp tell). No other artefact has a
+  second birth stamp to compare.
+- **`content`** — MFT-**resident `$DATA`** for small files (< ~700 B): the file's
+  bytes live inside the MFT entry. The only non-carving path to `file.content`.
+- **`owner_uid` / `owner`** — the entry's security-id → `$Secure:$SDS` owner SID
+  (see §3.7). NTFS's real owner, which POSIX `mode`/`owner_id` can never supply.
+- **`$I30` deleted filenames** — index slack in directory entries recovers names
+  of deleted files (extra `file`/`delete` rows).
+- **USN full paths** — `parent_file_reference` → MFT join reconstructs the
+  directory for all 359,999 bare-leaf USN rows (prior finding).
+
+The `l2t_mft` map (plaso_linux.py:354) is already well-formed (it even documents
+the `path_hints[0]`/`$SI`-vs-`$FN` intent). **The fix is to make the plaso lane
+run the `mft` parser and collect `$MFT`** — flag to epic #134. Until then every
+row above is an honest null *for want of input*, not a map defect.
+
+### 3.2 `olecf:document_summary_info` + `openxml:metadata` → file (map gap) — HIGH
+Two document-metadata data_types are **present and completely unmapped**:
+- `olecf:document_summary_info` (49) — carries **`company`** (e.g. `"Microsoft"`),
+  `application_version`, `shared_document`, and the doc's own `sha256_hash`. This
+  is the **only on-disk `file.company` source** and it is dropped. It is the exact
+  sibling of the already-mapped `olecf:summary_info`; the same `_ole_map` shape
+  extended with `company` closes it.
+- `openxml:metadata` (223) — modern OOXML (.docx/.xlsx/.pptx/templates). The
+  `czip/oxml` parser exposes core/app properties (creator, last_modified_by,
+  company, application, revision). On LoneWolf these rows are Office *template*
+  files so creator/company are sparse, but every row still yields `file_path` +
+  the document's `sha256_hash`, and the map belongs for real authored docs.
+  Map: → `file`, `owner`=creator, `company`=company, `sha256_hash`, timestamp-less
+  (all rows here are "Not a time"), authoring fields native. **Clean, low-risk.**
+
+### 3.3 amcache → file: recover the SHA-1 (+ company) — HIGH, grounded bug
+All **604** `windows:registry:amcache` rows are `timestamp_desc="Link Time"`, so
+they route **entirely** to the timestamp-less `file` record in
+`plaso_exec.py:244` (`plaso_is_amcache_link_time`) — the execution/process
+variant fires 0×. But that file record has two grounded defects:
+- `props.sha1_hash = _R("sha1")` — **there is no `sha1` key.** The program SHA-1
+  is in **`file_identifier`** (all 604 rows: length 44 = a `"0000"` pad + 40 hex,
+  e.g. `00009842cd168f6b…`). So `file.sha1_hash` resolves **NULL** today while the
+  hash is sitting right there. Fix: `regex1(file_identifier, r"0000([0-9a-f]{40})")`.
+- `company_name` (564), `product_name` (572), `file_version` (552) are **not
+  carried** — `company_name` → `file.company`, product/version native.
+
+amcache is the richest on-disk hash+identity source for executables *that also
+names the company*; both fixes are one line each. (This is the "file half" of the
+prior backlog's "amcache double-bug" #3 — recorded here for the `file` object.)
+
+### 3.4 `olecf:dest_list:entry` (jump-list DestList) → file/read — MEDIUM-HIGH
+**72** rows, **unmapped**. Each DestList entry is a file the user opened via a
+jump list, carrying a clean **`path`** (target file), the origin **`hostname`**
+(`desktop-pm6c56d` — where the file lived), `entry_number`, `pin_status`, and the
+DLT **`droid`/`birth_droid`** volume+file GUIDs (object-ID origin). Today only the
+jump-list *shell-item* halves reach `file` (via `plaso_shellitem`); the DestList
+entries — which hold the richest metadata (origin host, pin/access, droids) — are
+dropped. Map: → `file`/`read`, `file_path`=`path`, droids/hostname/pin native.
+Recorded-not-trusted (a DestList entry can be stale). Grounds real case activity
+(the `f01b4d95…automaticDestinations-ms` under `\Users\jcloudy\…\Recent`).
+
+### 3.5 save/open MRU `entries` → file/read (accessed files + the app) — MEDIUM
+`RecentDocs` (93), `OpenSavePidlMRU` (88), `LastVisitedPidlMRU` (20) arrive as
+`windows:registry:mrulistex`/`mrulist` and today become **registry `key_edit`**
+rows only — the accessed FILE named in the value is preserved only as a native
+`entries` string, never a CAR `file`/read. These strings name the case-defining
+files verbatim:
+- RecentDocs `.txt`: `"Path: key.txt, Shell item: [key.lnk]"` (the ransom-note file)
+- OpenSavePidlMRU `\html`: `"Shell item path: <My Computer> {b4bfcc3a-…}\Cubs'
+  Anthony Rizzo …'It's too Easy to Get a Gun'.html"` (downloaded/saved articles)
+- LastVisitedPidlMRU: `"Path: s3browser-win32.exe, Shell item path: …"` and
+  `"Path: chrome.exe, …\Users\jcloudy\Desktop"` — the **application** used *and*
+  the folder it last visited.
+Opportunity: parse `Path:\s*([^,]+)` / `Shell item path:\s*(?:<[^>]+>\s*)?(.+)`
+out of `entries` and emit a `file`/read (LastVisited's `Path:` also gives the
+opening app). **Caveat:** this parses plaso's rendered `entries` text (brittle,
+recorded-not-trusted); some shell-item halves already surface via
+`plaso_shellitem`, so scope to the string-only cases (RecentDocs value,
+LastVisited `Path: <app>`). Medium confidence.
+
+### 3.6 `signer` / `signature_valid` — NO on-disk source (TOOL gap) — noted
+pe_coff:file carries **0** signer/signature keys (plaso `pe` extracts
+imphash/sha256/sections but does **not** verify Authenticode). The security
+catalog (`catroot\*.cat`) is not parsed; amcache here has no signer field. The
+only producer of `file.signer`/`file.signature_valid` in the whole repo is the
+**Sysmon EVTX** map (`sysmon.py:246`, EID 6/7 — event-log, out of scope for disk
+artefacts). To fill these from a dead disk you would need an Authenticode/catalog
+extractor that does not exist. Honest no-source; flag to the collection lane as a
+tool gap, not a map gap.
+
+### 3.7 `$Secure:$SDS` owner SID + ACL → owner/owner_uid/acl_modify — BLOCKED
+The canonical NTFS owner/ACL source. `$Secure`/`$SDS` are present only as filestat
+metafile *paths* (no content decode); `security_descriptor` key = 0 everywhere.
+Ties to §3.1 — needs `$MFT` security-ids + `$Secure:$SDS` parsing. `acl_modify`
+has no producer at all on this image.
+
+### 3.8 thumbcache / IconCache — NO parser (TOOL gap) — noted
+`thumbcache_*.db` (782 path hits) and `IconCache.db` (1,266) hold thumbnails/paths
+of **deleted** files — a classic recovery source. Plaso has no parser for them,
+so their contents are unmined; only the container files appear via filestat.
+Tool/collection gap (e.g. thumbcache_viewer-class extraction).
+
+### 3.9 `windows:distributed_link_tracking:creation` → native only — LOW
+**254** rows, unmapped. Carries `uuid` (ObjectID / DLT file-droid GUID), a
+node **`mac_address`** (the origin machine's NIC), `origin` (the .lnk) and a
+Creation Time. No clean CAR **file** field fits a tracking GUID or a MAC —
+best surfaced as native provenance / a correlation key on the related LNK, not a
+`file`-field win. Recorded for completeness.
+
+---
+
+## 4. Honest no-sources on filesystem artefacts (correctly NULL here)
+
+- **`content`, `previous_creation_time`, action `timestomp`, `$I30` names, true
+  NTFS `owner`/`owner_uid`** — all blocked by the absent `$MFT`/`$Secure` (§3.1,
+  §3.7). Honest null *for want of input* (maps are fine / ready).
+- **`signer`, `signature_valid`, `acl_modify`** — no on-disk extractor exists
+  (§3.6, §3.7). Tool gap.
+- **`mime_type`, `pid`, `ppid`, `image_path`, `group`, `fqdn`** — no disk artefact
+  carries them.
+- **`mode`, `owner_uid`, `gid` (POSIX)** — 0 of 1.97M NTFS `fs:stat` rows (POSIX
+  block absent on NTFS; the maps are correct, the data isn't in this image).
+- **`md5_hash`, `sha1_hash` (filestat)** — 0 rows (only the sha256 hasher ran).
+- **ADS / Zone.Identifier (mark-of-the-web, HostUrl)** — 0 rows; no ADS emitted
+  and no zone parser (§0, §3.6-adjacent). Collection/parser gap.
+
+---
+
+## 5. Ranked one-line-ish backlog (this pass, `file`-object only)
+
+1. **Collect `$MFT`** (make the plaso lane run the `mft` parser) → unlocks
+   `previous_creation_time`, `timestomp`, resident `content`, `$I30` deleted
+   names, USN full-path join, and the security-id for owner. **Epic #134.** (§3.1)
+2. **amcache file record**: read the SHA-1 from `file_identifier` (strip the
+   `0000` pad) into `sha1_hash`, and map `company_name`→`company`. 604 rows,
+   grounded. (§3.3)
+3. **Map `olecf:document_summary_info`** (→ `company` + sha256) and
+   **`openxml:metadata`** (→ owner/creator + company + sha256) — both present,
+   both unmapped; extend the existing `_ole_map` shape. (§3.2)
+4. **Map `olecf:dest_list:entry`** → file/read with `path` + native droids/host. (§3.4)
+5. **Surface save/open MRU accessed files**: parse `entries` on RecentDocs /
+   OpenSavePidlMRU / LastVisitedPidlMRU → file/read (+ the opening app from
+   LastVisited `Path:`). Brittle string parse, recorded. (§3.5)
+6. **Tool gaps to flag (not map fixes):** Authenticode/catalog signer verify
+   (§3.6), `$Secure:$SDS` ACL decode (§3.7), thumbcache/IconCache extraction
+   (§3.8), SRUM parser wiring (still 0 rows), ADS/Zone.Identifier collection (§0).
+
+---
+
+### Appendix — verbatim record excerpts used (grounded)
+
+- **pe_coff:file (mined):** `display_name "VSS2:NTFS:\Windows\SysWOW64\en-US\
+  msieftp.dll.mui"`, `sha256_hash "cf027a6c…"`, `pe_type "Dynamic Link Library
+  (DLL)"`, `timestamp_desc "Not a time"`. (150,708 rows; imphash on 104,460.)
+- **olecf:document_summary_info (UNMAPPED):** `display_name "NTFS:\…\
+  MsoIrmProtector.xls"`, **`company "Microsoft"`**, `application_version
+  "11.5870"`, `sha256_hash "fe2adbf0…"`.
+- **openxml:metadata (UNMAPPED):** `display_name "NTFS:\Program Files (x86)\
+  Microsoft Office\root\Templates\1033\Access\DataType\Phone.accft"`,
+  `sha256_hash "8e1f7668…"`, `parser "czip/oxml"`.
+- **amcache (SHA-1 in the wrong key):** `full_path "c:\program files\google\drive\
+  googledrivesync.exe"`, **`file_identifier "00009842cd168f6b4d8be8979f3a40fb4de6f9afcbee"`**
+  (0000 + 40hex), `company_name ""`/`product_name ""` (empty on this entry),
+  `timestamp_desc "Link Time"`, `sha256_hash` = the Amcache.hve's own hash.
+- **olecf:dest_list:entry (UNMAPPED):** `display_name "…\Users\jcloudy\…\Recent\
+  AutomaticDestinations\f01b4d95cf55d32a.automaticDestinations-ms"`, has `path`,
+  `hostname "desktop-pm6c56d"`, `droid_file_identifier "{3869c1ca-…}"`,
+  `entry_number 3`, `pin_status`.
+- **RecentDocs MRU (file NOT surfaced):** key `…\Explorer\RecentDocs\.txt`,
+  `entries ["Index: 1 [MRU Value 0]: Path: key.txt, Shell item: [key.lnk]"]`.
+- **LastVisitedPidlMRU (app + folder, NOT surfaced):** `entries ["… Path:
+  chrome.exe, Shell item path: <My Computer> C:\\Users\\jcloudy\\Desktop", "…
+  Path: s3browser-win32.exe, …"]`.
+- **fs:stat (NTFS):** `filename "\Users\jcloudy\…\waterGlass.svg"`, `sha256_hash
+  "bd2f81d3…"`, `file_size 5263`, `is_allocated true` — NO `mode`/
+  `owner_identifier`/`group_identifier`/`md5`/`sha1`.
+- **usn:** `filename "oleaut32.dll"` (bare leaf), `display_name
+  "VSS1:NTFS:\$Extend\$UsnJrnl:$J"`, `update_reason_flags 2147483648`.

--- a/docs/car-provenance/lonewolf-fs-recheck/flow.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/flow.md
@@ -1,0 +1,114 @@
+# CAR `flow` — FILESYSTEM / DISK Provenance Audit (dead-box, no pcap)
+
+**Object:** `flow` — *"A sequence of packets from a source computer to a destination… may be captured at network or host level."*
+**Actions:** `start`, `message`, `end`.
+**Fields audited (26 + image_path):** application_protocol, content, dest_fqdn, dest_hostname, dest_ip, dest_port, end_time, exe, fqdn, hostname, (image_path), in_bytes, network_direction, out_bytes, packet_count, pid, ppid, proto_info, src_fqdn, src_hostname, src_ip, src_port, start_time, tcp_flags, transport_protocol, uid, user.
+
+**Scope of THIS pass:** filesystem/disk artefacts only. The prior pass (`docs/car-provenance/flow.md` / LS24) covered the network + host-telemetry vantages — Zeek conn (S1), Sysmon EID 3 (S2), memory netscan (S3), SMB30803 (S4), and SRUM-as-mapped (S5). This pass asks: **on a dead disk (no live capture), what filesystem artefacts could fill flow — and which has the pipeline not mined?**
+
+**Grounded in real data:** the full LoneWolf Win10 plaso timeline
+`data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (4,169,774 events, 6.6 GB) — every data_type / parser tallied (`_datatypes.txt`), flow-relevant artefacts sampled directly.
+
+---
+
+## The central fact for `flow` on a dead disk
+
+> **A dead-box filesystem has essentially no honest source for the flow 5-tuple.** `src_ip`/`dest_ip`/`src_port`/`dest_port`/`transport_protocol`/`application_protocol`/`tcp_flags`/`packet_count`/`content`/`proto_info` all require a *live* vantage (pcap, Zeek, Sysmon3, WFP audit, memory netscan). None is recoverable from files at rest. The **only** disk artefact that maps to CAR flow at all is **SRUM `network_usage`** — an hourly per-app **byte aggregate with no endpoints** — and it currently yields **0 rows everywhere in the processed store.** The one disk artefact that *would* carry a real 5-tuple + allow/block (the **Windows Firewall log, `pfirewall.log`**) is **not parsed and not present**. So filesystem flow coverage is: one mapped-but-empty aggregate source, one honest-but-absent 5-tuple source, and a set of download/network-profile artefacts that are near-misses for flow (they belong to `http`/`registry`).
+
+---
+
+## Filesystem source universe (what the LoneWolf disk actually produced)
+
+| # | Disk artefact | data_type (parser) | rows in LoneWolf | Maps to flow today? | Flow value |
+|---|---|---|---|---|---|
+| **FS1** | **SRUM `SruDb`** (SRUDB.dat, ESE) | `windows:srum:network_usage` (`esedb/srum`) | **0** (see gap #1) | **MAPPED** → flow/message (`plaso_srum.py:73`) | in_bytes/out_bytes + exe/image_path/uid — **no endpoints**. Empty. |
+| **FS2** | **NetworkList profiles** (SOFTWARE hive) | `windows:registry:network` (`winreg/networks`) | **6** | mis-routed → **registry/key_edit** (`plaso_registry.py`) | SSID, gateway MAC, DNS suffix, first/last-connected. **Fills NO flow field** (near-miss). |
+| **FS3** | **Chrome downloads** (History sqlite) | `chrome:history:file_downloaded` (`sqlite/chrome_27_history`) | **42** | **UNMAPPED** (no chrome handler in `plaso_web.py`) | download **source URL** + received/total bytes + start/end — an **http/get**; byte/time flow-adjacent. |
+| **FS4** | Chrome cache/cookies/visits | `chrome:cache:entry` 21,636; `chrome:cookie:entry` 8,863; `chrome:history:page_visited` 2,293 | 32k+ | **UNMAPPED** | domains contacted → **http**, not flow. |
+| **FS5** | IE/Edge WebCache (WebCacheV01.dat, ESE) | `msie:webcache:container` 921 (`esedb/msie_webcache`) | 921 | **UNMAPPED** | URL/history/download containers → **http**, not flow. |
+| **FS6** | Distributed Link Tracking (in .lnk) | `windows:distributed_link_tracking:creation` (`lnk`) | 254 | → registry-adjacent (native only) | embeds **origin machine MAC** + volume GUID. CAR flow has **no MAC field**. |
+| **FS7** | **Firewall log** `%windir%\System32\LogFiles\Firewall\pfirewall.log` | — (no plaso parser) | **0** (only registry path refs) | **NO** | Would give a real **5-tuple + allow/block** → flow. Absent + unparseable. |
+| **FS8** | **BITS** `qmgr.db` (on disk) | — (plaso has no qmgr.db parser) | 0 | **NO** (disk); BITS only via **EVTX 59/60** → http | url + bytes, but as an event-log http record, not disk-flow. |
+| **FS9** | DNS client cache | — (memory-resident, not persisted) | 0 | **NO** | honest null on a dead disk. |
+| **FS10** | hosts file | — (filestat sees the file; content not parsed) | 0 | **NO** | static name→IP mapping; not a flow anyway. |
+| **FS11** | **Zone.Identifier ADS `HostUrl`** | — (plaso does not parse ADS content) | **0** | **NO** | download source URL — recoverable instead from FS3 (chrome downloads). |
+| **FS12** | RDP client MRU (`Terminal Server Client\Servers`, NTUSER) | `windows:registry:key_value` (buried) | (in 1.5M key_value) | → registry/key_edit | outbound RDP **dest host** — a weak dest_hostname/dest_fqdn, not surfaced. |
+
+**Empirical confirmations (streamed over all 4.17M events):**
+- `windows:srum:*` data_type count = **0**. SRUDB.dat **exists on disk** (filestat: `\Windows\System32\sru\SRUDB.dat` + `SRUDB.jfm`, in VSS2) but produced **no parsed SRUM rows**. `data_store/processed/zimmerman/` (the dedicated SRUM two-step target) is **empty (.gitkeep only)**. SRUM is 0 end-to-end.
+- `Zone.Identifier` substring = **0 lines**. `pfirewall` = 18 lines, **all `windows:registry:key_value` from the SYSTEM hive** (the FirewallPolicy log-path value) — **no parsed firewall-log content**.
+- `windows:registry:network` sampled: `ssid="Net 2.4"`, `default_gateway_mac_address="5c:8f:e0:2a:1c:68"`, `dns_suffix="<none>"`, `connection_type=71`, rows at `"Creation Time"` (first-connected) and `"Last Connection Time"`.
+- `chrome:history:file_downloaded` sampled: `url="https://s3browser.com/download/s3browser-7-6-9.exe"`, `full_path="C:\Users\jcloudy\Downloads\s3browser-7-6-9.exe"`, `received_bytes=2483848`, `total_bytes=2483848`, `"Start Time"`/`"End Time"` rows.
+
+---
+
+## Per-field provenance table (filesystem vantage)
+
+Legend — **mined?**: **mapped-0** = an active map exists but has no input rows; **NO(fs)** = no filesystem source fills it; **near-miss** = a present artefact carries related data but not this canonical field; **unmapped** = a present artefact could feed it but no map consumes it.
+
+| field | fs artefact → native field | action | mined? | confidence & caveats |
+|---|---|---|---|---|
+| **out_bytes** | FS1 SRUM `bytes_sent`; (FS3 chrome download `received_bytes` is *in*-direction) | message | **mapped-0** (SRUM) | High design, **zero data**. SRUM is the *only* disk source and it is empty everywhere. Hourly per-app aggregate — never a per-connection count. |
+| **in_bytes** | FS1 SRUM `bytes_received`; FS3 chrome `received_bytes` (download) | message | **mapped-0** (SRUM); **unmapped** (FS3) | Same as out_bytes. FS3 download bytes are real but belong to `http` (a GET body), not flow — mapping them to flow.in_bytes would be a category slip. |
+| **exe** | FS1 SRUM `application` (basename); FS3/FS4 give the browser, not the flow owner | start/message | **mapped-0** (SRUM) | The one disk field that ties bytes to a process — but SRUM is empty. `application` may be a `\Device\…` path or a bare service name. |
+| **image_path** | FS1 SRUM `application` (if `\Device\…`) | start/message | **mapped-0** | Empty. No other disk artefact records the socket-owning image path. |
+| **uid** (SID) | FS1 SRUM `user_identifier` (gated to real `S-1-` form) | start/message | **mapped-0** | Empty. An SRUM internal index is refused (not an identity). No other disk source. |
+| **start_time** | FS1 SRUM `Timestamp` (hourly bucket); FS2 NetworkList `Creation Time` (first-connected); FS3 chrome download `Start Time` | start | **mapped-0** (SRUM); **near-miss/unmapped** (FS2/FS3) | SRUM = aggregate recorded-time, not a connect instant. NetworkList first-connected is a *network-join* time, not a flow. FS3 is a download start (http). |
+| **end_time** | FS3 chrome download `End Time`; FS2 NetworkList `Last Connection Time` | end | **unmapped/near-miss** | No mapped disk source. Both are download/network-join times, not flow ends. |
+| **dest_fqdn** | FS12 RDP MRU dest host; FS2 NetworkList `dns_suffix` (local suffix, not a dest) | start | **near-miss** | No disk artefact resolves the *dest* of a captured flow. RDP MRU names an outbound RDP target but is buried in `key_value`. |
+| **dest_hostname** | FS12 RDP client MRU server name | start | **near-miss (buried)** | Weak; would need a dedicated RDP-MRU map. Not a flow record per se. |
+| **dest_ip / dest_port / src_ip / src_port** | FS7 firewall log 5-tuple **(absent)**; FS1 SRUM has **none** | start/message | **NO(fs)** | **The core gap.** No file at rest carries the flow 5-tuple. SRUM records the interface only. Firewall log would — it is not parsed and not present. |
+| **transport_protocol** | FS7 firewall log proto **(absent)** | start/message | **NO(fs)** | Same — only the (absent) firewall log would give L4 from disk. |
+| **network_direction** | FS7 firewall log direction **(absent)** | start | **NO(fs)** | Firewall log records allow/block + inbound/outbound; nothing else on disk does. |
+| **application_protocol** | — | — | **NO(fs)** | L7 label is a live-capture (Zeek `service`) property. No disk source. |
+| **tcp_flags** | — | — | **NO(fs)** | Live-packet-only. Honest null on a dead disk. |
+| **packet_count** | — | — | **NO(fs)** | Live-packet-only. |
+| **content** | — | — | **NO(fs)** | Full-packet payload only. Never on disk. |
+| **proto_info** | — | — | **NO(fs)** | L7 decode (SMB/HTTP) — pcap/DPI only. The biggest flow-analytics gap, and no disk path to it. |
+| **pid / ppid** | — (SRUM has no pid) | — | **NO(fs)** | Live host telemetry only (Sysmon3 / memory). SRUM is per-app, not per-process. |
+| **user** | — (SRUM gives a SID→uid, not a `user` name) | — | **NO(fs)** | No disk source resolves the flow's process user name. |
+| **fqdn / hostname** (observing host) | FS1–FS3 `image_hostname` = `DESKTOP-PM6C56D` | start | **available** | The imaged host is the vantage; every disk row carries `image_hostname`. Fills the *observer* host, not a flow endpoint. |
+| **src_fqdn / src_hostname** | — | — | **NO(fs)** | No reverse-resolver; the disk names the host but not as a flow endpoint. |
+
+**Net:** of 26 flow fields, exactly **five** have a filesystem source and it is a **single artefact (SRUM) that is currently empty** (out_bytes, in_bytes, exe, image_path, uid; + image-host fqdn/hostname). Every endpoint/5-tuple/L7/packet field is an honest `NO(fs)` on a dead box.
+
+---
+
+## Ranked UNMINED opportunities (build order)
+
+1. **Parse SRUDB.dat so `l2t_srum` actually gets rows — #1 flow gap, and it is a *pipeline* gap not a data gap.**
+   SRUDB.dat is **present on the LoneWolf disk** (filestat, in VSS2) and the map (`plaso_srum.py`, flow/message: in_bytes/out_bytes/exe/image_path/uid) is **schema-complete** — but **0 rows reach it**. Root cause: the plaso lane runs `log2timeline.py` with **no `--parsers`** (default preset — which *does* include `esedb/srum`), yet the live SRUDB.dat yields nothing, consistent with a **dirty/needs-recovery ESE database** that `libesedb` skips (SRUDB.dat is normally an unclean-shutdown ESE db; it parses only after the `.jfm` log is replayed / `esentutl /r` recovery). The dedicated **Zimmerman SRUM two-step** (`dxdfir_zimmerman`, `log2timeline.py esedb/srum → psort`) exists to handle exactly this but its output dir is **empty**. Fix = recover SRUDB.dat before parsing (or point the SRUM two-step at a recovered copy) and route its JSONL through `l2t_srum`. Highest value: turns the only mapped disk-flow source from theoretical to real (per-app in/out bytes + user attribution). *(The docstring's "17,928 rows" figure came from a recovered copy, not this lane.)*
+
+2. **Parse `pfirewall.log` → flow (start/message + allow/block).**
+   The **only** filesystem artefact that carries a genuine flow **5-tuple** (`src_ip/dest_ip/src_port/dest_port/transport_protocol/network_direction`) plus action. Not present in the LoneWolf collection and **plaso has no firewall-log parser** — needs (a) the file collected and (b) a text/log map (a `text/` parser variant or a dxdfir map). This is the single biggest *potential* dead-box flow win, because it is the lone disk source for the fields SRUM cannot give (endpoints + direction). Blocked on collection + a parser.
+
+3. **Chrome browser artefacts → `http` (and download bytes/times) — a present, entirely unmapped family.**
+   `plaso_web.py` handles msiecf / firefox / java **but not Chrome**, and the LoneWolf disk is Chrome-heavy: `chrome:history:file_downloaded` (42 — download **source URL** + received/total bytes + start/end), `chrome:history:page_visited` (2,293), `chrome:cache:entry` (21,636), `chrome:cookie:entry` (8,863). These are **http** records (URL/domain requested), with the downloads carrying flow-adjacent byte/time data. Adding a `chrome_*` handler to `plaso_web` is a clean, high-volume win — primarily for the `http` object, secondarily surfacing download provenance. (This also *realises* the task's "Zone.Identifier HostUrl" goal: the download source URL is here, richer than the ADS.)
+
+4. **IE/Edge WebCache (`msie:webcache:*`, 921 rows) → `http`.** ESE WebCacheV01.dat containers (history/cache/cookies/downloads) — same http-object opportunity as #3, unmapped today.
+
+5. **NetworkList `windows:registry:network` — re-route + surface its fields (low flow value, honest about it).**
+   6 rows present, currently swallowed by `plaso_registry` into **registry/key_edit**, and its network-specific fields (`ssid`, `default_gateway_mac_address`, `dns_suffix`, `connection_type`, first/last-connected) are **not even captured in `native_extract`** — doubly under-mined. **But for CAR *flow* it fills no canonical field** (no IP/port/bytes/exe; a gateway MAC and SSID have no flow slot). Best handled as **enriched registry / a network-environment context**, not forced into flow. Recommend: extend `plaso_registry` native_extract to capture the NetworkList fields (cheap, correct) rather than minting a flow row.
+
+---
+
+## Honest no-sources (dead-box filesystem)
+
+- **content, packet_count, tcp_flags, proto_info** — full-packet / DPI properties. **No file at rest can produce them.** Honest nulls on a dead disk; only pcap / Suricata / Zeek per-protocol logs (a *live* vantage) fill them. `proto_info` remains the highest-impact flow-analytics gap and has **no disk path whatsoever**.
+- **application_protocol** — a capture-side L7 label (Zeek `service`); no disk artefact.
+- **src_ip / dest_ip / src_port / dest_port / transport_protocol / network_direction** — no filesystem 5-tuple source exists **except** the (absent, unparsed) firewall log. SRUM records the interface, not endpoints.
+- **pid / ppid / user** — live host telemetry (Sysmon3 / memory) only; SRUM is per-app-aggregate (SID→uid, no pid/ppid/user-name).
+- **src_fqdn / dest_fqdn / src_hostname / dest_hostname** — no reverse-DNS/resolver stage; the disk names the *observing* host (`image_hostname`) but not flow endpoints. (RDP client MRU is a weak, buried dest-host hint only.)
+- **Zone.Identifier ADS `HostUrl`** — plaso does not parse NTFS ADS content (0 lines); the download source URL is instead available via chrome:history:file_downloaded (#3).
+- **BITS `qmgr.db`** on disk — plaso has no qmgr.db parser; BITS reaches the pipeline only through **EVTX 59/60 → http** (an event-log, not a disk-flow, source).
+- **DNS client cache** — memory-resident, not persisted; nothing on the dead disk.
+- **hosts file** — filestat sees the file; content is not parsed, and a static name→IP map is not a flow event.
+
+## Key file references
+- Real data: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`; inventory `scratchpad/car-provenance-fs/_datatypes.txt`.
+- Mapped-but-empty SRUM: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_srum.py:73`; source decl `piiat_mitrecar/sources_model.py:120`; SRUM two-step lane `ansible/collections/get_sybers.dxdfir/roles/dxdfir_zimmerman/` (output `data_store/processed/zimmerman/` — empty).
+- Plaso lane (no `--parsers`, default preset): `python/get_sybers_dxdfir/plaso.py:312`; argv `roles/dxdfir_plaso/defaults/main.yml`.
+- NetworkList mis-route: `piiat_mitrecar/mappings/plaso_registry.py` (`plaso_is_registry`, all `windows:registry:*`).
+- Browser maps (no chrome handler): `piiat_mitrecar/mappings/plaso_web.py`.
+- BITS via EVTX only: `piiat_mitrecar/mappings/evtx_extra.py:48`.
+- Prior (live-vantage) flow catalogue: `docs/car-provenance/flow.md`.

--- a/docs/car-provenance/lonewolf-fs-recheck/http.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/http.md
@@ -1,0 +1,166 @@
+# CAR `http` — FILESYSTEM/DISK provenance audit (unmined web-history universe)
+
+**Scope.** Every canonical field of CAR `http`, versus the **on-disk browser + download
+artefacts** that could fill it — the filesystem web-history universe (Chrome/Edge History &
+Cache & Downloads SQLite, IE/legacy WebCacheV01.dat ESE, Java IDX, registry TypedURLs, ADS
+Zone.Identifier). READ-ONLY. This pass is the FS-artefact complement to the committed
+`docs/car-provenance/http.md` (which is Zeek/BITS/network-centric); it grounds the "browser
+depth beyond Firefox" gap (that doc's ranked item #4) in the **real LoneWolf Win10 image**.
+
+- **Real evidence:** `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+  (LoneWolf `LoneWolf.E01` via Plaso, 6.6 GB). Every count below is a full-file tally.
+- **Engine http maps:** `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_web.py`
+  (msiecf / firefox_cache / firefox_places / javaidx), `core.py` (zeek), `evtx_extra.py` (BITS).
+- **Routing:** `pipeline.py` `ROUTES` (L49-96) + `adapters/l2t_split.py` `table_name()`.
+
+## 0. The decisive finding: LoneWolf is a Chrome/Edge box, and 100% of its web history is UNMINED
+
+The four Plaso http maps that DO exist (`l2t_msiecf`, `l2t_firefox_cache`, `l2t_firefox_places`,
+`l2t_javaidx`) all hit **ZERO rows** on this image — there is no Firefox, no IE `index.dat`
+(`msiecf`), no Java IDX. Every web artefact present is Chrome/Edge or the ESE WebCache, and
+**none of them route to an http map.** Real tallies of the web/download universe:
+
+| data_type | rows | Plaso parser | split file `table_name()` | route → | mined for http? |
+|---|--:|---|---|---|---|
+| `chrome:cache:entry` | **21,636** (18,145 w/ `http` url) | `chrome_cache` | `.L2tChromeCache` | **no ROUTES match → `[]`** | **NO — raw** |
+| `chrome:cookie:entry` | 8,863 | `sqlite/chrome_17_cookies` | `.L2tSqlite` | `l2t_firefox_places` | NO (not http; not ff) |
+| `chrome:history:page_visited` | **2,293** | `sqlite/chrome_27_history` | `.L2tSqlite` | `l2t_firefox_places` | **NO — pred rejects** |
+| `msie:webcache:container` | **921** (183 w/ `response_headers`, 452 `Visited:` history) | `esedb/msie_webcache` | `.L2tEsedb` | `l2t_srum` | **NO — pred rejects** |
+| `chrome:autofill:entry` | 802 | `sqlite/chrome_autofill` | `.L2tSqlite` | `l2t_firefox_places` | NO (not http) |
+| `windows:registry:msie_zone_settings` | 90 | `winreg/msie_zone` | `.L2tWinreg` | registry maps | NO (config, no url) |
+| `msie:webcache:cookie` | 134 | `esedb/msie_webcache` | `.L2tEsedb` | `l2t_srum` | NO (cookie) |
+| `chrome:history:file_downloaded` | **42** | `sqlite/chrome_27_history` | `.L2tSqlite` | `l2t_firefox_places` | **NO — pred rejects** |
+| `windows:registry:typedurls` | 15 | `winreg/windows_typed_urls` | `.L2tWinreg` | `plaso_registry` | NO (→ registry object, not http) |
+
+**Why each is raw (confirmed in code, not inferred):**
+- `l2t_split.table_name()` keys off the **top-level** parser segment. `sqlite/chrome_27_history`,
+  `sqlite/chrome_17_cookies`, `sqlite/chrome_autofill` → **`.L2tSqlite`** → `ROUTES` sends that to
+  `["l2t_firefox_places"]`, whose only predicate is `plasoweb_is_ff_visit` =
+  `data_type == "firefox:places:page_visited"` (`plaso_web.py` L57-60). **Chrome rows fail it →
+  `default: None` → raw.**
+- `chrome_cache` (no `/`) → **`.L2tChromeCache`** → **no `ROUTES` pattern matches** → `route()`
+  returns `[]` → raw. No map anywhere references `chrome_cache`/`chrome:cache` (grep of `mappings/`
+  = 0 hits).
+- `esedb/msie_webcache` → **`.L2tEsedb`** → `ROUTES` sends that to `["l2t_srum"]`, whose predicates
+  gate `windows:srum:network_usage` / `application_usage` only (`plaso_srum.py` L41-46). **WebCache
+  rows fail it → raw.** No map references `webcache` (grep = 0 hits).
+- `winreg/*` → `.L2tWinreg` → `plaso_registry` maps `typedurls` as a **registry** object
+  (`plaso_registry.py` L4), never as http.
+
+## 1. Per-field provenance (FILESYSTEM artefacts)
+
+Legend: `[direct]` 1:1 copy · `[inferred]` regex out of a compound field · `[derived]` transform ·
+`[asserted]` constant the record proves. **Mined?** = does any wired map route+accept this row for http.
+
+### `url_full` — the full URL requested
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **chrome:history:page_visited** `url` [direct] | get | **NO** — `.L2tSqlite`→ff-only predicate rejects | High/direct. 2,293 rows. Same shape as the wired firefox_places map. |
+| **chrome:history:file_downloaded** `url` [direct] | get | **NO** — same predicate | High/direct. 42 rows; source download URL (e.g. `https://s3browser.com/download/s3browser-7-6-9.exe`). |
+| **chrome:cache:entry** `original_url` [direct] | get | **NO** — `.L2tChromeCache` unrouted | High/direct. 18,145 `http` urls of 21,636. A cache fetch = a GET. |
+| **msie:webcache:container** `url` (`https://…` or `Visited: user@<url>`) [coalesced] | get | **NO** — `.L2tEsedb`→SRUM-only | Med/High. 183 direct `https` + 452 `Visited:` history (strip `Visited:\s*[^@]*@` exactly as `_IE_URL` already does). |
+| **windows:registry:typedurls** `entries[i]` = `"urlN: <url>"` → strip `^url\d+:\s*` [inferred] | get | **NO** — routes to registry object | Med. 15 rows. User-typed address-bar URLs; strongest intent signal, weakest volume. |
+| ADS **Zone.Identifier** `HostUrl=` | get | **NO SOURCE** | Plaso has no Zone.Identifier ADS decoder; 0 rows here (the 9 `zone.identifier` string hits are SmartScreen prefetch path-hints, not ADS content). Real-universe via MFT `$DATA:Zone.Identifier` extraction. |
+
+### `url_domain` / `url_scheme` / `url_remainder` — parsed from the url
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| chrome history / downloads / cache, webcache | `regex1(url, …)` [inferred] | get | **NO** (as above) | Identical derivations to `plaso_web._http_props()` — `scheme=^(https?)://`, `domain=^https?://([^/?#:]+)`, `remainder=^https?://[^/]+(/[^\s]*)`. Would drop straight in. Chrome downloads/history/cache carry real `https` (LoneWolf), so scheme is genuinely `https` — unlike Zeek which is forced `http`. |
+
+### `hostname` — the vantage (host the request was seen ON)
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| ALL of the above | `image_hostname` = `DESKTOP-PM6C56D` [direct] | get | **NO** (rows raw) | High. Every row carries the lane-stamped imaged host. Endpoint artefact = the imaged host IS the vantage (same principle as the wired browser maps). |
+
+### `response_status_code`
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **msie:webcache:container** `response_headers` → `regex1(rh, "HTTP/\d\.\d\s+(\d{3})")` [inferred] | get | **NO** — SRUM-only route | **Med/High. The only on-disk status source on this image.** All 183 header-bearing rows parse cleanly (all `200` here, but the parse is deterministic & status varies on richer images). |
+| firefox_cache `response_code` | — | (wired, but 0 rows here) | The existing wired parse; no Firefox on LoneWolf. |
+| chrome:cache:entry | — | **NO SOURCE** | This Plaso `chrome_cache` version emits only `original_url`+`payloads` — no status/method/content-type fields. Honest null. |
+
+### `http_version`
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **msie:webcache:container** `response_headers` → `regex1(rh, "HTTP/(\d\.\d)")` [inferred] | get | **NO** — SRUM-only route | Med/High. All 183 → `1.1`. **Only FS source for http_version anywhere** (Zeek is the only other). |
+
+### `response_body_bytes`
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **chrome:history:file_downloaded** `received_bytes` / `total_bytes` [direct] | get | **NO** — ff-only predicate | Med/High. 42 rows (e.g. `2483848` bytes). Downloaded-object size; maps to response body like BITS `bytesTransferred`, with the same "transfer total, not strict HTTP body-len" caveat. |
+| **msie:webcache:container** `response_headers` → `regex1(rh, "content-length:\s*(\d+)")` [inferred] | get | **NO** — SRUM-only route | Med. 183 rows carry `content-length`. Wire response-body length. |
+| chrome:cache:entry | `payloads` are data-file **offsets**, not sizes | — | **NO** | Cache-object size not exposed as a numeric field here. |
+
+### `request_referrer`
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **chrome:history:page_visited** `from_visit` [coalesced] | get | **NO** — ff-only predicate | Med. Same `from_visit` referrer the wired firefox_places map already reads (`plaso_web.py` L142-144) — Chrome populates the identical column; blocked only by the data_type gate. Client-side recorded, not navigation proof. |
+| chrome:history:file_downloaded | `downloads_url_chains` is in the SQL `query` but **not emitted** as a field | — | **NO SOURCE** | This Plaso version surfaces only the final `url`; the referrer chain isn't in the record. Honest null. |
+
+### Fields with NO fs source anywhere (honest nulls)
+| field | why | 
+|---|---|
+| `request_body_bytes`, `request_body_content` | No disk web-history artefact records request bodies. |
+| `response_body_content` | Chrome `Cache_Data`/`data_N` blocks and WebCache `cached_filename` hold response bodies **on disk**, but neither Plaso plugin extracts the bytes — `chrome:cache:entry.payloads` are only offset pointers (`"data_3 (offset: 0x00002000)"`). Would need a cache-body extractor. |
+| `requester_ip_address` | Endpoint artefacts don't record the client's own source IP. (WebCache/IDX record the *server*.) |
+| `user_agent_full` / `_name` / `_version` / `_device` | No browser-history/cache artefact retains the request UA header. (UA-parse gap unchanged from the Zeek doc: `_full` exists only from Zeek, and name/version/device need a `[heuristic]` parser that exists nowhere.) |
+
+## 2. Coverage matrix — FS artefacts × field (all UNMINED)
+`U`=present-but-unmined · `·`=not recorded · `N*`=no fs source anywhere
+
+| field | chrome:history | chrome:downloads | chrome:cache | msie:webcache | reg:typedurls |
+|---|:--:|:--:|:--:|:--:|:--:|
+| hostname | U | U | U | U | U |
+| url_full | U | U | U | U | U |
+| url_domain/scheme/remainder | U | U | U | U | U |
+| request_referrer | U | · | · | · | · |
+| response_status_code | · | · | · | **U** | · |
+| http_version | · | · | · | **U** | · |
+| response_body_bytes | · | **U** | · | **U** | · |
+| request_body_* / response_body_content | N* | N* | N* | N* | N* |
+| requester_ip_address | N* | N* | N* | N* | N* |
+| user_agent_* | N* | N* | N* | N* | N* |
+
+## 3. Ranked UNMINED opportunities (all found in real LoneWolf data)
+
+1. **Chrome/Edge History → extend the `.L2tSqlite` route (2,293 visits + 42 downloads, highest volume).**
+   Cheapest, highest-value win. The `l2t_firefox_places` map already derives exactly these fields;
+   only its predicate (`data_type == firefox:places:page_visited`) blocks Chrome. Add a
+   `chrome:history:page_visited` variant (url + from_visit referrer + `visit_count`/`typed_count`/
+   `page_transition_type` native, `get`) and a `chrome:history:file_downloaded` variant
+   (url + `received_bytes`/`total_bytes`→response_body_bytes + `full_path`→file link, `get`).
+   Same for Edge (Chromium — identical `chrome:*` data_types). Downloads also cross-link to the
+   `file` object via `full_path`.
+
+2. **WebCacheV01.dat (ESE) → new `msie:webcache:container` map (uniquely gives status + version + bytes).**
+   The **only on-disk source of `response_status_code`, `http_version`, and content-length** on a
+   Windows box. Route: `.L2tEsedb` already reaches the plaso esedb lane but `l2t_srum` accepts only
+   SRUM — add a `webcache` map (or a second predicate) parsing `response_headers`
+   (`HTTP/(\d\.\d)\s+(\d{3})`, `content-length:\s*(\d+)`, content-type) + `url` (direct `https` **and**
+   `Visited: user@<url>` history, reusing the existing `_IE_URL` strip). 183 header rows + 452 history
+   rows here. Medium effort (new compound-field parse), unique field coverage.
+
+3. **Chrome/Edge Cache → new `chrome_cache` route + map (18,145 url observations, biggest raw dump).**
+   Add `(".L2tChromeCache", ["l2t_chrome_cache"])` to `ROUTES` and a map asserting url_full/domain/
+   scheme/remainder + hostname + `get` from `original_url`. No status/method in this Plaso version, so
+   url + vantage only — but it's 18k independent GET observations currently going 100% to raw.
+
+4. **Registry TypedURLs → optional http cross-emit (15 rows, strongest intent).**
+   Already captured as a `registry` object. If http coverage of user-typed navigation is wanted, a
+   `get` http observation per `entries[i]` (strip `^url\d+:\s*`) with hostname=image_hostname; only the
+   MRU (`url1`) carries the TypedURLsTime, the rest are timestamp-less. Low volume, low effort.
+
+5. **ADS Zone.Identifier `HostUrl`/`ReferrerUrl` → download provenance (NO SOURCE in current pipeline).**
+   The textbook mapping (`url_full`+`request_referrer` of a downloaded file). **Not reachable today:**
+   Plaso emits no Zone.Identifier ADS record, and the pipeline doesn't extract MFT `$DATA:Zone.Identifier`
+   stream content. Real-universe value is high (ties a file to its origin URL + referrer) but needs an
+   MFT-ADS extraction step that doesn't exist. Highest effort, honest gap.
+
+## 4. Honest no-sources (do NOT fabricate)
+- **request/response body content & request bytes** — no fs web-history artefact records them; cache
+  bodies exist on disk but neither Plaso plugin extracts the bytes.
+- **requester_ip_address** — endpoint artefacts record server IP, never the client's own.
+- **user_agent_* ** — browser history/cache/downloads keep no UA header; the name/version/device parse
+  gap (needs `[heuristic]` `ua_parser`/`woothee`) is unchanged and still unmapped anywhere.
+- **Network Action Predictor, Safari, Opera, WER URLs, Office/SharePoint MRU** — 0 rows on LoneWolf
+  (Network Action Predictor has no Plaso data_type at all); genuine no-source here.

--- a/docs/car-provenance/lonewolf-fs-recheck/module.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/module.md
@@ -1,0 +1,248 @@
+# FILESYSTEM/disk provenance pass — MITRE CAR `module`
+
+**Object:** `module` — executable/loadable content (DLLs, shared libs) mapped into a
+process address space. **Actions:** `load`, `unload`.
+**Fields (13):** `base_address, fqdn, hostname, image_path, md5_hash, module_name,
+module_path, pid, sha1_hash, sha256_hash, signature_valid, signer, tid`.
+
+**Scope of THIS pass:** disk/filesystem artefacts only. The prior pass
+(`docs/car-provenance/module.md`, LS24) covered the three *live* producers —
+Sysmon EID 7, WMI 5857, memory `windows.piiat.modules` — and already flagged
+prefetch `mapped_files` (backlog Tier-1 #7) and hash-hydration (Tier-2 #6) as
+gaps. This pass grounds those in **real disk evidence** and sweeps every other
+filesystem source exhaustively.
+
+**Grounding data (REAL):** LoneWolf Win10 plaso timeline
+`data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB, 4,169,774
+events). Counts below are measured from it.
+
+**Engine maps read:** `piiat_mitrecar/mappings/plaso_exec.py` (prefetch/amcache/
+shimcache → process), `plaso_fs_extra.py` (`pe_coff:file` → file), `sysmon.py`
+(EID 7, the only rich module producer), `evtx_more.py` (WMI 5857). Convergence:
+`piiat_mitrecar/crosssource.py`; STIX projection `stix.py`.
+
+**Headline:** the disk holds a *huge* module population that the pipeline parses
+but never turns into `module` rows. Only `sysmon.py` and `evtx_more.py` emit
+`object: module` (verified — no plaso/registry/PE map does). Concretely on
+LoneWolf: **150,708 `pe_coff:file` rows** (137,979 DLLs) carry
+path + SHA-256 + imphash, mapped to **`file`**, never `module`; **1,312 prefetch
+rows** carry a `mapped_files` DLL list kept **native on `process/create`**, never
+exploded into `module/load`. Both are the #1/#2 unmined levers. Amcache, shimcache
+and WER are **honest non-sources for `module`** in this real data (no DLL rows /
+no parser).
+
+---
+
+## 1. Filesystem source inventory (measured on LoneWolf) — what each could give `module`
+
+| fs artefact | plaso data_type | rows | today maps to | module content it holds | emits `module`? |
+|---|---|---:|---|---|---|
+| **PE files on disk** | `pe_coff:file` | **150,708** | `file/create` (`plaso_fs_extra.py:188` `_pe_map`, time-free entity) | `display_name`→path, `sha256_hash`, `imphash`, `pe_type` (DLL/EXE/SYS), `section_names`, `export_dll_name` | **NO** |
+| **Prefetch loaded-module list** | `windows:prefetch:execution` | **1,312** | `process/create`; `mapped_files` kept **native only** (`plaso_exec.py:231`) | `mapped_files[]` (every DLL/file the run touched), `path_hints[0]`+`executable` (the owning process) | **NO** |
+| **Amcache** | `windows:registry:amcache` | 604 | `process/create` (exe) / `file/create` (link-time) | `full_path`, `file_identifier`(SHA-1), `sha256_hash`, `company_name`, `product_name`, `file_version` | **NO** — and **no DLL rows** (see §3) |
+| **Shimcache / AppCompatCache** | `windows:registry:appcompatcache` | 1,463 | `process/create` (`plaso_exec.py:335`) | `path`, `sha256_hash` | **NO** — **no DLL rows** (exe/appx only) |
+| **WER crash reports** | *(none)* | 0 | — | would carry a loaded-modules list | **NO** — plaso emits no WER data_type |
+| **KnownDLLs (SYSTEM hive)** | `windows:registry:key_value` (raw) | — | raw only | list of always-mapped DLL names | **NO** — config list, no pid/load event |
+
+---
+
+## 2. Per-field provenance — FILESYSTEM sources (`fs artefact → native field`)
+
+Notation matches the house tables. "Mined?" = does a shipping map assert this
+canonical `module` field from the disk artefact today (**all NO** — no fs source
+produces a `module` row at all).
+
+### base_address
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — none — | load | **NO (honest no-source)** | **Runtime-only field.** A load VA exists only in a live/memory view. No disk artefact (PE, prefetch, amcache, shimcache) records where a module was mapped. Memory `windows.piiat.modules`→`Base` is the sole producer (prior pass). Permanent null from disk. |
+
+### fqdn / hostname
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| PE / prefetch / amcache / shimcache → `image_hostname` (lane-stamped) | load | NO (fs→module not wired) | **Would be High if wired.** Every plaso row already carries `image_hostname` (the imaged host), used verbatim by the process/file maps. A prefetch- or PE-derived `module/load` would inherit it directly. `fqdn` only when the stamped host is dotted (dot-guard, same as elsewhere) — usually a bare NetBIOS name → honest null. |
+
+### image_path  *(CAR = the OWNING PROCESS image, not the DLL)*
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **Prefetch → `path_hints[0]` / `executable`** | load | **NO** | **Medium-High.** Prefetch is the ONE disk source that pairs a module list with its owning process: each `mapped_files` entry belongs to the process named by `executable` (bare name, always present) / `path_hints[0]` (full path — but a plaso **list** the marker set can't index today; same limitation the process map hit, `plaso_exec.py:218`). So a prefetch `module/load` gets correct `image_path` when path_hints is non-empty, else the bare name in a native field + honest null. |
+| PE / amcache / shimcache | load | NO | **No-source.** A PE on disk has no owning process; amcache/shimcache index the executable itself, not a load-into-process relationship. |
+
+### module_name  *(DLL basename)*
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **Prefetch → `basename(mapped_files[i])`** | load | **NO** | **High.** e.g. `\VOLUME{…}\WINDOWS\SYSTEM32\NTDLL.DLL` → `NTDLL.DLL`. Free from the path. |
+| **PE → `basename(display_name)`** | load (presence) | **NO** | **High.** `NTFS:\Windows\System32\<x>.dll` → `<x>.dll`. But PE has no load event — presence on disk, not a load into a process (§3). |
+| amcache/shimcache → `basename(full_path/path)` | — | NO | Only exe/sys/cpl paths here → not module basenames (§3). |
+| PE version-resource `OriginalFileName` | — | **NO (no-source)** | **Plaso's `pe` parser extracts NO VERSIONINFO** — 0 of 150,708 rows carry `original_file_name`/`company_name`/`file_version`/`product_name` (measured). The "OriginalFileName → module_name" idea needs a new PE-resource reader; not in the pipeline. |
+
+### module_path  *(full path of the loaded DLL)*
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **Prefetch → `mapped_files[i]`** | load | **NO — #1 gap** | **High** for the path itself. Full NT path per entry, e.g. `\VOLUME{01d3c5cc91d8a333-aa920881}\WINDOWS\SYSTEM32\NTDLL.DLL`. Caveats: **volume-GUID prefix** (`\VOLUME{…}`) needs stripping/normalising to join other sources; the list **mixes DLLs with data files** (saw `LOCALE.NLS` alongside DLLs) — filter by extension/`pe_type`; **no per-module load time, no base_address, no hash, no runtime pid**. Sample run (`TASKHOSTW.EXE`) had **54** mapped files. |
+| **PE → `display_name` path** (`_PATH` strips the `VSS/NTFS:` volume prefix, `plaso_fs_extra.py:55`) | load (presence) | **NO — #2 gap** | **High** for the path. `\Windows\System32\*.dll` (23,779), `\Windows\SysWOW64\*.dll` (14,689), `\Windows\WinSxS\*` (66,234, incl. SxS side-by-side + `.mui`). Covers live NTFS **and** VSS1/VSS2 shadow copies. Presence, not a load. |
+
+### md5_hash
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — none — | load | **NO (no-source)** | No disk PE source emits MD5. Plaso `pe` hashes SHA-256 only; amcache carries SHA-1. |
+
+### sha1_hash
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **Amcache → `file_identifier`** (SHA-1) | load | **NO** | **Low relevance for module here.** `file_identifier` is the SHA-1 (44 chars = plaso's `0000` prefix + 40 hex) — present on all 604 rows. BUT amcache has **zero DLL rows** on LoneWolf (566 exe / 36 sys / 2 cpl — §3), so it hydrates `process`/`driver`, not `module`. **Bonus bug:** the amcache map reads `sha1=_R("sha1")` (`plaso_exec.py:286`), a field **absent** in this plaso build — the real SHA-1 is `file_identifier`, so amcache SHA-1 is currently NOT captured at all (a field-name mismatch, affects process/file rows). |
+| PE / prefetch / shimcache | load | NO | No SHA-1 (PE=sha256, prefetch/shimcache no module hash). |
+
+### sha256_hash
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| **PE → `sha256_hash`** (the `pe` parser hashes the file) | load | **NO — #2 gap** | **High** as a disk-file hash: present on 100 % of 150,708 `pe_coff:file` rows, incl. all 137,979 DLLs, keyed by disk path. This is the natural `module.sha256_hash` hydration source (join module_path→PE path). Caveat: it is the **on-disk** file's hash — matches a loaded module only if the loaded copy equals the disk copy (true for clean loads; a packed/hollowed in-memory image will differ — that discrepancy is itself signal). Also carries native `imphash`, `pe_type`, `section_names`. |
+| amcache → `sha256_hash` | load | NO | Present, but no DLL rows (§3) → hydrates process/driver, not module. |
+| shimcache → `sha256_hash` | load | NO | Present, but exe/appx only (§3). |
+
+### signature_valid / signer
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — none — | load | **NO (honest no-source from disk)** | **Plaso extracts NO Authenticode/catalog signer and runs NO WinVerifyTrust.** 0 of 150,708 PE rows carry a signer/signature field (measured). Amcache's `company_name`/`product_name` are **version-resource strings, NOT the signer** (and are dropped by the map anyway). Getting `signer`/`signature_valid` from disk needs a new step: parse the PE Authenticode cert **or** the `\Windows\System32\catroot` security-catalog for the file's hash, then verify — not wired. Today only Sysmon EID 7's own `Signature`/`SignatureStatus` supplies these. |
+
+### pid
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — none — | load | **NO (honest no-source from disk)** | Prefetch is per-**executable** (aggregates runs), never records a runtime PID; PE/amcache/shimcache are disk files. `module.pid` from any fs source is a permanent null (only Sysmon7/WMI/memory give it). |
+
+### tid
+| fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|
+| — none — | load | **NO (honest no-source)** | No artefact in the whole pipeline records the loading thread; disk least of all. Permanent null. |
+
+---
+
+## 3. Honest non-sources (measured, so the negatives are grounded)
+
+- **Amcache is NOT a `module` source on this image.** All 604 rows are exe (566),
+  sys (36), cpl (2) — **zero `.dll`**. Plaso's amcache parser surfaces the
+  `InventoryApplicationFile`/legacy-`File` "primary file" of installed programs
+  (mostly EXEs) + drivers (`.sys` → `driver`). The DLL-per-application detail the
+  brief hoped for is not present. So amcache's SHA-1/version fields feed
+  `process`/`driver`, never `module`, here.
+- **Shimcache is NOT a `module` source.** 1,030 exe + UWP appx package paths, 8
+  cpl, 136 extension-less — **zero `.dll`**. AppCompatCache indexes executables.
+- **WER: no parser.** No WER/Windows-Error-Reporting data_type exists in the
+  timeline (only `WerFault.exe.mui` as a PE file). Plaso does not parse `.wer`
+  crash reports, so their "loaded modules" list is unreachable — genuine
+  no-source (would need a dedicated WER report parser).
+- **KnownDLLs (SYSTEM hive):** only appears as WinSxS *manifest* `fs:stat` rows;
+  the `…\Session Manager\KnownDLLs` key would land as raw `windows:registry:
+  key_value`. It is a *configuration list* of always-mapped DLL names — no
+  process, no pid, no base, no load event. Weak: could seed `module_name`/
+  `module_path` for a fixed set of system DLLs but asserts no load. Effectively
+  no-source for a `module/load`.
+- **DLL search-order-hijack candidates (app-dir DLLs):** an *analytic derivation*
+  over the PE/prefetch populations (a non-system DLL sitting beside an EXE in its
+  app dir), not a native provenance field. Out of scope as a source; belongs in an
+  analytic once PE/prefetch feed `module`.
+- **`base_address`, `pid`, `tid`:** runtime-only — honest permanent nulls from disk.
+- **`unload` action:** no disk artefact records a `FreeLibrary`/unload. Every
+  filesystem source is a *presence/load* snapshot. Honest no-source.
+
+---
+
+## 4. The convergence gap — why hashes don't reach `module` even today (code-grounded)
+
+`crosssource.py` is the right vehicle (it already unions properties across
+sources by content hash and image path), **but as keyed it cannot hydrate
+`module` hashes from disk PEs:**
+
+1. **Content-hash bucket is object-scoped.** `_keys()` builds the definitive
+   content key as `(obj if obj != "process" else "file", *hash)`
+   (`crosssource.py:130`). Only `process` collapses into the `file` bucket;
+   **`module` and `driver` keep their own object tag**. So a `pe_coff` **file**
+   row (`("file", sha256, …)`) never converges with a **module** row
+   (`("module", sha256, …)`) even when the bytes are identical. A *hashed*
+   Sysmon-7 module does **not** pick up the disk PE's metadata.
+2. **The image/path key never uses `module_path`.** `_image_key()` =
+   `basename(image_path or exe)` (`crosssource.py:112`). For a `module`,
+   `image_path` is the **owning process** image (CAR semantics), not the DLL — and
+   module rows have no `exe`. So the heuristic-image join keys a module by its
+   *host process's* name, never by the DLL's own name/path. `module_path`/
+   `module_name` participate in **no** convergence key.
+
+Net: even if prefetch `mapped_files` were exploded into `module/load` rows (giving
+`module_path` + `module_name`, no hash), the existing convergence could not attach
+the on-disk PE's SHA-256 to them. Hydration needs one of: (a) add `module`/`driver`
+to the `process→file` hash-bucket collapse, and/or (b) a new key on
+`(host, normalised module_path | module_name)` ↔ file `file_path`/`file_name`.
+
+**STIX note:** at export, `_b_module` (`stix.py:934`) already projects a module to
+a `file_instance(host, module_path, module_name, hashes, "module", …)`, and
+`file_instance` is path-keyed (`stix.py:529,641`). So a module SCO and a `pe_coff`
+file SCO *at the same exact path string* would merge downstream — but only in STIX
+output, only on an exact path match, and the path forms differ across sources
+(prefetch `\VOLUME{…}\…`, PE `\Windows\…`, Sysmon `C:\Windows\…`, amcache
+`c:\…` lowercase) so they won't coincide without normalisation. It does not
+back-fill `car.db`.
+
+---
+
+## 5. Ranked UNMINED opportunities (filesystem)
+
+1. **Explode prefetch `mapped_files` → `module/load` rows.** *Highest value,
+   lowest cost — the data is already parsed and sitting native
+   (`plaso_exec.py:231`).* Per entry: `module_path` = the mapped path,
+   `module_name` = its basename, `image_path` = owning `path_hints[0]`/`executable`,
+   `hostname`/`fqdn` from `image_hostname`. 1,312 prefetch rows on LoneWolf.
+   Caveats: strip `\VOLUME{…}` prefix; filter data files (`.nls`, `.dat`) from real
+   modules by extension/`pe_type`; no hash/base/pid/tid/load-time. Confidence:
+   High for path+name identity, this is a *loaded-into-process* relationship (the
+   correct `module/load` semantics), not mere disk presence.
+
+2. **Map `pe_coff:file` (DLLs) → `module` (or a disk-module hash table) + join.**
+   150,708 rows / 137,979 DLLs carry `sha256_hash` + `imphash` + `pe_type` keyed
+   by path — the definitive on-disk module-hash source (System32, SysWOW64,
+   WinSxS, live + VSS). Either emit disk-`module` presence rows, or (better) fix
+   the convergence keying (§4) so this hash hydrates `module.sha256_hash` for
+   modules seen hashless via prefetch/memory. Confidence: High for the hash/path;
+   the caveat is disk-copy ≠ in-memory-image for tampered loads (a signal, not a
+   defect).
+
+3. **Cross-object hash hydration — extend `crosssource.py` to `module`/`driver`.**
+   Add module/driver to the content-hash collapse and/or a `module_path`↔`file_path`
+   key with path normalisation. Turns opportunities 1+2 into a real
+   `module.sha256_hash`/`sha1_hash` fill. This is the same `crosssource.py`
+   machinery the backlog Tier-2 #6 already names; this pass pins the exact keying
+   fix required.
+
+4. **(Bonus, adjacent) Fix the amcache SHA-1 field name** (`sha1` → `file_identifier`)
+   in `plaso_exec.py:286` so amcache's SHA-1 is actually captured — helps
+   `process`/`driver` hydration (not `module`, since amcache has no DLLs here).
+
+**Not worth wiring for `module`:** amcache/shimcache (no DLL rows), WER (no
+parser), KnownDLLs (config list, no load event), PE version-resource signer/name
+(plaso extracts none — needs a new parser). Signer/signature_valid from disk needs
+Authenticode/catroot verification that the pipeline does not perform — Sysmon EID 7
+remains the only signer source.
+
+---
+
+## 6. Coverage at a glance — filesystem sources vs `module` (13 fields)
+
+| field | Prefetch `mapped_files` | PE `pe_coff:file` | Amcache | Shimcache | best fs today |
+|---|:--:|:--:|:--:|:--:|---|
+| base_address | – | – | – | – | **no-source (runtime)** |
+| fqdn | (avail) | (avail) | (avail) | (avail) | inherit `image_hostname` |
+| hostname | (avail) | (avail) | (avail) | (avail) | inherit `image_hostname` |
+| image_path | ✅(owning) | – | – | – | prefetch only |
+| md5_hash | – | – | – | – | no-source |
+| module_name | ✅ | ✅ | (no DLLs) | (no DLLs) | prefetch / PE |
+| module_path | ✅ | ✅ | (no DLLs) | (no DLLs) | prefetch / PE |
+| pid | – | – | – | – | **no-source (disk)** |
+| sha1_hash | – | – | (exe/sys only) | – | none for module |
+| sha256_hash | – | ✅(disk) | (exe/sys only) | (exe only) | PE (disk copy) |
+| signature_valid | – | – | – | – | no-source (no verify) |
+| signer | – | – | (company≠signer) | – | no-source |
+| tid | – | – | – | – | **no-source** |
+
+`(avail)` = the row carries `image_hostname`, free to inherit if fs→module is
+wired. **Every ✅ is currently UNMINED** — no filesystem source produces a
+`module` row today; the entire column is opportunity, gated on wiring
+prefetch/PE into the object (opportunities 1–3).

--- a/docs/car-provenance/lonewolf-fs-recheck/process.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/process.md
@@ -1,0 +1,235 @@
+# PROPERTY-PROVENANCE CATALOGUE — MITRE CAR `process`, **UNMINED FILESYSTEM ARTEFACTS**
+## Grounded in the REAL LoneWolf Windows-10 disk image (plaso timeline)
+
+**Object:** `process`. This pass is the *filesystem-artefact* sweep — the on-disk residue that names
+a program, its command line, its launching user or its scheduled/autostart recipe — deliberately
+scoped to artefacts the earlier LoneWolf re-check **did not** analyse.
+
+**Builds on (do NOT redo):** `scratchpad/car-provenance-lonewolf/process.md` already settled the
+execution-artefact family — **prefetch, amcache, shimcache/appcompatcache, userassist, BAM, SRUM** —
+and the `user`-from-`\Users\<name>\` gap. Those findings stand; this document assumes them and covers
+everything else on disk.
+
+**Evidence (full-file, not sampled from a fixture):**
+`data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB, `LoneWolf.E01` via plaso).
+Host `DESKTOP-PM6C56D`; principal user `jcloudy` (SID domain `S-1-5-21-2734969515-1644526556-1039763013`).
+Every count below is a full-file tally (`scratchpad/car-provenance-fs/datatype_hist.txt`); every quoted
+record is a verbatim real row (`scratchpad/car-provenance-fs/samples.json`).
+
+**Maps checked:** `piiat_mitrecar/mappings/{plaso_exec,plaso_registry,plaso_shellitem,plaso_fs_extra,
+plaso_artifacts,jlecmd,recmd}.py`; `piiat_mitrecar/{crosssource.py,relationships.yml,
+cascade_relationships.yml,enrich.py}`; all `sources/*.yaml`.
+
+---
+
+## 0. The routing truth (why these artefacts don't fill `process`)
+
+Grepping every map: the **only** disk sources whose `object` is `process` are
+`plaso_exec_prefetch`, `plaso_exec_winreg` (amcache/userassist/bam/appcompatcache), `plaso_exec_cron`,
+and `l2t_srum` — i.e. exactly the six the prior pass covered. **Every other disk artefact routes to a
+`file` or `registry` object, or is dropped raw.** The consequence for `process`:
+
+| plaso data_type | LoneWolf rows | where it goes today | process fields it *could* fill but doesn't |
+|---|---:|---|---|
+| `windows:registry:service` | **1796** | `plaso_registry` → **registry**/key_edit | image_path, exe, command_line (ImagePath+args), user/sid (ObjectName) |
+| `windows:registry:task_scheduler:task_cache:entry` | **1454** | `plaso_registry` → registry (task_name **not even in native**) | task name only — the command is in the XML plaso doesn't read |
+| `windows:lnk:link` | **1639** (350 w/ args, 521 w/ workdir) | `l2t_lnk` → **file** (and *Not-a-time* rows dropped) | exe/image_path (target), command_line (args), current_working_directory |
+| `pe_coff:file` | **150708** | `plaso_pecoff` → **file** (time-free) | sha256_hash (of an on-disk PE) — reaches process only via a join (§4) |
+| `windows:registry:run` | **27** | `plaso_registry` → registry (`entries` list) | exe/image_path/command_line (autostart command) |
+| `olecf:dest_list:entry` | **72** | **raw** (`plaso_olecf` handles only summary_info) | launching-app identity (AppId), opened-target path |
+| `windows:tasks:job` (.job) | **4** | **raw** (no `winjob` map exists) | image_path, exe, **command_line**, **user** — all present natively |
+| `windows:tasks:trigger` | **6** | **raw** | same as .job + a scheduled-start time |
+| `windows:registry:winlogon` | **12** | `plaso_registry` → registry (`command` native) | exe/command_line (Shell=explorer.exe, Userinit) |
+| `windows:registry:diagnosed_applications` | **4** | `plaso_registry` → registry (`process_name` **dropped**) | exe (`process_name`=chrome.exe) |
+| `windows:registry:boot_execute` | **3** | `plaso_registry` → registry (`value` **dropped**) | command_line/exe (autochk) |
+| `windows:registry:key_value` → **RecentApps** | **74** | `plaso_registry` → registry (values list) | exe/image_path (AppPath), run-count, run-time, user |
+| `windows:registry:key_value` → **Compatibility Assistant\Store** | **5 keys** | `plaso_registry` → registry (value-names) | exe/image_path (value name = full exe path), user |
+| `windows:registry:key_value` → **MUICache / CIT** | 62 / 9 | `plaso_registry` → registry | MUICache: exe path (value name); CIT: opaque/hashed |
+
+**Absent from this image entirely (0 rows, no plaso parser fired):** `windows:timeline:*`
+(**ActivitiesCache.db**), any WMI CIM (`OBJECTS.DATA`), `windows:wer` (**WER**), RecentFileCache.bcf,
+`$MFT`/`fs:ntfs:mft` (only `fs:stat` + `usn_change` present — consistent with the prior pass), and any
+Authenticode/catalog verification. These are §5.
+
+---
+
+## 1. Per-field provenance — all 29 `process` fields, FILESYSTEM artefacts
+
+Legend — **mined?**: **NO** = no map lands it on `process`; **reg/file** = lands on another object
+only; **join** = reachable on `process` via cross-source enrichment; **yes(prior)** = covered by the
+execution-artefact pass. Confidence C=Confirmed on this data, I=Inferred/structural.
+
+| field | fs artefact → native field | action | mined? (where / NO) | conf & caveats |
+|---|---|---|---|---|
+| **exe** | .job `application` (basename); Service `image_path`/ImagePath; RecentApps `AppPath`; CompatAssist\Store value-name; diagnosed_apps `process_name`; MUICache value-name; LNK target/`env_var_location`; Winlogon `command`; Run `entries`; BootExecute `value` | create | **NO for all** (.job/dest_list/trigger raw; rest → **reg**/**file**) | C. Every one carries a real program name; none reaches `process.exe`. |
+| **image_path** | .job `application` (full `C:\…\DropboxUpdate.exe`); **Service `image_path`** (`\SystemRoot\…\iagpio.sys`); RecentApps `AppPath` (`C:\Windows\system32\notepad.exe`); CompatAssist value-name (`C:\…\FileSyncConfig.exe`); LNK `local_path`/`env_var_location` | create | **NO** — Service `image_path` is a **canonical column but on the `registry` object**; RecentApps/CompatAssist ride the unindexable `values` list; .job raw; LNK → file | C. Highest-volume clean path is Service (1796) + RecentApps (74). |
+| **command_line** | **.job `application`+`parameters`** (`…DropboxUpdate.exe` + `/ua /installsource scheduler`); **LNK `command_line_arguments`** (350 rows, e.g. `/name Microsoft.DeviceManager`); Service ImagePath value (svchost `-k …`); Run `entries` command; Winlogon `command`; BootExecute `value` (`autocheck autochk *`) | create | **NO** (.job raw; LNK → file, *Not-a-time* dropped; Service/Run/Winlogon/BootExecute → reg native) | **C — CORRECTS the prior "no disk source for command_line".** .job and LNK are genuine disk sources of process ARGUMENTS. Recorded-not-run for LNK/Run/task (a recipe, not proof of an invocation). |
+| **current_working_directory** | **LNK `working_directory`** (521 rows) | create | **NO** — → file native | C. The *only* disk source for cwd. It is the shortcut's recorded target workdir (recipe), not a live cwd. |
+| **user** | **.job `username` = `DESKTOP-PM6C56D\jcloudy`** (a REAL name, not `"-"`); RecentApps/CompatAssist/MUICache per-user NTUSER path `\Users\jcloudy\`; Service **ObjectName** (LocalSystem / a run-as account) | create | **NO** (.job raw; hive-path un-mined exactly as the prior `\Users\<name>\` gap; ObjectName not extracted) | **C — the .job is the one disk artefact whose native user is populated.** Everything else needs the `\Users\<name>\` regex the engine already proves in `recmd.py`. |
+| **sid** | Service ObjectName *iff* it is a SID; per-user hive path (but plaso renders `\Users\name\`, not `HKU\<SID>` — dead, per prior) | create | **NO** | I. No new strong disk SID source beyond BAM (prior). .job gives name, not SID. |
+| **sha256_hash** | **`pe_coff:file` sha256** of the on-disk PE, keyed by path (150708 rows) | create | **join** — not a native `process` field, but `relationships.yml:process_image_content` (+ `crosssource.py` `definitive_content`) links a `process` whose `image_path` == a `file`'s `file_path`, attaching the PE's hash | **C — CORRECTS the prior "no sha256 for a disk process".** Works only when an execution artefact's path matches a pe_coff path; the join is wired but hash never lands *on* the process row. |
+| **sha1_hash** | amcache `file_identifier` (prior pass — stranded, not `sha1`) | create | **NO** (prior) | C. No new fs source. |
+| **md5_hash** | — none | create | NO | I. No disk artefact offers MD5. |
+| **guid** | minted uuid5 spindle (as for every mapped disk row) | create | reg/file synth | I. Any newly-mapped source would get a synthetic spindle, never a Windows GUID. |
+| **hostname** | `image_hostname` on all rows; dest_list also has native `hostname`=`desktop-pm6c56d` | create | reg/file (stamped) | C. `DESKTOP-PM6C56D` universally; fills trivially once a row is mapped. |
+| **fqdn** | — (workgroup host, no dot) | — | NO | C. No domain. |
+| **integrity_level** | Task **XML** `<Principal><RunLevel>` (HighestAvailable/LeastPrivilege) | create | **NO source in this pipeline** | I. The .job format has no RunLevel; the Task **XML** (`\Windows\System32\Tasks\*`) that does is **not parsed by plaso** (only the task_cache *registry* is, and it has no principal). Structurally null here. |
+| **command_line (parent) / parent_exe / parent_image_path / parent_guid** | — | create | NO | I. No disk artefact records a parent. Structural. |
+| **pid / ppid** | — (residue, no live id) | create | NO | I. Structural — same as the execution-artefact pass. |
+| **env_vars** | — (LNK `env_var_location` is the *target's* path, NOT a process env block) | create | NO | I. Memory-only field. Do not mistake LNK env_var_location for `env_vars`. |
+| **signer** | — (pe_coff carries NO Authenticode; catalog/$Secure not parsed) | create | NO | C. plaso `pe` gives imphash/pe_type/sections but does **not** verify signatures. Structurally null on disk. |
+| **signature_valid** | — (no WinVerifyTrust / catalog lookup in the pipeline) | create | NO | C. Same — no signature verification anywhere on the disk lane. |
+| **access_level / call_trace / target_address / target_guid / target_name / target_pid** | — (`access`-action fields) | access | NO | I. Every disk artefact is a `create`; the `access` sextet has no disk source (Sysmon 10 / memory only). |
+| **uid** | — (no numeric uid in any Windows disk artefact) | create | NO | I. Structural. |
+
+**FS artefacts CAN newly fill (if mapped):** `image_path`/`exe` (Service, RecentApps, CompatAssist,
+.job, LNK), **`command_line`** (.job, LNK, Service, Run), **`current_working_directory`** (LNK),
+**`user`** (.job natively; others via hive path), and `sha256_hash` (pe_coff, via the existing join).
+Everything else is null, and for the parent/pid/ppid/access/env/integrity/signer set that null is
+**structural and honest**, not a pipeline omission — with one nuance: `integrity_level` *does* have a
+theoretical disk source (Task XML RunLevel) that this pipeline simply never parses.
+
+---
+
+## 2. The structurally-hard fields — which fs artefact uniquely supplies them
+
+The prior pass concluded `command_line`, `user`, `integrity_level` and the parent set are unfillable
+from disk. Real filesystem data revises three of those:
+
+- **`command_line` — .job and LNK are genuine disk sources of process arguments.** Prefetch/shimcache/
+  amcache/UA/BAM record a *path only* (prior pass, correctly). But the **Scheduled-Task `.job`** carries
+  `application` + `parameters` — a complete command line — and **1,639 LNKs carry
+  `command_line_arguments` on 350 of them**. Verbatim: `application="C:\Program Files (x86)\Dropbox\
+  Update\DropboxUpdate.exe"`, `parameters="/ua /installsource scheduler"`. This is the single most
+  important correction in this pass.
+- **`current_working_directory` — LNK `working_directory` (521 rows) is the only disk source.** Nothing
+  else on disk records a working directory.
+- **`user` — the `.job` is the only disk artefact whose native user is a real name.** `username =
+  "DESKTOP-PM6C56D\jcloudy"` (contrast the `"-"` on 100% of prefetch/shimcache/UA/amcache from the
+  prior pass). Everywhere else the account is still in the `\Users\<name>\` path, unmined.
+- **`integrity_level`** stays null — its disk source (Task XML `<RunLevel>`) is a file plaso does not
+  parse; the `.job` format does not expose it.
+
+---
+
+## 3. Ranked highest-value UNMINED opportunities (with real LoneWolf evidence)
+
+**Tier 1 — clean, high-volume, direct `process/create` shape:**
+
+1. **RecentApps** (`HKCU\Software\Microsoft\Windows\CurrentVersion\Search\RecentApps`, **74 rows**,
+   per-user `jcloudy`). A UserAssist-class GUI-launch artefact with a *clean full path*. Real values:
+   `AppPath="C:\Windows\system32\notepad.exe"`, `LaunchCount=7`, `LastAccessedTime=131666161949090000`
+   (FILETIME), `AppId="{1AC14E77-…}\NOTEPAD.EXE"`. Today it is an opaque `windows:registry:key_value`
+   → registry, with `AppPath` buried in the unindexable `values` list. **Map to process:** exe/
+   image_path←AppPath, number_of_executions←LaunchCount, ts←LastAccessedTime, user←`\Users\jcloudy\`
+   from `display_name`. **Best cost/value on this image** — a distinct source with a real path *and* a
+   real user, both currently dropped.
+
+2. **Services** (`windows:registry:service`, **1796 rows**). A service is a launcher. `image_path` is
+   already the canonical column — but on the `registry` object. Real row: `name="iagpio"`,
+   `image_path="\SystemRoot\System32\drivers\iagpio.sys"`. For win32 (non-driver) services the `values`
+   list holds `ImagePath` (svchost command line → **command_line**) and `ObjectName` (the run-as
+   account → **user/sid**). **Map to process/create** (autostart-configured), carrying image_path/exe
+   now and command_line/user once the values list is flattened. Highest volume of any candidate.
+
+3. **Scheduled-Task `.job` + `trigger`** (`windows:tasks:job` **4** + `windows:tasks:trigger` **6**,
+   parser `winjob`, currently **raw — no map exists**). Lowest volume, **highest fidelity**: the only
+   disk rows that give `image_path` + **`command_line`** + a **real `user`** together (see §2).
+   Verbatim above. A ~15-line `winjob` map → process/create closes command_line+user+cwd in one source.
+
+**Tier 2 — real execution/autostart evidence, lower volume or messier:**
+
+4. **AppCompatFlags → Compatibility Assistant\Store** (per-user, **5 keys**, several exe each). The
+   value *names* are full paths of programs that ran and tripped the compat assistant:
+   `"C:\Program Files\DellTPad\ApMsgFwd.exe"`, `"C:\Users\jcloudy\AppData\Local\Microsoft\OneDrive\…\
+   FileSyncConfig.exe"`, `"…\OneDriveSetup.exe"`, `"…\OfficeClickToRun.exe"`. Genuine
+   presence-implies-execution evidence with a per-user hive → process exe/image_path + user. Today an
+   opaque key_value key.
+
+5. **Winlogon (12) / Run+RunOnce (27) / BootExecute (3)** — autostart commands →
+   process. Real: Winlogon `command="explorer.exe"` (Shell, trigger Logon); BootExecute
+   `value="autocheck autochk *"`. Note the HKLM `Run`/`RunOnce` `entries` list is **empty** on this
+   image (nothing persisted there); value is in per-user hives / other keys. Low volume, but the
+   command strings are dropped (`value`/`entries` not promoted).
+
+6. **LNK launch-recipes** (350 with args, 521 with working_directory). Rich (`command_line_arguments`,
+   `working_directory`, `env_var_location=%windir%\explorer.exe`) but **quality-caveated**: (a) a
+   shortcut is a *recipe*, not proof of a run; (b) most LoneWolf LNKs here are system Start-Menu/WinX
+   applets, not user-run binaries; (c) the `l2t_lnk` map only emits create/modify/read rows and sends
+   **`Not a time`** to `default:None` — and *every* args-bearing example above is `Not a time`, so they
+   are dropped before any object is built (this compounds the prior BACKLOG's "931/1639 LNK drop"). If
+   promoted at all, promote to `file` first (as today) and treat a process view as a lead.
+
+7. **diagnosed_applications `process_name`** (4 rows, `chrome.exe`) — literal process name at a "Last
+   Detection Time"; trivially → process/exe, but tiny and single-app; `process_name` isn't even in
+   `plaso_registry`'s native extract, so it's lost entirely.
+
+**Tier 3 — hash enrichment (already half-wired):**
+
+8. **pe_coff:file sha256 → process via image-path join.** 150,708 on-disk PEs carry a real SHA-256 by
+   path. `relationships.yml:process_image_content` and `crosssource.py:definitive_content` already
+   relate a `process` (from prefetch/shimcache/amcache path) to the `file` at the same path/hash — so
+   the disk process's binary hash is *reachable* even though execution artefacts carry no hash. Verify
+   the join actually fires on real paths; it is the cleanest route to `sha256_hash` for a
+   disk-only process. (No signer — pe_coff does not do Authenticode; see §5.)
+
+---
+
+## 4. Jump Lists — the launching app (partially there, mostly raw)
+
+`olecf:dest_list:entry` (**72**, parser `olecf/olecf_automatic_destinations`) is **raw** — the
+`plaso_olecf` map handles only `olecf:summary_info`. Each DestList entry names the **launching
+application** by the AutomaticDestinations filename hash (real: `display_name=…\AutomaticDestinations\
+f01b4d95cf55d32a.automaticDestinations-ms`, `f01b4d95cf55d32a` = a known AppID) and the opened target
+(`path="knownfolder:{FDD39AD0-…}"`), plus DLT `droid_*` GUIDs, `entry_number`, `pin_status`,
+`hostname`. For the **process** object the value is indirect (AppID→app needs a lookup table, and the
+target here is a folder). The *file* targets inside jump lists already reach `file` via
+`windows:shell_item:file_entry` → `plaso_shellitem`. Net: dest_list is a weak process source; its main
+loss is the launching-app identity, not a program path.
+
+---
+
+## 5. Honest no-sources (absent from this image / no parser / structural)
+
+- **ActivitiesCache.db (Windows Timeline)** — **the single richest possible `process` disk source**
+  (exe + command line via the activity payload + user + window title/`DisplayText` + start/end →
+  **duration**). plaso's `windows_timeline` plugin exists but **fired 0 rows** here — no
+  `windows:timeline:*` data_type, and no `ActivitiesCache`/`ConnectedDevicesPlatform` key in
+  key_value. Either the plugin isn't in this plaso build's default set or the DB wasn't reached.
+  **Flag for the provisioning epic (#134):** if Timeline matters, the plaso lane must parse
+  `\Users\<u>\AppData\Local\ConnectedDevicesPlatform\*\ActivitiesCache.db`. No evidence to mine today.
+- **WMI `OBJECTS.DATA` (CommandLineEventConsumer → command_line)** — plaso has **no CIM-repository
+  parser**; 0 rows. A real persistence/command_line source, absent. Needs a dedicated parser.
+- **WER reports** — no `windows:wer` rows; the crashed-process path+version+modules are not ingested.
+- **RecentFileCache.bcf** — no plaso parser; absent.
+- **$MFT resident PE metadata / timestomp** — no `$MFT` data_type on LoneWolf (only `fs:stat` +
+  `fs:ntfs:usn_change`), confirming the prior pass; the resident-attribute/`$FN` angle has no input.
+- **Authenticode via catalog / `$Secure`** — no signature verification anywhere on the disk lane;
+  `signer`/`signature_valid` are structurally null (pe_coff gives imphash/sections, never a signer).
+- **hiberfil.sys / pagefile.sys carving** — memory territory (the `volatility` lane on `memdump.mem`
+  is the live pid/ppid/parent/integrity source), not the plaso disk lane; out of this fs scope.
+- **CIT** (`AppCompatFlags\CIT`, 9 rows) — present but **opaque**: value names are hashes
+  (`"2BB8F37D"=1`), not readable program paths; plaso does not decode CIT. No usable process field.
+- **MUICache** (62 key_value hits) — real MUICache lists exe paths as value names, but on this image
+  the strong hits are `muicachebuilder` component-family keys under COMPONENTS (build metadata), not
+  the classic `UsrClass…\MuiCache` exe→friendly-name map; treat as a weak/secondary exe-path source,
+  behind RecentApps and Compatibility Assistant\Store.
+- **RecentApps AppSwitched / ShellNoRoam** — 0 hits on this image.
+
+---
+
+## 6. Through-line (vs the prior LoneWolf pass)
+
+The execution-artefact pass proved the pipeline drops the **user** that sits in the artefact path. This
+filesystem pass finds the same pattern one level up: **the disk is full of program paths, command lines
+and a real username that never reach the `process` object because the artefact is routed to `registry`
+or `file`, or dropped raw.** Concretely, on real LoneWolf data:
+- **command_line and current_working_directory — declared unfillable from disk — actually have disk
+  sources** (`.job` application+parameters; LNK command_line_arguments+working_directory).
+- **A real `user` (`DESKTOP-PM6C56D\jcloudy`) is sitting, populated, in 4 `.job` rows that no map
+  reads.**
+- **RecentApps + Services (1,870 rows) carry clean full exe paths** that land as opaque registry keys.
+- **sha256 for a disk process is reachable** via the already-wired image-path/content join to the
+  150,708 pe_coff file hashes.
+The cheapest wins are RecentApps (a values-list flatten + the `\Users\<name>\` regex) and a ~15-line
+`winjob` map; the biggest volume is Services; the biggest *absent* prize is ActivitiesCache.db.

--- a/docs/car-provenance/lonewolf-fs-recheck/registry.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/registry.md
@@ -1,0 +1,232 @@
+# CAR `registry` — FILESYSTEM/disk-hive provenance audit: what the pipeline HASN'T MINED
+
+Deep-audit of the MITRE CAR **registry** object against the real Windows-10 **LoneWolf**
+disk-registry evidence, focused on **hive content the pipeline drops** rather than the
+per-field basics (those are in `../car-provenance-lonewolf/registry.md`). Every count
+below is measured this pass over the actual plaso JSONL. READ-ONLY.
+
+- **Evidence:** `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+  (6.6 GB, 4,169,774 rows; **1,512,651** are `windows:registry:*`).
+- **Maps under audit:** `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_registry.py`
+  (predicate `startswith("windows:registry:")`, action **key_edit**) and `recmd.py`
+  (RECmd batch → **value_edit**). Routing: `piiat_mitrecar/pipeline.py` `ROUTES`.
+- **Extraction lane:** `python/get_sybers_dxdfir/zimmerman.py` (`ARTIFACT_GROUPS` filter +
+  per-tool argv) and `plaso.py`.
+- **CAR registry fields:** `data, fqdn, hive, hostname, image_path, key, new_content, pid,
+  type, user, value`; actions `add, key_edit, remove, value_edit`.
+
+## 0. Headline — the pipeline extracts far more hive content than it mines
+
+Two structural drops, both grounded:
+
+1. **The Zimmerman lane RUNS `RECmd`, `SBECmd`, `AmcacheParser`, `AppCompatCacheParser`
+   over every extracted hive (with `.LOG1/.LOG2` for dirty-hive replay) — but the CAR
+   `ROUTES` table consumes only RECmd.** `sbecmd.json` (ShellBags), `amcache.csv`,
+   `appcompatcache.csv` have **no route** → their output is written to
+   `processed/zimmerman/<host>/` and silently dropped. Compute is spent; evidence is binned.
+2. **plaso's generic `winreg/winreg_default` plugin produced 1,505,072 of 1,512,651
+   registry rows (99.5%)** — i.e. almost the entire registry reaches CAR untyped, as a
+   `key_edit` whose `value`/`data`/`type` are **trapped in a `values` LIST** the marker set
+   cannot index. **1,351,741** of the 1,506,720 `key_value` rows carry a non-empty `values`
+   list. That is 1.35M rows of on-disk registry content present in the record but absent from
+   the CAR columns.
+
+Note on state: there is currently **no Zimmerman/RECmd output in the store** (the lane has
+not been run on this image — `data_store/processed/zimmerman/` holds only `.gitkeep`, and no
+`recmd_batch.json`/`sbecmd.json`/`amcache.csv` exists anywhere on disk). So on the evidence
+as it sits, the registry object is fed by plaso **only** (`plaso_registry` +
+`plaso_exec_winreg` + `plaso_shellitem` off the `.L2tWinreg` route). The RECmd
+value/data/type flattening and dirty-hive replay are wired but presently fire on nothing.
+
+## 1. Corpus facts measured this pass
+
+**By plaso winreg plugin (`parser`) — this is the real "typed vs generic" split:**
+
+| parser (plugin) | rows | typed? |
+|---|---|---|
+| `winreg/winreg_default` | **1,505,072** | NO — generic key snapshot, value/data/type in `values` list |
+| `winreg/amcache` | 2,215 | typed (exec inventory) |
+| `winreg/windows_services` | 1,796 | typed |
+| `winreg/appcompatcache` | 1,463 | typed |
+| `winreg/windows_task_cache` | 1,454 | typed |
+| `winreg/userassist` | 153 | typed |
+| `winreg/msie_zone` | 108 | typed |
+| `winreg/bam` | 76 | typed |
+| `winreg/bagmru` | 62 | typed (but message = raw object repr, see §4) |
+| `winreg/windows_usb_devices` | 30 | typed |
+| `winreg/windows_run` | 27 | typed |
+| `winreg/windows_sam_users` | 27 | typed |
+| `winreg/mrulistex_*` (4 variants) | 65 | typed |
+| `winreg/mrulist_string` | 17 | typed |
+| `winreg/windows_typed_urls` | 15 | typed |
+| `winreg/winlogon` | 12 | typed |
+| `winreg/explorer_mountpoints2` | 12 | typed |
+| `winreg/windows_usbstor_devices` | 9 | typed |
+| `winreg/windows_version` | 9 | typed |
+| `winreg/networks` | 6 | typed (payload DROPPED, §4) |
+| `winreg/windows_boot_execute` / `windows_shutdown` | 6 / 6 | typed |
+| `winreg/explorer_programscache` | 4 | typed |
+| `winreg/diagnosed_applications` | 4 | typed |
+| `winreg/windows_timezone` | 3 | typed |
+
+- **Transaction-log records: `0`.** No plaso record has a `.LOG1/.LOG2` `display_name` — plaso
+  does **not** parse or replay transaction logs; every registry row is the *base* hive.
+- **SECURITY hive parsed:** 273 rows under `HKLM\Security\Policy` (incl. `Policy\Secrets`, 45).
+- **SAM hive parsed:** 249 rows under `HKLM\SAM\SAM\Domains` (incl. `Account\Users`, 62).
+- **Keys of interest (all via `winreg_default` unless noted):** Services subtree 10,156;
+  Session Manager 1,529; USB Enum 1,233; Amcache driver/app 705/635; Winlogon subtree 391
+  (typed `winlogon` only 12); Uninstall 258; USBSTOR 256 (typed); IFEO 234; Shellbags `\Bags\`
+  180; LSA `\Control\Lsa` 177; App Paths 157; BagMRU 116; SAM bin users 62; **LSA Secrets 45**;
+  Run subtree 36 (typed `run` 27); NetworkList Profiles 12 (typed `networks`); KnownDLLs 3;
+  MountedDevices present; ComputerName present.
+
+## 2. Per-field provenance — disk registry (grounded)
+
+`plaso_registry` promotes only `key/hive/hostname` (+`image_path` on service rows); `recmd`
+promotes `data/hive/key/new_content/type/user/value`. "hive/key → native field" is the plaso
+source unless the RECmd column is noted.
+
+| field | hive/key → native field | action | mined? | conf & caveats |
+|---|---|---|---|---|
+| **key** | `key_path` (plaso) / `KeyPath` (recmd) | key_edit / value_edit | **YES** 100% | High. plaso normalises per-user root to `HKEY_CURRENT_USER`; some rows keep the raw `\REGISTRY\MACHINE\...` form (app-package `Registry.dat` hives). |
+| **hive** | `display_name` (plaso) / `HiveType` (recmd) | key_edit / value_edit | **YES** | plaso fills the hive **FILE PATH** (`...\config\SYSTEM`), not the logical root CAR wants (`HKEY_LOCAL_MACHINE`); the root is `key_path`'s first segment, unused. recmd fills it correctly. Semantic mismatch (from lonewolf audit). |
+| **hostname** | `image_hostname` | key_edit | **YES** 100% | High; lane-stamped (`DESKTOP-PM6C56D`). |
+| **value** | `values[].name` (plaso, LIST) / `ValueName` (recmd) | — / value_edit | **plaso NO; recmd YES** | plaso: present on **1,351,741** key_value rows but trapped in the `values` list, unindexable → native-only. recmd flattens one row per value → canonical. **Biggest single drop.** |
+| **data** | `values[].data` (plaso, LIST) / `ValueData*` (recmd) | — / value_edit | **plaso NO; recmd YES** | Same trap. Binary values render as `"(224 bytes)"` (size only) — the bytes themselves are not carried even in native. |
+| **type** | `values[].data_type` (plaso, LIST) / `ValueType` (recmd) | — / value_edit | **plaso NO; recmd YES** | Same trap. Real types present: REG_SZ/BINARY/DWORD_LE/EXPAND_SZ/MULTI_SZ/NONE/UNKNOWN. |
+| **new_content** | — (plaso) / `ValueData*` snapshot (recmd) | — / value_edit | **plaso n/a; recmd YES** | A plaso key snapshot has no before/after. recmd sets new_content = current data (snapshot convention). |
+| **user** | `\Users\<name>\` in `display_name`/`HivePath` | key_edit / value_edit | **plaso NO; recmd YES** | GAP-1 (lonewolf): plaso leaves `user` null on all 1.5M rows though `jcloudy` sits in 28,371 per-user hive paths; its `hive_user_sid` SID-regex matches 0. recmd's `regex(HivePath, Users/<name>)` is the proven fix. System hives → null (correct). |
+| **image_path** | `image_path` (service rows only) | key_edit | **partial/misleading** | Present on the 1,796 `service` rows = the *configured* service binary, **not the writer**. Null on the other ~1.51M. Field-name collision. |
+| **pid** | — | — | **NO (honest)** | A dead hive never records the writing process. 100% null correct. |
+| **fqdn** | — | — | **NO (honest)** | Only bare NetBIOS `image_hostname`; no domain in the record. |
+
+## 3. Pipeline routing reality — EZ-tool hive parsers produced then dropped
+
+`pipeline.py` `ROUTES` (first-match-wins, filename-pattern → map keys). Registry-relevant:
+
+| Zimmerman output (produced by zimmerman.py) | route pattern present? | consumed by | verdict |
+|---|---|---|---|
+| `recmd_batch.json` (RECmd, all hives, Kroll batch) | `_RECmd_Batch_`, `recmd_batch.json` | `recmd_batch` → registry/value_edit | **mined** (but no input in store yet) |
+| `sbecmd.json` (SBECmd — UsrClass/NTUSER **ShellBags**) | **none** | — | **DROPPED.** Registry-hive folder-access evidence unmined. |
+| `amcache.csv` (AmcacheParser — Amcache.hve) | **none** | — | **DROPPED.** SHA1/ProgramId/driver decode unmined; Amcache reaches CAR only via plaso. |
+| `appcompatcache.csv` (AppCompatCacheParser — SYSTEM) | **none** | — | **DROPPED.** Shimcache reaches CAR only via plaso. |
+| `rbcmd.csv`, `mftecmd.json`, `lecmd` | none / `[]` | — | dropped/raw (not registry). |
+
+`_is_raw_l2t()` only catches unwrapped plaso `json_line` (top-level `data_type`, no `Record`)
+— the EZ CSV/JSON shapes are not raw-l2t, so they are never picked up by the fallback either.
+(SRUM's `srum.jsonl` IS raw-l2t and is consumed via `.L2tEsedb`→`l2t_srum` — the one EZ-lane
+product that does reach CAR by the fallback.)
+
+## 4. Unmined hive-content sweep (be exhaustive)
+
+### 4a. The `values` LIST flattening — 1.35M rows of value/data/type (SEVERE, from lonewolf, re-quantified)
+Every `winreg_default` key carries its values as a list; the marker set can't index a list, so
+`value`/`data`/`type` never become columns. Confirmed rich payloads sitting in the list:
+- `HKLM\System\MountedDevices` — `\DosDevices\C:`, `\??\Volume{GUID}` → REG_BINARY drive/volume
+  mappings (device & USB correlation, disk signatures).
+- `...\Session Manager\KnownDLLs` — REG_SZ DLL list (search-order-hijack surface).
+- `...\ComputerName\ComputerName` — `DESKTOP-PM6C56D` (+ `mnmsrvc` default).
+- `...\Uninstall\*`, `...\App Paths\*` — installed-software inventory.
+- `...\Services\*` subkeys — `EventMessageFile`, `ProviderGuid`, `ImagePath`, `ServiceDll`.
+- `Amcache.hve \Root\InventoryApplicationFile\*` — `FileId` (SHA1), `LowerCaseLongPath`,
+  `LinkDate`, `BinFileVersion`, `BinaryType` (all in the values list — see §4d).
+- Office registration product names, etc.
+RECmd flattens all of this — but only for keys in the curated Kroll batch, and only if that
+lane runs. Full-hive plaso value/data/type is unmined.
+
+### 4b. Transaction logs (.LOG1/.LOG2 — unflushed writes)
+- **plaso emits 0 rows from any `.LOG` file** → the base-hive rows are stale w.r.t. any writes
+  still sitting in the transaction log (the most recent registry activity — often the most
+  IR-relevant). The Zimmerman filter deliberately co-extracts `.LOG1/.LOG2` for **EZ dirty-hive
+  replay**, so replayed values would reach CAR **only** through RECmd's flattened rows (a
+  curated subset), never through the 1.5M plaso rows. The log entries themselves (dirty pages
+  with their own sequence numbers / write times) are surfaced by no map.
+
+### 4c. Hive slack / deleted keys & values (registry carving)
+- `recmd.py` `recmd_is_value_record` requires `Deleted is not True`; `Deleted: true` records
+  (recovered from unallocated) fall to `default: None` → **RAW, unmined**. plaso's winreg parser
+  does not carve unallocated at all. So recovered/deleted registry content (a classic
+  anti-forensics/persistence-cleanup signal) reaches **no CAR field** from either dead-hive map.
+  The map's rationale (deletion *time* is unknowable → refuse to assert a time) is sound for the
+  `remove` action, but the deleted key's **content** is still evidence and could be surfaced as
+  a timeless/`add`-style record with a "recovered, time-unknown" caveat.
+
+### 4d. Hives / keys with NO typed handler (all → `winreg_default`, value/data trapped)
+- **LSA Secrets** — `HKLM\Security\Policy\Secrets\*` (45 rows: `DefaultPassword`, service-account
+  creds, DPAPI machine keys, `NL$KM`). Present as key rows, but **encrypted** and the pipeline has
+  **no SYSKEY/bootkey decryption** (no secretsdump-equivalent) → content unusable.
+- **Cached domain creds** — `HKLM\Security\Cache` (3 rows) — same: encrypted, undecoded.
+- **SAM F/V binary** — `HKLM\SAM\SAM\Domains\Account\Users\*` (62 rows): per-RID `F`/`V` blobs
+  (password-hash presence, group membership, account flags, logon count/timestamps) undecoded.
+  Only plaso's 27 typed `sam_users` rows surface `username/account_rid/login_count/fullname`. **No
+  hash extraction** (no samdump/bootkey step).
+- **IFEO** — `...\Image File Execution Options\*` (234 rows). Persistence/priv-esc (T1546.012).
+  The `Debugger`/`GlobalFlag`/`VerifierDlls` payload rides in the values list; no handler flags a
+  hijack, and value/data are dropped from CAR columns.
+- **MountedDevices / KnownDLLs / ComputerName / Uninstall / App Paths / BootExecute** — see §4a;
+  all generic, content in the values list.
+- **Winlogon (partial)** — typed `winreg/winlogon` fired only 12×; the wider `\Winlogon` subtree
+  (391 rows: `Notify`, `Shell`, `Userinit`, `Taskman`, per-user) falls to `winreg_default`, so
+  Shell/Userinit/Notify **persistence** values are only in the untyped list.
+- **Services (partial)** — typed `windows_services` = 1,796 (the service root config); the wider
+  `\Services\` subtree (10,156 rows: `Parameters`, `Security`, per-service `ImagePath`/`ServiceDll`
+  in subkeys) is `winreg_default`.
+
+### 4e. `network` typed payload dropped (from lonewolf, re-confirmed)
+The 6 `windows:registry:network` rows carry `ssid` ("Net 2.4"), `default_gateway_mac_address`
+(`5c:8f:e0:2a:1c:68`), `dns_suffix`, `description`, `connection_type` **natively** — **none** are
+on `plaso_registry`'s `native_extract` allowlist, so only `key/hive/hostname` survive; the wireless
+profile + gateway MAC (T1016, network-geo/attribution) are lost.
+
+### 4f. ShellBags (UsrClass) — best decoder unrouted
+- plaso `windows:registry:bagmru` (62 rows) message is a raw Python object repr
+  (`<...AttributeContainerIdentifier object at 0x...>`) — useless. Shell items only surface if
+  plaso also emits `windows:shell_item:file_entry` (→ `plaso_shellitem` → **file**/access), and
+  even then as `file`, not as a registry view.
+- **SBECmd (`sbecmd.json`) — the tool that cleanly decodes UsrClass BagMRU into absolute folder
+  paths, MRU slot positions, first/last-interacted times — is produced and UNROUTED (§3).**
+
+## 5. Cross-object flags (typed keys that ALSO belong elsewhere)
+Registry rows that are simultaneously evidence for another CAR object (already partly handled by
+`plaso_exec_winreg`/`plaso_shellitem`, flagged so they aren't double-counted as "registry gaps"):
+- `run`, `winlogon` `command`/`application` → **process/file** (persistence T1547.001/.004).
+- **IFEO** `Debugger` → **process/file** (T1546.012) — currently neither registry-mined nor exec-mined.
+- `service` `image_path`/`service_dll` → **process/module/service** (T1543.003).
+- `usb`, `usbstor` → **device / host** (removable media, T1091); `MountedDevices` correlates volume↔drive↔signature.
+- `mrulistex`, `mrulist`, `bagmru`/shellbags, `explorer_programscache` → **file** (access, T1083).
+- `typedurls`, `msie_zone` → **http / url** (browsing).
+- `mount_points2`, `network_drive` → **flow** (mapped shares, T1021); `networks` → host interface + flow.
+- `sam_users` → **user**; `amcache`/`appcompatcache`/`userassist`/`bam` → **process/file** (execution — already dual-viewed by `plaso_exec_winreg`).
+
+## 6. Ranked UNMINED opportunities (highest value first)
+1. **Route the EZ-tool hive parsers that the lane already runs** — add `sbecmd.json` (ShellBags),
+   `amcache.csv`, `appcompatcache.csv` to `pipeline.py` `ROUTES` + write their maps. Zero new
+   extraction cost; recovers cleanly-decoded registry evidence currently binned. (SBECmd is the
+   only good shellbag decoder; AmcacheParser's SHA1 is in the correct `0000`+40hex form.)
+2. **Flatten plaso's `values` LIST → per-value `value_edit` rows** (or promote value/data/type).
+   1,351,741 rows of on-disk value/data/type presently native-only; RECmd already proves the shape.
+   Engine change (list explosion), largest payoff.
+3. **Surface deleted/carved keys & values** (RECmd `Deleted:true`, §4c) as timeless "recovered,
+   time-unknown" registry records instead of dropping to raw — persistence-cleanup evidence.
+4. **Transaction-log unflushed writes** — either route RECmd's replayed output (so the most recent
+   writes reach CAR) or note in the contract that plaso rows are pre-replay/stale (§4b).
+5. **IFEO + full Winlogon/Services subtree persistence** — a typed handler (or a value-flatten) so
+   `Debugger`/`Shell`/`Userinit`/`ServiceDll` become findable, not buried in `winreg_default` lists.
+6. **`network` payload** — add `ssid`/`default_gateway_mac_address`/`dns_suffix`/`description`/
+   `connection_type` to the `native_extract` allowlist (6 rows, high per-row value).
+7. **LSA Secrets / SAM hashes** — genuine capability gap: no SYSKEY/bootkey decryption in the
+   pipeline. The keys are present but encrypted; a secretsdump/samdump step (SECURITY+SYSTEM,
+   SAM+SYSTEM) would be a new tool, not a map fix. Flag, don't pretend it's a one-liner.
+
+## 7. Honest no-sources / correct nulls (do NOT "fix")
+- **`pid`** — the writing process is never recorded in a dead hive. Null on 100% is correct.
+- **`image_path` of the writer** — never recorded; the only `image_path` present is the *configured*
+  service binary. Writer-image is a genuine no-source for dead hives.
+- **`fqdn`** — record carries only bare NetBIOS.
+- **`new_content` (plaso)** — a key snapshot has no after-state.
+- **`add`/`remove`/`value_edit` from plaso** — a static snapshot can only assert `key_edit`; creation
+  vs edit is indistinguishable, and a truly deleted key isn't in the base hive. Live-writer actions
+  (Sysmon 12/13/14, Security 4657) remain the only legitimate source of `add`/`remove`/`value_edit`
+  with a real time + writer `pid`/`user` — and those arrive via evtx, not the disk hive.
+- **LSA/SAM secret *values*** — recoverable in principle, but only with a decryption step the
+  pipeline doesn't have; present-but-encrypted is the truth of the evidence today.

--- a/docs/car-provenance/lonewolf-fs-recheck/service.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/service.md
@@ -1,0 +1,134 @@
+# FILESYSTEM Property-Provenance Audit — MITRE CAR `service`
+
+Deep-audit of **disk/filesystem** artefacts that could fill the CAR `service` object but
+which the DX_DFIR pipeline has **not mined into a service object yet**. Companion to the
+LS24 memory/live catalogue (`docs/car-provenance/service.md`); this pass is disk-only,
+grounded in the **real LoneWolf Win10 plaso timeline**.
+
+- **Object** `service`: fields `command_line, exe, fqdn, hostname, image_path, name, pid, ppid, uid, user`; actions `create, delete, pause, start, stop` (`car_data_model.json`).
+- **Ground truth**: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+  (LoneWolf.E01, host `DESKTOP-PM6C56D`), 4.17M rows. Numbers below are counted from it.
+- **Maps in play**: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_registry.py`
+  (F), `.../recmd.py` (G), `.../plaso_exec.py` (prefetch/amcache), `.../plaso_fs_extra.py`
+  (filestat/PE = $MFT).
+
+---
+
+## HEADLINE (the #1 opportunity)
+
+The SYSTEM hive `...\Services` key is **already fully parsed** — plaso's
+`winreg/windows_services` parser emits **1,796** `windows:registry:service` rows in the real
+LoneWolf timeline (**618 distinct services**; 608 live on `/p4`, the rest VSS/shadow-only) —
+but `plaso_registry.py` maps every `windows:registry:*` row to CAR **`registry` /
+`key_edit`**. **A dead-disk image therefore yields ZERO `service` objects today.** The whole
+object is sitting in the evidence, parsed, mis-classified as registry.
+
+The service definition is carried on the plaso record itself (verified top-level field
+presence over the 1,796 rows):
+
+| plaso field (top-level) | present | → CAR `service` field |
+|---|---|---|
+| `name` (Services subkey name) | 1796/1796 | `name` [direct] |
+| `image_path` (ImagePath, args intact) | 1760/1796 | `command_line` verbatim; `image_path`/`exe` after parse |
+| `object_name` (run-as ObjectName) | **718/1796** | `user` [direct] |
+| `service_dll` (svchost hosted DLL) | **591/1796** | the REAL binary (native today) |
+| `service_type` / `start_type` / `error_control` | 1796/1796 | driver-vs-win32 / autostart (native) |
+
+`object_name` and `service_dll` are **already extracted into `_native`** by `plaso_registry.py`
+(`native_extract` lines 72–73) — so the reconstruction inputs are literally already in the DB,
+just hung on the wrong object. **The fix is a service-reconstruction map (or an enrichment
+pass over the registry native): one `service/create` per live Services subkey.** That single
+change lights up ~608 service objects per LoneWolf-class disk image, from data already parsed.
+
+---
+
+## Per-field table (Services-key / other fs artefact → native field)
+
+`mined?` column: **registry YES** = the fact reaches the DB but on a `registry` object;
+**service NO** = no `service` object is emitted from disk today.
+
+| field | Services-key / other fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|---|
+| **name** | Services subkey name → plaso `name` (1796); RECmd subkey/ValueName | create | registry YES / service **NO** | HIGH. Verbatim key name. The one field on every row. |
+| **image_path** | ImagePath → plaso `image_path` (1760/1796) → parse bare exe | create | registry YES (as `registry.image_path`) / service **NO** | HIGH. Env-vars stay literal (`%SystemRoot%\System32\svchost.exe`) — the exe_path parse must expand `%SystemRoot%`. For the **205 svchost-hosted** live services the exe is svchost.exe; the *real* binary is `service_dll` (below). |
+| **exe** | `basename(image_path)` | create | service **NO** | HIGH, derived. Inherits svchost caveat (basename = `svchost.exe`, not the DLL). |
+| **command_line** | ImagePath **verbatim incl. args** → plaso `image_path` (221/608 live carry args/switches, e.g. `svchost.exe -k netsvcs -p`) | create | registry YES (native) / service **NO** | HIGH. Distinct from image_path: keeps the `-k <group> -p` args. Env-vars literal. |
+| **user** | **ObjectName → plaso `object_name`** (718/1796): LocalSystem 454, NT AUTHORITY\LocalService 198, NetworkService 63, \Driver\WudfRd 3 | create | registry YES (native) / service **NO** | MEDIUM-HIGH. Run-as **name**, not SID. Casing/prefix variants (`localSystem`, `NT Authority\` vs `NT AUTHORITY\`) need normalising. Null on the ~1078 driver rows (kernel drivers have no ObjectName → honest null). |
+| **hostname** | `image_hostname` = `DESKTOP-PM6C56D` (1796/1796) | create | registry YES (as `registry.hostname`) / service **NO** | HIGH. Already the host-label on the registry object; trivially carried to a service object. |
+| **fqdn** | `image_hostname` iff dotted | create | service **NO** | N/A here. `DESKTOP-PM6C56D` is NetBIOS, not dotted → honest null. Only populated if the machine name is an FQDN. |
+| **pid** | — (Services key is static config) | — | **NO source (fs)** | **Honest null.** A dead hive records configuration, not a running instance. pid exists only from memory `svcscan` (see companion). |
+| **ppid** | — | — | **NO source** | **Honest null.** No disk artefact records a service's parent PID. Structural. |
+| **uid** | — (`object_name` is a NAME; hive `username`=`-` for SYSTEM hive) | — | **NO source (fs)** | **Honest null.** The Services key names the run-as identity as a string (fills `user`), never a SID. SYSTEM-hive owner is `-`. No clean `uid`. |
+
+---
+
+## Corroborating fs artefacts (fill OTHER objects; link to the service via binary path at enrichment — NOT service fields)
+
+These do not populate a `service` field, but they corroborate `image_path`/`service_dll` and
+supply the missing *runtime/plant-time* dimension the static Services key cannot. Counts from
+the real timeline:
+
+| artefact | rows (LoneWolf) | maps to (today) | what it adds for a service |
+|---|---|---|---|
+| **Prefetch** `windows:prefetch:execution` | 1,312 | `plaso_exec.py` → **process/create** | The service **exe actually RAN** = de-facto `start` evidence — but only for **exe-hosted** services; svchost-hosted (205) share `svchost.exe`'s prefetch → ambiguous, cannot attribute a start to one service. |
+| **Amcache** `windows:registry:amcache` | 604 | `plaso_exec.py` → **process/create** + **file/create** (PE link time) | Service **binary presence + SHA1 + PE compile time** (when it was planted/built). Keyed on binary path, not service name. |
+| **$MFT / filestat** `fs:stat` | 1,968,065 | `plaso_fs_extra.py` → **file** (create/modify) | Service binary / `service_dll` **existence + NTFS creation time** = when the binary was dropped on disk. Corroborates image_path; joins by path. |
+| **PE metadata** `parser:pe` | 150,852 | `plaso_fs_extra.py` → **file** | Signer / compile-stamp of the service binary (signature_valid, signer on the `file` object). |
+| **USN journal** `parser:usnjrnl` | 359,999 | (fs) | Create/rename of the service binary — plant-time even after the $MFT entry is reused. |
+| **Scheduled Tasks** `...:task_cache:entry` | 1,454 | `plaso_registry.py` → **registry** (swept as `windows:registry:*`) | Service-**like** persistence but a *different* object; CAR has **no task object**, and a task is not an SCM service. Out of `service` scope by design. |
+
+**Takeaway:** every one of these is a *binary-centric* corroboration joined to the service by
+`image_path`/`service_dll` at the enrichment end-stage — none is a native `service` field and
+none changes the field table above.
+
+---
+
+## Actions from a dead disk
+
+The Services key is a **static snapshot at its key LastWrite time** (all 1,796 rows are
+`timestamp_desc = "Content Modification Time"` — one timestamp per key). That supports exactly
+one action:
+
+| action | fs source | verdict |
+|---|---|---|
+| **create** | Services subkey exists @ key LastWrite | **THE reconstruction target.** LastWrite is the install/config-time proxy. |
+| **start** | prefetch of exe-hosted service (indirect) | Not a service action today; would over-assert if promoted (and blind for svchost DLLs). |
+| **stop / pause** | — | **No fs source.** A static config key cannot record a stop/pause. |
+| **delete** | **shadow diff**: keys in VSS but absent live | **Weak/noisy signal, unmined.** Only 10 shadow-only names in LoneWolf, and they are transient per-user (`*_18279b`: CDPUserSvc, OneSyncSvc…) + a Defender temp scanner (`MpKsl4f881ef9`) — not real deletions. Not worth wiring as a delete source; note it, don't trust it. |
+
+---
+
+## Honest no-sources (disk)
+
+- **pid, ppid, uid** — structurally absent from a static hive (config ≠ runtime; run-as is a
+  name not a SID; SYSTEM-hive owner is `-`). pid exists only from memory `svcscan`.
+- **fqdn** — only if the recorded machine name is dotted; NetBIOS here → null (not faked).
+- **stop / pause** actions — no disk artefact records them.
+- **Autoruns** — CAR's canonical service create/delete sensor is still not wired (empty grep
+  in `piiat_mitrecar/` and `python/`), consistent with the companion catalogue.
+
+---
+
+## Grounding / file index
+
+- Real data: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` — 1,796
+  `windows:registry:service` rows (`parser: winreg/windows_services`), 618 distinct services;
+  top-level `object_name` 718, `service_dll` 591, `image_path` 1,760.
+- Mis-classified map (the gap): `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_registry.py`
+  (object=registry, action=key_edit; `native_extract` already pulls `object_name`,
+  `service_dll`, `start_type`, `service_type`, `error_control`, `name`, `values`).
+- Value-granular disk map: `.../mappings/recmd.py` (registry/value_edit; real but not
+  materialised in this store — `data_store/processed/zimmerman/` is empty).
+- Corroboration maps: `.../mappings/plaso_exec.py` (prefetch/amcache → process/file),
+  `.../mappings/plaso_fs_extra.py` (filestat/PE → file).
+- No disk `car.db` exists yet (`data_store/processed/.../car.db` is the **memory** run only) —
+  so the "zero service objects from disk" gap is confirmed by the map logic, not yet by a DB.
+- Semantics: `third_party/piiat-mitrecar/third_party/car/data_model/service.yaml`; schema
+  `car_data_model.json`.
+
+### service_type / start_type reference (observed distributions)
+- `service_type`: 1 Kernel driver (937), 2 FS driver (111), 8 recognizer (3) → ~1,051 **driver**
+  rows (overlap CAR `driver`); 16 Win32-own (154), 32 Win32-shared (528), +interactive/
+  per-user flags (96/224/272/288) → the true **service**-object subset (~745 rows /≈248 distinct).
+- `start_type`: 0 Boot (257), 1 System (74), 2 Auto (225), 3 Manual (1,201), 4 Disabled (39).
+  Autostart (0/1/2 = 556) is the persistence-relevant slice.

--- a/docs/car-provenance/lonewolf-fs-recheck/socket.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/socket.md
@@ -1,0 +1,182 @@
+# CAR `socket` — FILESYSTEM/disk Property-Provenance Audit (unmined-artefact hunt)
+
+FS/disk companion to the earlier memory-grounded catalogue (`../car-provenance/socket.md`).
+That pass established the **live/memory** truth: the *only* active socket source in this pipeline is
+Volatility3 `windows.piiat.network`/`netscan` → `socket`/`listen` (memory), and WFP 5158 → `socket`/`bind`
+is built-but-inert. **This pass asks a different question: what DISK artefacts record a bound/listening
+socket, and does the pipeline mine them?** Answer up front: **socket is a runtime object — disk evidence is
+thin, and what little exists is *policy/config*, not an observed bind.** But there is one real, sizeable,
+completely-unmined seam: **the Windows Firewall rule set in the registry.**
+
+- **Evidence (real):** `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB, LoneWolf
+  Win10 via plaso). Every count/example below is measured on this file this pass.
+- **Maps under audit:** `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_registry.py` (claims every
+  `windows:registry:*` type as `registry`/`key_edit`), `plaso_artifacts.py`, `plaso_fs_extra.py`,
+  `plaso_linux.py`. Memory socket map for the field vocabulary:
+  `third_party/piiat-mem/piiat_mem/mappings.py` `_SOCKET_MAP`.
+- **CAR `socket` fields (car_data_model.json):** `family, image_path, local_address, local_path,
+  local_port, pid, protocol, remote_address, remote_port, success`; actions `bind, listen, close`.
+
+## 0. Headline
+
+- **NO disk→`socket` mapping exists anywhere in the pipeline.** `grep` for socket emission across
+  `mappings/*.py` returns only the memory package (`piiat-mem`). Every plaso mapping routes to
+  `file`/`registry`/`process`/`user_session`/`flow`/`http` — **never `socket`.** So 100 % of the disk
+  socket surface below is UNMINED.
+- **The one real seam: `SharedAccess\...\FirewallPolicy\FirewallRules`** in the SYSTEM hive. Each rule is a
+  pipe-delimited REG_SZ string carrying **`Dir` + `Protocol` + `LPort`/`RPort` + `App` + `Svc`** — i.e. a
+  *configured* per-app inbound listener (`image_path`+`local_port`+`protocol`+direction). Measured on
+  LoneWolf: **895 `Dir=In` rules carry an `LPort`** (≈298 per VSS snapshot) across 40 distinct `App`
+  binaries. This is a **policy**, not an observed bind — heuristic/config confidence — but it is exactly the
+  socket local-end tuple, and today it is invisible at field level.
+- **The data is ALREADY in the CAR store, just not projected.** `plaso_registry.py` claims the
+  `FirewallRules` key as a `registry`/`key_edit` row and keeps its `values` list in `_native.values`
+  (`native_extract: {"values": _R("values")}`). But — per the prior `registry.md` finding — the marker set
+  cannot index a list, and nothing parses the rule grammar, so the `Dir`/`LPort`/`App` tuple stays as opaque
+  REG_SZ text. Mining it needs **no disk re-read** — a downstream value-explode + grammar-parse.
+- **PortProxy exists but is EMPTY on this image** (default). Populated, it is the strongest disk artefact of
+  all (a real `bind`+`remote` forward). **hosts/services/IIS configs are present only as `fs:stat`
+  filenames** — plaso never parses their content, so their ports/bindings are unrecoverable without a new
+  parser. SSH/PuTTY: **absent** from this image.
+
+---
+
+## 1. Corpus facts (measured this pass on `DESKTOP-PM6C56D.jsonl`)
+
+- **`FirewallRules` registry keys: 3 distinct locations**, each captured 3× (VSS snapshots ×3 → 9 records):
+  1. `HKLM\System\ControlSet001\Services\SharedAccess\Defaults\FirewallPolicy\FirewallRules` — OS default set
+  2. `HKLM\System\ControlSet001\Services\SharedAccess\Parameters\FirewallPolicy\FirewallRules` — **effective/
+     active set** (where user- or malware-added rules land; the T1562.004 forensic target)
+  3. `HKLM\System\ControlSet001\Services\SharedAccess\Parameters\FirewallPolicy\RestrictedServices\AppIso\FirewallRules`
+     — UWP app-container isolation rules
+  - Each is a single `windows:registry:key_value` record (parser `winreg/winreg_default`) with a **`values`
+    LIST** (the first Defaults record alone holds **356** rule values).
+- **Rule-grammar tally over the 9 records (VSS-inflated ~3×; per-snapshot ≈ ⅓):**
+  `Dir` = In **1604** / Out **1362**; `Protocol` = 6/TCP **1159**, 17/UDP **734**, 58/ICMPv6 165, 1/ICMPv4 33,
+  47/GRE 12, 41/IPv6 12, 2/IGMP 12; **`Dir=In` WITH `LPort` = 895** (the configured-listener seam);
+  `Dir=Out` WITH `RPort` = 414; rules with `RA4=`/`RA6=` (remote-address scope) = 978; **40 distinct `App`**
+  paths, **36 distinct `Svc`** names.
+- **Rule string grammar (verbatim example):**
+  `v2.27|Action=Allow|Active=TRUE|Dir=In|Protocol=6|Profile=Domain|Profile=Private|LPort=9955|App=%SystemRoot%\system32\svchost.exe|Svc=AJRouter|Name=@FirewallAPI.dll,-37003|...`
+  Sample configured inbound listeners (App, LPort, Proto, Svc, Action, Active):
+  `svchost.exe/9955/TCP/AJRouter/Allow/TRUE`, `svchost.exe/1900/UDP/Ssdpsrv/Allow/FALSE`,
+  `svchost.exe/68/UDP/dhcp/Allow/TRUE`, `svchost.exe/546/UDP/dhcp/Allow/TRUE`, `System/10247/TCP/-/Allow/TRUE`,
+  `svchost.exe/Teredo/UDP/iphlpsvc/Allow/TRUE`.
+- **PortProxy:** `HKLM\System\ControlSet001\Services\PortProxy` present, message `(empty)`, **no values** — no
+  `netsh interface portproxy` forwarding configured on this host.
+- **`RpcEptMapper\Parameters`:** present (`ServiceDll: RpcEpMap.dll`), **no port** — RPC endpoints are dynamic
+  (assigned at runtime), never on disk.
+- **`applicationHost.config` / `web.config`:** present but as **`data_type: fs:stat` (parser `filestat`)**
+  only — e.g. `…\WinSxS\…servercommon…\applicationHost.config`. Content (the `<binding>` ports) is **not
+  parsed** by plaso; IIS is not even active on this workstation image.
+- **`\drivers\etc\hosts` and `\drivers\etc\services`:** present as `fs:stat` file records only (`Type: file`);
+  content not parsed.
+- **`sshd_config`/`ssh_config`: 0. PuTTY (`SimonTatham`): 0. `iptables`: 0** (Windows image, no Linux).
+
+---
+
+## 2. Per-field provenance — DISK artefacts (all currently UNMINED into `socket`)
+
+Legend — **action**: which socket action the artefact would carry. **mined?**: is there a disk→`socket`
+projection today (almost always **NO**). `fs artefact → native field` is the on-disk source column.
+
+| field | fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|---|
+| **image_path** | FirewallRules rule string `App=` (e.g. `%SystemRoot%\system32\svchost.exe`) → rule value `data` | bind/listen (configured) | **NO** — ingested as `registry` native `values[]` only; never projected to `socket` | **Med (config).** 40 distinct App paths; svchost dominates (786) so `Svc=` is needed to disambiguate which hosted service. Env-var form (`%SystemRoot%`) needs expansion. It is the *permitted* binary, not an observed bind. |
+| **local_port** | FirewallRules `LPort=` on `Dir=In` rules → rule value `data` | bind/listen (configured) | **NO** | **Med (config).** 895 In-rules carry LPort. **Caveat: not always numeric** — keywords (`Teredo`, `RPC`, `RPC-EPMap`, `IPHTTPS`) and lists/ranges (`137,138`) appear; parser must handle them. A rule is a *policy* — the port may never actually be bound. |
+| **protocol** | FirewallRules `Protocol=` (`6`→TCP, `17`→UDP) → rule value `data` | bind/listen (configured) | **NO** | **Med (config).** Needs numeric→name normalize (same fix the inert 5158 map needs). Non-L4 protos also appear (1/58 ICMP, 47 GRE, 41 IPv6, 2 IGMP) — those are not TCP/UDP sockets and should be filtered/kept native. |
+| **local_address** | FirewallRules `LA4=`/`LA6=` (local-address scope) → rule value `data` | bind (configured) | **NO** | **Low.** Present on few rules; most inbound app rules omit it (wildcard `0.0.0.0`/`::`). It is an *allowed local scope*, not the actual bound address. |
+| **remote_address** | FirewallRules `RA4=`/`RA6=` (remote-address scope) on scoped rules → rule value `data`; **PortProxy** `connectaddress` | (Out) / bind+forward | **NO** | **Low.** 978 rules carry RA4/RA6, but these are *allowed peer ranges* (often `LocalSubnet`, `Intranet`, a CIDR), not an observed remote end — and a socket with a live remote end is a `flow` here anyway. PortProxy would give a real forward target but is **empty** on LoneWolf. |
+| **remote_port** | FirewallRules `RPort=` on `Dir=Out` rules; **PortProxy** `connectport` | (Out) / bind+forward | **NO** | **Low.** 414 Out-rules carry RPort — but an outbound-to-remote-port rule is `flow`-shaped, not a bound socket. PortProxy `connectport` would be the true bind+remote pairing; empty here. |
+| **pid** | — (no disk artefact) | — | **NO (honest null)** | A firewall rule / portproxy / config file records **policy**, never the runtime PID that binds. `Svc=`/`App=` are the join keys; PID resolves only at runtime (memory). Correct null on disk. |
+| **family** | weakly inferrable: FirewallRules `RA4/LA4`→ipv4, `RA6/LA6`→ipv6, `Protocol=58`→ipv6 | bind (configured) | **NO** | **Low/weak.** A plain TCP/UDP `LPort` rule is dual-stack (no family). Only address-scoped or ICMPv6 rules hint at family. Don't fake it for the common case. |
+| **success** | n/a (const-by-existence does not apply to a policy) | — | **NO (honest n/a)** | Unlike the memory listener (`success=const(True)` — a kernel socket object *proves* a successful bind), a firewall rule proves nothing was ever bound. If projected, `success` must stay **null** (or an explicit `configured`/`Active` flag in native), never `true`. `Active=TRUE/FALSE` is on the rule (many sampled listeners are `FALSE`/disabled). |
+| **local_path** | — (AF_UNIX, Linux-only) | — | **NO SOURCE (honest)** | AF_UNIX socket filesystem path. Windows image has no AF_UNIX; `plaso_linux.py` emits only `user_session`+`file` (no socket). Even upstream CAR leaves `local_path` empty. True no-source. |
+
+**Action mapping note.** A firewall *inbound-allow* rule with `LPort`+`App` is the disk analogue of WFP 5158
+("bind allowed") → it maps most naturally to **`bind`** (or `listen`) at **config confidence**. It must be
+tagged distinctly from the memory `listen` (which is an *observed* steady-state listener) so a consumer never
+conflates "the firewall would permit this app to listen on 9955" with "this app is listening on 9955".
+
+---
+
+## 3. Ranked UNMINED opportunities (highest value first)
+
+1. **Parse `FirewallRules` → per-app configured inbound listeners as `socket`/`bind` (config confidence).**
+   The single real disk seam. For every `Dir=In` value with an `LPort`: emit `socket`/`bind` with
+   `image_path=expand(App)`, `local_port=LPort`, `protocol=map(Protocol,{6:TCP,17:UDP})`, `success=null`,
+   plus native `svc=Svc`, `rule_name=name`, `active=Active`, `profile=Profile`, `action=Action`. **≈298
+   listeners per VSS snapshot on LoneWolf, 40 distinct binaries.** Requires: (a) explode the registry
+   `values` LIST per rule (the same list-flatten the `registry.md` audit already asks for value/data/type),
+   (b) a small pipe-grammar parser, (c) numeric-protocol normalize, (d) LPort-keyword handling
+   (`Teredo`/`RPC`/ranges). **No disk re-read — the rule strings are already in `_native.values` in the CAR
+   store.** Value: it is the *only* way this pipeline gets any socket coverage from a dead disk image.
+   Caveat to bake in: it is **policy, not observation** — distinct action/confidence, `success` null.
+
+2. **`Svc=` → service-object join (cross-object enrichment).** The rule's `Svc=AJRouter`/`Ssdpsrv`/`dhcp`
+   ties the configured listener to a service already ingested (`windows:registry:service` rows carry
+   `name`+`image_path`). Joining lets svchost-hosted rules (786 of them share `svchost.exe`) resolve *which*
+   hosted service owns the port — the disambiguation memory does with the real PID. Surfaces as a
+   relationship, not a new socket field.
+
+3. **PortProxy → `socket`/`bind`+remote forward (empty here, but wire it).** When
+   `…\Services\PortProxy\v4tov4\tcp` (or v4tov6/v6tov4/v6tov6) is populated, each value is
+   `<listenaddress>/<listenport> = <connectaddress>/<connectport>` — a genuine **bind (local) + remote
+   forward** in one record: `local_address`/`local_port` + `remote_address`/`remote_port`. This is the
+   richest disk socket artefact (a real configured redirector, classic T1090 relay). **Zero rows on LoneWolf**
+   (parent key empty), so it can't be validated here, but the mapping is worth building against a host that
+   has run `netsh interface portproxy add`. Note: plaso renders the parent as one empty `key_value` — the
+   forwards live in the typed subkey, which must be captured.
+
+4. **IIS `applicationHost.config` / `web.config` bound ports — needs a new parser (no plaso source).**
+   The `<binding protocol="http" bindingInformation="*:80:host" />` elements are real configured listeners,
+   but plaso emits these files **only as `fs:stat` filenames** — content is never parsed. Would require a
+   dedicated XML binding parser fed the file bytes. Low priority for this corpus (IIS inactive; the hit is a
+   staged WinSxS copy), but it is the canonical "web-app bound port on disk" artefact for server images.
+
+5. **`remote_*` from FirewallRules `RA*`/`RPort` / outbound rules — mostly out of scope by design.** 978
+   rules carry `RA4/RA6`, 414 carry `RPort`, but a remote endpoint means the record is `flow`-shaped, and the
+   values are *allowed peer scopes* (`LocalSubnet`, CIDRs), not observed peers. Only revisit if outbound
+   firewall policy should ever be modelled as `socket` rather than dropped — currently correct to leave null.
+
+---
+
+## 4. Honest no-source / correct-null (do NOT "fix") — socket is fundamentally a runtime object
+
+- **`pid`** — no disk artefact records the process that binds. Firewall rule / portproxy / config carry
+  `App`/`Svc` (policy identity), never a runtime PID. Correct null from disk; PID is memory's job.
+- **`success`** — the memory listener's `success=const(True)` is proven by a kernel object's *existence*; a
+  disk policy proves nothing was bound. Any FS projection must leave `success` null. Honest n/a.
+- **`local_path` (AF_UNIX)** — Linux-only; no AF_UNIX on the Windows image, and `plaso_linux.py` has no
+  socket mapping. Upstream CAR also empty. True no-source (matches the memory pass).
+- **`close` action** — no disk artefact records a socket *close* transition. A firewall rule/portproxy is a
+  steady-state policy; a config file has no lifecycle. No producer anywhere emits `close`.
+- **`family`** — largely absent from disk policy (TCP/UDP rules are dual-stack); only weakly inferable from
+  `RA6`/`LA6`/ICMPv6. Better left null than faked.
+- **`\drivers\etc\hosts`** — present, but it is **name→IP resolution**, not a socket bind. And plaso records
+  only its `fs:stat`; content unparsed. Not a socket source even in principle.
+- **`\drivers\etc\services`** — present, but it is the **static IANA service-name↔port lookup table** shipped
+  with every Windows box; it proves nothing is bound to those ports. Content unparsed (fs:stat only). Not a
+  socket source.
+- **`RpcEptMapper` / `\Rpc\` keys** — present, but RPC endpoints are **dynamic** (ncacn_ip_tcp ports assigned
+  at runtime); the registry holds `ServiceDll`/config, never a bound port. No local_port from disk.
+- **SSH / PuTTY config** — absent from this image (0 hits); on a host that had them, `sshd_config Port 22` /
+  PuTTY `PortForwardings` would be config-level listener/forward evidence needing bespoke parsers — but plaso
+  ships no parser for either (config file → `fs:stat` filename only).
+- **Scheduled tasks that open listeners** — 1,454 `task_scheduler:task_cache:entry` rows exist, but a task's
+  *action* is a command line; whether that command binds a port is opaque on disk (would require parsing the
+  target binary's behaviour). No disk field expresses a task-opened socket.
+
+## 5. Cross-reference to the memory pass (`../car-provenance/socket.md`)
+
+- **Consistent:** that pass found the active socket object is memory-only / `listen`-only / local-end-only,
+  with WFP 5158 `bind` inert and `remote_*`/`local_path`/`close` unsourced. This FS pass confirms **disk adds
+  no *observed* socket at all** — only *policy* (firewall rules) and, potentially, a *configured forward*
+  (portproxy).
+- **New here:** the FirewallRules seam (895 In+LPort rules, 40 apps, already sitting unparsed in
+  `_native.values`) is a concrete, no-disk-re-read way to give a dead-disk image *some* socket local-end
+  coverage — at explicit config/heuristic confidence, `bind` action, `success` null. It is the disk cousin of
+  the inert 5158 `bind` map and shares the same protocol-normalize fix.
+- **Honest bottom line:** socket's real home is memory/live. The FS contribution is one policy seam worth
+  mining (firewall rules), one empty-here-but-worth-wiring seam (portproxy), and a set of genuine no-sources
+  that should stay null rather than be faked from name-resolution or static OS files.

--- a/docs/car-provenance/lonewolf-fs-recheck/thread.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/thread.md
@@ -1,0 +1,267 @@
+# PROPERTY-PROVENANCE CATALOGUE — MITRE CAR `thread`, FILESYSTEM / DISK ARTEFACTS
+## Grounded in the REAL LoneWolf Windows-10 disk image (plaso timeline)
+
+**Object:** `thread` — the smallest scheduled unit of execution, a purely **runtime** entity
+(TEB / KTHREAD / `_ETHREAD` live state). This pass is scoped to **dead-box FILESYSTEM / disk
+artefacts** only: WER, crash dumps / minidumps, `hiberfil.sys` / `pagefile.sys` / `MEMORY.DMP`
+(memory-on-disk), prefetch, scheduled tasks — **not** event logs (Sysmon EID 8) and **not** live
+memory (Volatility), both of which are the runtime lanes already catalogued in
+`scratchpad/car-provenance/thread.md` (LS24).
+
+**Bottom line up front (the honest headline this pass exists to confirm):**
+`thread` has **near-zero filesystem provenance**. It is a runtime object sourced almost entirely
+from ETW/Sysmon (the `remote_create` lane) and live memory (the `create` lane). Every one of its 15
+fields is **structurally null from ordinary disk artefacts**, and every disk artefact that touches
+threads at all does so **only as `fs:stat` filesystem metadata (name / timestamps / size), never as
+parsed content**. There is exactly **one genuine — but entirely UNMINED — disk source**: a **parsed
+user-mode crash dump / minidump** (and, as memory-on-disk, a **carved `hiberfil.sys`/`pagefile.sys`**),
+which is really "memory on disk". Both are present on the real LoneWolf image; the pipeline captures
+only their filesystem metadata and parses none of their contents.
+
+**Fields (15):** hostname, src_pid, src_tid, stack_base, stack_limit, start_address, start_function,
+start_module, start_module_name, tgt_pid, tgt_tid, uid, user, user_stack_base, user_stack_limit.
+**Actions (4):** create, remote_create, suspend, terminate.
+(Authoritative: `car_data_model.json` L337-363; `third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`.)
+
+**Evidence (full-file tallies, read verbatim — not a thin fixture):**
+`/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+(6.6 GB, LoneWolf `LoneWolf.E01` via plaso). Host `DESKTOP-PM6C56D`; the only real interactive user
+is **`jcloudy`** (+ `defaultuser0` OOBE). 66 distinct `data_type`s in the whole timeline.
+
+---
+
+## 0. What the pipeline can do with threads from disk (code reality)
+
+Exhaustive grep of the ingest code (`third_party/piiat-mitrecar/piiat_mitrecar` + `sources`,
+`third_party/piiat-mem/piiat_mem`, `python/`):
+
+- **The ONLY `thread` producer in the entire pipeline is Sysmon EID 8** (`mappings/sysmon.py`
+  L442-467, `thread/remote_create`) — a **runtime event log**, out of scope here — plus the memory
+  lane (`piiat-mem`, `thread/create`) — **runtime memory**, out of scope here.
+- **No minidump / WER / crashdump / hiberfil / pagefile parser or map exists anywhere.**
+  `grep -rniE "minidump|reportarchive|report\.wer|localdumps|crashdumps|hiberfil|pagefile|\.mdmp|\.hdmp"`
+  over all pipeline code returns **zero** matches. There is no code path that opens a `.dmp`, a
+  `Report.wer`, or a page/hibernation file.
+- **`fs:stat` (the filesystem-metadata data_type, 1.97 M rows) maps only to the CAR `file` object**
+  (`mappings/plaso_fs_extra.py` — "Plaso filesystem/file artefacts → CAR file"), **never to
+  `thread`.** So even where a dump/hiber/WER file is seen on disk, it lands as a `file/create|modify`
+  record, contributing **nothing** to any `thread` field.
+
+Conclusion: from disk, the pipeline maps **not a single `thread` field**. The rest of this document
+is about what *could* be mined and honestly documenting why almost none of it can.
+
+---
+
+## 1. Disk-artefact universe that could conceivably bear on threads (full-file counts)
+
+| Artefact | how it appears in the timeline | rows | thread relevance | parsed content? |
+|---|---|---:|---|---|
+| **User-mode crash dumps** (`*.dmp`) | `fs:stat` metadata only | 6 distinct files (see §2) | **THE one real disk source** of faulting-thread TID + stack + loaded modules | ❌ **contents never parsed** |
+| **`hiberfil.sys`** (memory-on-disk) | `fs:stat` metadata only | 1 file, **6.83 GB** | live thread stacks/TEBs/KTHREADs **iff carved** (= the memory `create` lane) | ❌ not carved by plaso |
+| **`pagefile.sys` / `swapfile.sys`** (memory-on-disk) | `fs:stat` metadata only | pagefile 3.08 GB; swapfile present | paged-out thread stacks **iff carved** | ❌ not carved |
+| **kernel `MEMORY.DMP`** | **not present as a file** — the 6 "MEMORY.DMP" hits are `CrashControl` **registry config** (DumpFile path + FilesNotToBackup), not a dump | 0 files | would carry every thread if it existed | n/a (no file) |
+| **WER `Report.wer`** | `fs:stat` metadata only | 104 `.wer` fs hits (~13 distinct AppCrash/NonCritical reports) | faulting **module/offset** (weak `start_module`), **no TID/stack** | ❌ **no `windows:wer` data_type emitted at all** |
+| **Prefetch** (`windows:prefetch:execution`) | parsed | 1312 | `mapped_files` = per-**process** loaded-DLL list → `start_module` *candidates* only | ✅ but no thread binding |
+| **Scheduled tasks** (`task_cache:entry` / `windows:tasks:job` / `:trigger`) | parsed | 1454 / 4 / 6 | launch **command** → weak proxy for the eventual **main thread's** start command | ✅ but no thread fields |
+
+Everything else in the 66-`data_type` universe (registry, LNK, shellbags, browser, USN, PE, etc.)
+has **no bearing on threads whatsoever**.
+
+---
+
+## 2. The one genuine exception: crash dumps / minidumps (present, real, UNMINED)
+
+Real user-mode crash dumps exist on the LoneWolf disk — captured by Windows Error Reporting /
+`LocalDumps` / Chrome Crashpad — and each is **the only dead-box artefact that actually contains
+thread runtime state** (the faulting thread's TID, its call stack, and the module list at crash time):
+
+```
+\Users\jcloudy\AppData\Local\CrashDumps\Dropbox.exe.13188.dmp          (jcloudy)
+\Users\jcloudy\AppData\Local\CrashDumps\Dropbox.exe.5748.dmp           (jcloudy)
+\Users\jcloudy\AppData\Local\CrashDumps\Dropbox.exe.9780.dmp           (jcloudy)
+\Windows\System32\config\systemprofile\AppData\Local\CrashDumps\svchost.exe.4104.dmp   (SYSTEM)
+\Users\jcloudy\AppData\Local\Google\Chrome\User Data\Crashpad\reports\080881cc-….dmp   (Chrome Crashpad)
+\Users\jcloudy\AppData\Local\Google\Chrome\User Data\Crashpad\reports\561ca1c6-….dmp   (Chrome Crashpad)
+```
+(each also duplicated in the `VSS2:` shadow copy).
+
+**Every one of these is stored only as an `fs:stat` / `filestat` record** — keys are exactly
+`display_name, filename, file_size, file_entry_type, timestamp(_desc), inode, is_allocated,
+sha256_hash (of the .dmp file itself)`. **No thread content is extracted.** A minidump parser
+(`minidumpparser` / `dbghelp` / a Volatility-style walk) run over these files *could* yield, for the
+**faulting thread only**:
+
+- `tgt_tid` — the crashing thread's id (in the MINIDUMP_THREAD list),
+- `tgt_pid` — the process the thread runs in,
+- `stack_base` / `stack_limit` / `user_stack_base` / `user_stack_limit` — from the thread's TEB /
+  stack range embedded in the dump,
+- `start_address` — the thread's start / instruction pointer,
+- `start_module` / `start_module_name` — resolved against the dump's ModuleList.
+
+That is **five-plus `thread` fields recoverable from disk** — but for **one thread per dump** (the
+faulting one; a minidump need not include every thread's full stack), and **only after parsing the
+dump body**, which the pipeline never does. This is the single real UNMINED opportunity for `thread`.
+
+**A bonus that needs no dump-body parse:** the CrashDumps filename convention `<image>.<pid>.dmp`
+embeds the crashing process's **PID** — `svchost.exe.4104.dmp` → PID 4104, `Dropbox.exe.13188.dmp`
+→ PID 13188. That is a weak-but-real **`tgt_pid`** signal recoverable by regex from the `fs:stat`
+`display_name` alone. Currently unmined (fs:stat → `file` object only).
+
+---
+
+## 3. Memory-on-disk: hiberfil.sys / pagefile.sys (a thread source ONLY if carved)
+
+`\hiberfil.sys` (6.83 GB) and `\pagefile.sys` (3.08 GB) are literally **RAM written to disk**. If
+carved with a memory forensics engine they yield the full live-thread universe — `_ETHREAD`/`KTHREAD`
+stacks, TEB user-stacks, start addresses, every TID — i.e. **exactly the memory `create` lane already
+catalogued** in the LS24 `thread.md` (`stack_base`/`stack_limit`/`user_stack_base`/`user_stack_limit`
+are memory-only fields sourced from KTHREAD/TEB). **Be explicit:** this is *memory-on-disk*, not a
+filesystem artefact in any meaningful sense — the values come from parsing RAM structures, not from
+NTFS metadata or a Windows on-disk log. Plaso records these files **only as `fs:stat` metadata** and
+carves nothing. No kernel `MEMORY.DMP` exists on this image (the string hits are `CrashControl`
+registry config pointing at where one *would* be written, not a file).
+
+So: hiberfil/pagefile are a *route to* the runtime `create` lane, not an independent disk source, and
+they belong to the Volatility lane, not the plaso/disk lane.
+
+---
+
+## 4. WER Report.wer: present, but weak for threads — and unparsed anyway
+
+104 `Report.wer` `fs:stat` hits, ~13 distinct crash reports incl.
+`AppCrash_svchost.exe_…`, `AppCrash_Dropbox.exe_…` (×3), `NonCritical_…taskhostw/OneDrive/Update`.
+**There is NO `windows:wer` data_type in the timeline** — plaso's WER parser never fired; the `.wer`
+files exist purely as filesystem metadata.
+
+Even if parsed, a WER `Report.wer` is **the wrong artefact for `thread`**: its text carries the
+faulting **application**, the faulting **module** + offset, and an exception code — which touches
+`start_module`/`start_module_name` *weakly* (the module the fault was in ≈ where the thread was
+executing) — but it carries **no thread id, no stack, no start address**. The thread stack lives in
+the companion `.dmp` (§2), not the `.wer`. So WER is at best a corroborating `start_module` hint, and
+here it is unmined on both counts (no parser, and it maps to `file` regardless).
+
+---
+
+## 5. Prefetch and scheduled tasks: indirect, and honestly nil for `thread`
+
+**Prefetch (1312 rows, parsed).** Each `.pf` carries `mapped_files` — the list of DLLs/modules the
+process loaded in its first ~10 s (e.g. `NTDLL.DLL`, `KERNEL32.DLL`, … 54 entries for `TASKHOSTW.EXE`).
+This is a per-**process** module set. It supplies a pool of **`start_module` *candidates*** (a
+thread's start address is usually inside one of the process's loaded modules) — but there is **no
+thread record, no TID, no start address, no per-thread linkage**: you cannot say *which* thread
+started in *which* module. For the `thread` object this is honest nil (it is a `module`/`process`
+artefact). Documented as the single, very weak indirect signal.
+
+**Scheduled tasks (1454 TaskCache + 4 `.job` + 6 trigger, parsed).** A `.job`/TaskCache action is a
+process-launch command — e.g. `Application: C:\Program Files (x86)\Dropbox\Update\DropboxUpdate.exe
+/ua /installsource scheduler`, `Scheduled by: DESKTOP-PM6C56D\jcloudy`. When the task runs it creates
+a process and its initial/main thread, so the action is a **weak proxy for that main thread's start
+command** — but a launch command is **not even a CAR `thread` field** (`thread` has
+`start_address`/`start_module`/`start_function`, not a command line), and the record has **no TID, no
+stack, no start address**. `Scheduled by` gives the owning **user** (weakly inheritable to the
+launched *process*, not the thread). Honest nil for `thread`.
+
+---
+
+## 6. Per-field provenance — all 15 `thread` fields, FILESYSTEM artefacts only
+
+Legend — **mined?**: essentially all **NO**. "UNMINED (dump)" = recoverable only by a minidump-body
+parser that does not exist; "carve" = only via hiberfil/pagefile carving (= the memory lane).
+
+| field | fs artefact → native field | action | mined? | confidence & caveats |
+|---|---|---|---|---|
+| hostname | image context → `image_hostname` (`DESKTOP-PM6C56D`), stamped on every plaso row | (n/a) | **NO** for a *thread* record (no thread record is emitted from disk); the value exists generically on every fs row | high value / low specificity. Not thread-specific; it is the image's host, inherited by any object. |
+| src_pid | — (the CREATOR is never recorded on disk) | create/remote_create | **NO** | HONEST NO-SOURCE, permanent. No dead-box artefact records who *created* a thread. Only ETW/EDR do. |
+| src_tid | — | remote_create | **NO** | HONEST NO-SOURCE, permanent. The creating thread id exists in no disk artefact (nor in Sysmon nor memory — see LS24). Dead field for disk. |
+| stack_base | crash dump (faulting thread's stack range) → parse; or `hiberfil/pagefile` carve | create | **NO** — UNMINED (dump) / carve | Memory-only concept. Recoverable ONLY by parsing a `.dmp` body (faulting thread) or carving RAM-on-disk. Not from NTFS/logs. |
+| stack_limit | crash dump → parse; or carve | create | **NO** — UNMINED (dump) / carve | as above. |
+| start_address | crash dump (faulting thread IP/start) → parse; or carve | create | **NO** — UNMINED (dump) / carve | The `.dmp` MINIDUMP_THREAD carries the faulting thread's start/instruction pointer. Unparsed. |
+| start_function | crash dump → resolve against dump ModuleList; or carve | create | **NO** — UNMINED (dump) / carve | Needs symbol resolution over the dump's module list; never done. WER gives faulting module but not a function. |
+| start_module | crash dump ModuleList / WER faulting module / prefetch `mapped_files` (candidates) | create | **NO** — UNMINED (dump); weak candidates from prefetch/WER | Best disk signal is the `.dmp` module list for the faulting thread; prefetch/WER give only process-level *candidates*, no thread binding. |
+| start_module_name | `basename` of any of the above | create | **NO** — UNMINED (dump) | derived from start_module; same caveats. |
+| tgt_pid | crash dump body (owning PID); **or `<image>.<pid>.dmp` filename regex** on the `fs:stat` display_name | create | **NO** — UNMINED (weak, filename) | Rare exception: the CrashDumps filename embeds the PID (`svchost.exe.4104.dmp` → 4104). Recoverable from fs:stat path without parsing the dump — but currently fs:stat → `file` only. |
+| tgt_tid | crash dump (faulting thread id) → parse; or carve | create | **NO** — UNMINED (dump) / carve | The one thread id a dump does hold (the faulting thread). Unparsed. No other disk source. |
+| uid | — (no numeric uid on any Windows disk artefact) | (n/a) | **NO** | HONEST NO-SOURCE, permanent. Windows disk artefacts carry SIDs at best, never a numeric uid; `thread` has `uid` not `sid`. |
+| user | owning path of the dump/WER file (`\Users\jcloudy\…\CrashDumps\` → jcloudy; `…\systemprofile\…` → SYSTEM); task `Scheduled by` | create | **NO** — weak, path-inherited | Not a thread attribute; it is the *file owner* (dump author = the crashing process's user), a weak proxy for the thread's process user. Not impersonation-aware. |
+| user_stack_base | crash dump (TEB) → parse; or carve | create | **NO** — UNMINED (dump) / carve | TEB-only. Same as stacks. |
+| user_stack_limit | crash dump (TEB) → parse; or carve | create | **NO** — UNMINED (dump) / carve | TEB-only. Same as stacks. |
+
+**Action coverage from disk:** `create` — only via a parsed dump/carve (unmined). `remote_create` —
+**no disk source ever** (injection/creator lineage is runtime-only; `src_pid`/`src_tid` unknowable
+from disk). `suspend` — **no disk source ever**. `terminate` — **no disk source ever** (a crash dump
+implies a thread *died*, but records the faulting thread's live state at crash, not a terminate event;
+and it is unparsed regardless).
+
+---
+
+## 7. Honest NO-SOURCE section (the point of this pass)
+
+`thread` is a **runtime object**. The following is true and worth stating plainly:
+
+1. **From ordinary disk artefacts — NTFS metadata, registry, event logs' on-disk form, LNK,
+   shellbags, browser, prefetch, scheduled tasks, USN, PE — not one `thread` field is fillable.**
+   These artefacts record files, keys, executions, and launches; **none records a unit of execution
+   (a thread), its stack, its TEB, its start address, its TID, or who created it.** The pipeline
+   reflects this exactly: **zero** `thread` rows are emitted from any disk source, and `fs:stat`
+   (where dumps/hiber/page/WER surface) maps only to the `file` object.
+
+2. **`src_pid`, `src_tid`, `uid` have NO disk source at all — permanent honest nulls.** The thread's
+   *creator* (src_pid/src_tid) is a lineage fact captured only by live ETW/EDR (and even Sysmon EID 8
+   lacks src_tid — see LS24). A numeric `uid` does not exist in Windows disk artefacts.
+
+3. **`remote_create`, `suspend`, `terminate` actions have NO disk source whatsoever.** Thread
+   injection, suspension, and termination are runtime events. Nothing on disk asserts them.
+
+4. **The stack quartet (`stack_base`/`stack_limit`/`user_stack_base`/`user_stack_limit`),
+   `start_address`, `tgt_tid` are memory-only** (KTHREAD/TEB live state). Their *only* dead-box route
+   is **memory-on-disk that has been carved** (hiberfil/pagefile/a crash dump) — i.e. you are back in
+   the memory lane, not a filesystem lane. Confirms the LS24 catalogue's "memory-only" finding from
+   the disk side.
+
+5. **`hostname` and `user` are the only fields with any generic disk value, and even those are
+   inherited context, not thread facts:** `hostname` from the image (`DESKTOP-PM6C56D`, on every row),
+   `user` from a dump/WER file's owning path (`\Users\jcloudy\` / SYSTEM) — the *process/file* owner,
+   never the thread's (impersonation-aware) user context.
+
+**The rare exceptions (genuine UNMINED opportunities), ranked:**
+
+- **A. Parse the user-mode crash dumps / minidumps** (`*.dmp` in `…\CrashDumps\` and Chrome
+  `Crashpad\reports\`). This is the ONE artefact that actually holds thread runtime state on disk:
+  faulting-thread `tgt_tid`, `stack_*`/`user_stack_*`, `start_address`, and `start_module(_name)` via
+  the dump ModuleList. Present on LoneWolf (6 files: Dropbox×3, svchost, Chrome×2); today captured as
+  `fs:stat` metadata only. Real but narrow (one — the faulting — thread per dump) and no parser exists.
+- **B. Regex `tgt_pid` out of the CrashDumps filename** (`<image>.<pid>.dmp`) — a zero-cost weak
+  `tgt_pid`/process-link from the fs:stat `display_name`, no dump-body parse needed. Unmined.
+- **C. Carve `hiberfil.sys` / `pagefile.sys`** → the full memory `create` lane (all stack/start/TID
+  fields). This is memory-on-disk = the Volatility lane, not a new filesystem source; flag it as the
+  bridge, not as disk provenance.
+- **D. (weak) Parse WER `Report.wer`** for faulting **module** → corroborating `start_module` only;
+  no TID/stack. Not currently parsed (no `windows:wer` data_type) and maps to `file` anyway.
+- **E. (very weak / not really thread) Prefetch `mapped_files`** as `start_module` *candidates*, and
+  **scheduled-task** launch command as a main-thread start-command proxy — neither has a thread
+  record; document as context, not sources.
+
+**Net:** `thread` is confirmed a runtime/ETW/memory object with **essentially nil dead-box filesystem
+provenance**. The only honest disk exceptions are *memory-on-disk* (crash dumps and carved
+hiber/page), which are memory content that happens to live in a file — and even those are entirely
+unmined by the current pipeline (captured as filenames, never parsed).
+
+---
+
+## 8. Key files & evidence (absolute paths)
+
+- Evidence: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB)
+- Canonical model: `/opt/github/DX_DFIR/car_data_model.json` (L337-363);
+  `/opt/github/DX_DFIR/third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`
+- Only `thread` producer (runtime, out of scope): `…/piiat_mitrecar/mappings/sysmon.py` (L442-467, EID 8)
+- `fs:stat` → **file** object (never thread): `…/piiat_mitrecar/mappings/plaso_fs_extra.py`
+- Prior runtime catalogue (Sysmon EID 8 + memory lanes): `scratchpad/car-provenance/thread.md`
+- Confirmed ABSENT from the pipeline (grep, zero matches): any minidump / WER / crashdump / hiberfil /
+  pagefile parser or map across `piiat_mitrecar`, `piiat-mem/piiat_mem`, `sources`, `python/`.
+- Real disk artefacts (all `fs:stat` metadata only, contents unparsed): crash dumps
+  `\Users\jcloudy\AppData\Local\CrashDumps\Dropbox.exe.{13188,5748,9780}.dmp`,
+  `\Windows\System32\config\systemprofile\AppData\Local\CrashDumps\svchost.exe.4104.dmp`,
+  Chrome `…\Crashpad\reports\{080881cc…,561ca1c6…}.dmp`; memory-on-disk `\hiberfil.sys` (6.83 GB),
+  `\pagefile.sys` (3.08 GB), `\swapfile.sys`; WER `\ProgramData\Microsoft\Windows\WER\ReportArchive\
+  {AppCrash_svchost.exe,AppCrash_Dropbox.exe×3,NonCritical_…}\Report.wer` (104 fs hits).
+  No kernel `MEMORY.DMP` file (the 6 hits are `CrashControl` registry config).

--- a/docs/car-provenance/lonewolf-fs-recheck/user_session.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/user_session.md
@@ -1,0 +1,139 @@
+# CAR `user_session` — FILESYSTEM / dead-box provenance (unmined disk artefacts)
+
+Deep audit of the MITRE CAR **`user_session`** object for **filesystem / disk artefacts** (dead-box, no
+event logs) that *could* fill its properties but the pipeline has **not mined** yet. Companion to the
+event-log-centric `docs/car-provenance/user_session.md` (that pass covered S1–S7: Security evtx, RDP
+TerminalServices evtx, Winlogon evtx, Linux utmp/utmpx/sshd, Volatility memory). This pass is the **disk
+lane** those seven sources ignore.
+
+- **Object fields (10):** `dest_ip, dest_port, hostname, login_id, login_successful, login_type, src_ip, src_port, uid, user`
+- **Actions (5 in brief; model also has create/metadata/terminate):** `lock, login, logout, reconnect, unlock`
+- **Ground truth image:** LoneWolf Win10 (`LoneWolf.E01`, host `DESKTOP-PM6C56D`), plaso super-timeline
+  `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.5 GB, 4.17 M rows). Real records quoted below.
+- **Engine maps:** `third_party/piiat-mitrecar/piiat_mitrecar/mappings/` (`plaso_registry.py`, `plaso_linux.py`),
+  enrichment `piiat_mitrecar/enrich.py`, routing `piiat_mitrecar/pipeline.py`.
+
+---
+
+## Headline finding — the whole disk lane is unmined for `user_session`
+
+**No filesystem/disk artefact produces a `user_session` object today.** Every emitter of
+`"object": "user_session"` in the codebase is an **event-log / winevt / utmp / memory** source:
+
+| emitter | file | lane |
+|---|---|---|
+| Security 4624-family | `mappings/evtx_windows.py:231,248,259` | evtx |
+| Winlogon 7001/7002 | `mappings/evtx_more.py:172,183` | evtx |
+| RDP TerminalServices 21/24/25 | `mappings/evtx_extra.py:80` | evtx |
+| utmp/utmpx/sshd | `mappings/plaso_linux.py:300` | plaso (Linux login DB) |
+| Volatility sessions | `../piiat-mem/piiat_mem/mappings.py:251,343` | memory |
+
+The registry hives **are parsed and ingested** — SAM `sam_users`, SOFTWARE `ProfileList`, `Winlogon`,
+`shutdown` all flow through the pipeline — but `mappings/plaso_registry.py` claims **every** `windows:registry:*`
+data_type as a **`registry` object, action `key_edit`** (line 44-110). The account fields that ARE the
+substance of a session (`username`, `account_rid`, `login_count`) are dropped into `_native` (lines 80-84) and
+the timestamp — even when it is literally a **"Last Login Time"** — is relabelled a registry key-edit. The
+session semantics is thrown away. So the answer to the "is ANY disk source mapped to user_session?" column
+below is **NO, everywhere.**
+
+Second-order gap: `piiat_mitrecar/enrich.py` has **no SID→user resolution from plaso ProfileList rows**. (The
+separate PIIAT-Mem/Volatility `enrich.py:_sid_user_index` does a ProfileList join, but it keys on a flat
+`value=="ProfileImagePath"` shape the plaso registry rows — which nest values in a `_native.values` LIST — do
+not have.) So even the `uid`↔`user` link that disk fully supports is not wired on the disk lane.
+
+---
+
+## Per-field provenance (filesystem / disk artefacts only)
+
+Legend for **mined?**: **NO(reg)** = the artefact IS ingested but only as a `registry`/`file` object, never
+as `user_session`; **NO(none)** = not ingested at all; **null** = honest no-source from disk.
+
+| field | fs artefact → native field | action | mined? | conf & caveats |
+|---|---|---|---|---|
+| **user** | SAM `sam_users.username` (`jcloudy`) **[direct]**; SOFTWARE `ProfileList\<SID>.ProfileImagePath` basename (`C:\Users\jcloudy`→`jcloudy`) **[derived]** | login | **NO(reg)** — both become `registry/key_edit`; username sits in `_native`, ProfileImagePath in `_native.values` | HIGH. Two independent disk sources agree. |
+| **uid** (SID) | SAM `account_rid` (`1001`) **[direct]** + machine domain-SID prefix from any `ProfileList\S-1-5-21-…` subkey → full SID `S-1-5-21-2734969515-1644526556-1039763013-1001` **[derived]**; or the ProfileList key SID itself **[direct from key_path]** | login | **NO(reg)** | HIGH. RID→SID reconstruction is deterministic (one domain-SID prefix per image; also in `SAM\Domains\Account\V`). ProfileList only lists *loaded* profiles, but the prefix it yields resolves every local RID (incl. never-logged-in Administrator/Guest). |
+| **hostname** | `image_hostname` (`DESKTOP-PM6C56D`) on every plaso row **[direct]**; SYSTEM hive `ComputerName` | all | **NO(reg)** as a `user_session` field — value rides on registry rows / the CAR header, never a session | HIGH. |
+| **login_successful** | SAM `sam_users.login_count`>0 **and** a real "Last Login Time" ⇒ assert `True` **[asserted]** | login | **NO** | MED. Sound *True* assertion (a recorded last-login proves ≥1 success). **No `False` from disk**: plaso's `sam_users` exposes `login_count` but **not** the bad-password / failed-login counters in the SAM `F` value, and Windows has no on-disk failed-login store (no btmp analogue) — failed logons live only in Security.evtx 4625. |
+| **login_id** (LUID) | — | — | **null** | HIGH honest null. The LUID is a runtime, per-boot token id; it is never persisted to any hive or file. Disk cannot supply the cross-artefact join key. |
+| **login_type** | — (LogonUI/Winlogon/SAM record no logon-type) | — | **null** | HIGH honest null. Could only be *guessed* (`interactive`/`local` for a console profile) — no artefact states it. Do not fake. |
+| **src_ip / src_port** | — (inbound-session origin is not written to disk) | — | **null** | HIGH. Source endpoint of an inbound logon exists only in the Security log / network capture, not on the dead disk. |
+| **dest_ip / dest_port** | RDP **client** artefacts only: `NTUSER\…\Terminal Server Client\Default\MRU*` + `\Servers\<host>` (dest host/user), `Default.rdp`, bitmap cache `Cache####.bin` **[derived]** | login | **NO(none) / null here** | MED-conditional. Meaningful **only if the host was used as an RDP client**. **Absent on this image** — DESKTOP-PM6C56D was not an RDP client (no `Terminal Server Client` key; only OS RDP binaries in WinSxS). So honest null *here*, a real conditional source *elsewhere*. Yields a hostname, rarely a literal IP; port never. |
+
+---
+
+## Ranked UNMINED opportunities (real disk sources, not yet mapped to `user_session`)
+
+**1. SAM `sam_users` → `user_session/login` — the headline.** `winreg/windows_sam_users` already emits a
+per-account **"Last Login Time"** row whose `Timestamp` IS the last-logon FILETIME; `plaso_registry.py`
+currently drowns it as a `registry/key_edit`. Everything a login row needs is on the record:
+
+```
+data_type: windows:registry:sam_users   parser: winreg/windows_sam_users
+display_name: NTFS:\Windows\System32\config\SAM     image_hostname: DESKTOP-PM6C56D
+username: jcloudy   account_rid: 1001   login_count: 23
+timestamp_desc: "Last Login Time"   ts: 1523017587572470  (2018-04-06T13:46:27Z)
+```
+
+Map → `user_session` login: `user`=username, `uid`=RID→SID, `login_successful=True` (login_count>0),
+`hostname`=image_hostname, `login_count`→`_native`, ts=Last Login Time. Confidence HIGH; the data is *already
+flowing through the pipeline* with the correct timestamp — it only needs a second (user_session) emission on
+the `Last Login Time` variant. (LoneWolf: `jcloudy` RID 1001, 23 logins, last 2018-04-06; `defaultuser0` RID
+1000, 2 logins.)
+
+**2. SOFTWARE `ProfileList` SID↔user index → `uid`↔`user` resolution + downstream naming.** Ingested today as
+`windows:registry:key_value` (`ProfileList\S-1-5-21-…-1001 → C:\Users\jcloudy`). Wire a disk-lane SID→user
+index in `piiat_mitrecar/enrich.py` (mirroring PIIAT-Mem's `_sid_user_index`, but reading `_native.values` for
+`ProfileImagePath`) so RID-only SAM rows and SID-only Winlogon rows get a `user`, and vice-versa. Confidence HIGH.
+
+**3. SAM "Last Password Set Time" → `user_session/metadata` (or `authentication`).** Same `sam_users` record
+carries a `Last Password Set Time` variant (`jcloudy` ts 1522142338259150) — the account credential timeline
+alongside the login. Currently a registry key_edit. Confidence HIGH for the fact, MED for placing it on
+`user_session` vs `authentication`.
+
+**4. Profile-hive load times (session-activity proxy).** `NTUSER.DAT` / `UsrClass.dat` MAC times
+(`fs:stat`, currently the **`file`** object) and their registry **last-write** stamps bound when the profile
+was mounted — i.e. a login/logout window when no session log survives. LoneWolf `NTFS:\Users\jcloudy\NTUSER.DAT`
+Creation Time ts 1522142338688793. Confidence MED (a proxy, not a session record); best surfaced as a
+`user_session/metadata` corroborator, not a hard login.
+
+**5. `Last Shutdown Time` (SYSTEM `\ControlSet001\Control\Windows\ShutdownTime`) → logout/session-end proxy.**
+Present (`windows:registry:shutdown`, `timestamp_desc: Last Shutdown Time`) → registry key_edit today. Bounds
+the end of the last session. Confidence MED (machine-wide, not per-user).
+
+**6. RDP client-side artefacts → `dest_*`/`user` for OUTBOUND rdp (conditional).** `Terminal Server Client`
+MRU / `Servers` subkeys, `Default.rdp`, bitmap cache `Cache*.bin`. The only disk path to `dest_ip`/`dest_port`.
+**Not present on this image** (workstation, not an RDP client) — a real source on jump-boxes/admin hosts.
+Confidence MED-conditional.
+
+---
+
+## Honest no-sources (do not fake from disk)
+
+- **`login_id` (LUID)** — runtime-only, never persisted; permanent disk null.
+- **`login_type`** — no hive/file records the CAR vocabulary; would be a guess.
+- **`src_ip` / `src_port`** — inbound-session origin is not written to disk (Security.evtx / pcap only).
+- **`dest_ip` / `dest_port`** — only via RDP *client* artefacts, only if the host was a client; null on this image.
+- **`login_successful = False`** — plaso `sam_users` exposes `login_count` but not the SAM `F` bad-password /
+  failed-login counters; Windows keeps no on-disk failed-login store (no btmp analogue). No `False` from disk.
+- **`lock` action** — no filesystem artefact records a workstation lock/unlock (Security 4800/4801 only).
+
+**Tangential / weak:** `ActivitiesCache.db` (Windows Timeline, per-user under
+`…\ConnectedDevicesPlatform\<id>\`) is present **only as `fs:stat`** (file MAC times) — plaso does not parse
+its SQLite content; and it records app usage, not sessions. Note, don't prioritise.
+
+**Security.evtx fallback (de-emphasised, filesystem focus):** carving the on-disk `Security.evtx` from the
+image and feeding the **evtx lane** would light up S1 (4624-family → 8/10 fields) — but that is the event-log
+lane, not a registry/filesystem artefact, and no on-disk Security.evtx is present in this light LoneWolf
+collection (`data_store/raw/collections/lonewolf/logs/winevt/` is empty). Filesystem-native `user_session`
+therefore rests on the SAM/ProfileList registry chain above.
+
+---
+
+## Bottom line
+
+The disk lane is a **clean, unexploited seam** for `user_session`: SAM `sam_users` "Last Login Time" (login,
+user, uid-via-RID, login_successful=True, login_count) plus SOFTWARE `ProfileList` (uid↔user) reconstruct a
+genuine login event with HIGH confidence entirely from dead hives that the pipeline already parses — today
+they are silently demoted to `registry/key_edit` rows. `login_id`, `login_type`, `src_*`, and inbound
+`dest_*` are honest disk nulls; `dest_*` via RDP-client artefacts is a real but image-conditional source
+(absent on LoneWolf).


### PR DESCRIPTION
Preserves two grounded re-checks of the CAR extraction squeeze, correcting the earlier LS24 round with (a) a real Windows dead-box image and (b) a whole-processed-tree value hunt. **Docs only** — no code, no submodule-pointer changes.

## `docs/car-provenance/lonewolf-fs-recheck/`
A *find-once-done* sweep of all 13 CAR objects against the **LoneWolf** Win10 image (`DESKTOP-PM6C56D`, plaso 4.17M events, VSS included). One `<object>.md` per CAR object + `BACKLOG.md`.

The five recurring gap shapes it surfaces — most are **cheap re-emits of data plaso already parsed**, not new tooling:
1. **Right data, wrong object** — `Services` key → `registry` not `service` (a dead disk yields 0 `service` objects today); amcache/`pe_coff` never hydrate `driver`/`module`; MRU → `registry` not `file`/read.
2. **`user` is in the path, never mined** — null `user`/`uid` while the account is right there in `\Users\<name>\`, hive `display_name`, SIDs. `recmd.py` already does it; nothing else does. **#1 win.**
3. **Over-narrow predicate** — `l2t_firefox_places` gates Firefox-only, so all Chrome/Edge history is rejected.
4. **Value trapped in an unindexable list** — 1.35M registry rows hide `value`/`data`/`type` in a `values` list.
5. **Parser output produced then binned** — the Zimmerman lane runs SBECmd/Amcache/AppCompatCache but `pipeline.py` ROUTES consumes none of them.

`BACKLOG.md` ranks the cheap A1–A11 map fixes vs the collection-lane gaps ($MFT, SRUM, ActivitiesCache, mail stores) tracked under epic #134.

## `docs/car-provenance/crosslink/`
Grepping unambiguous values (GUIDs, SIDs/users, hosts/IPs, command lines, ports/serials) across the whole `data_store/processed/` tree. Per-class detail + `SUMMARY.md`.

**Decisive finding:** of **44,327** non-null `guid` values, **zero** are canonical `{8-4-4-4-12}` GUIDs — the CAR join key is synthetic-only, so no MachineGuid / volume GUID / Sysmon ProcessGuid is ever promoted to a queryable field. Records the real convergence keys that *do* exist (volume GUID across 6 data_types, `jcloudy`=RID 1001, USB serials, network-infra bridges) and the **B1–B5** linkage backlog that gives the cross-source convergence stage real keys to join on.

## Relationship to the engine PR
This is the *evidence* behind Get-Sybers/PIIAT-MitreCar#55 (the A-class per-field disk-squeeze fixes). This PR records the findings + backlog in the DX_DFIR tree; the code lands in the submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)