### PR TITLE
docs(car-provenance): fix dead cross-refs + machine-specific paths (#148 review)

### DIFF
--- a/docs/car-provenance/crosslink/cmdlines.md
+++ b/docs/car-provenance/crosslink/cmdlines.md
@@ -1,6 +1,6 @@
 # Command-line cross-artefact linkage hunt — DX_DFIR processed dataset
 
-READ-ONLY analysis. Repo `/opt/github/DX_DFIR`, dataset `data_store/processed/`.
+READ-ONLY analysis over the processed dataset `data_store/processed/`.
 Command-bearing artefacts extracted by a single streaming pass over the 6.6 GB
 LoneWolf disk timeline plus targeted reads of the Sysmon evtx, Hayabusa timeline,
 Volatility plugins and `car.db`.
@@ -244,8 +244,10 @@ rule CMD_Silent_RecursiveDelete
 
 ---
 
-### Artefact-extraction working files (scratchpad)
-`/tmp/claude-0/-opt-github-DX-DFIR/efe5c9e9-eea7-4e0b-98c8-5da8aa5f00db/scratchpad/car-crosslink/`
-— `prefetch.jsonl amcache.jsonl appcompatcache.jsonl bam.jsonl userassist.jsonl lnk.jsonl
+### Artefact-extraction working files
+This pass projected per-artefact JSONL out of the processed tree —
+`prefetch.jsonl amcache.jsonl appcompatcache.jsonl bam.jsonl userassist.jsonl lnk.jsonl
 service.jsonl run.jsonl taskjob.jsonl taskcache.jsonl mrulistex.jsonl shellitem.jsonl
-evtx_proc.jsonl` plus `pf_exe.txt am_path.txt shim_path.txt bam_path.txt ua_val.txt`.
+evtx_proc.jsonl` plus the extracted value lists `pf_exe.txt am_path.txt shim_path.txt
+bam_path.txt ua_val.txt` — as intermediate scratch (not committed). The findings above
+are the durable output; the projections are reproducible from `data_store/processed/`.

--- a/docs/car-provenance/crosslink/guids.md
+++ b/docs/car-provenance/crosslink/guids.md
@@ -1,6 +1,6 @@
 # GUID cross-artefact linkage hunt — DX_DFIR processed dataset
 
-READ-ONLY scan (rg / python sqlite3). Repo `/opt/github/DX_DFIR`, tree `data_store/processed/`.
+READ-ONLY scan (rg / python sqlite3) over the processed tree `data_store/processed/`.
 
 ## Dataset reality: three distinct hosts (linkage is WITHIN a host)
 The processed tree mixes three unrelated images. A GUID converges *inside* one host's

--- a/docs/car-provenance/crosslink/host_ip.md
+++ b/docs/car-provenance/crosslink/host_ip.md
@@ -208,7 +208,7 @@ rule GENERIC_Windows_Hostname_NETBIOS
 
 ---
 
-## 6. Evidence pointers (absolute paths)
+## 6. Evidence pointers
 
 - Memory static IP / DNS (BGP-WS1-CONF): `data_store/processed/volatility/memdump.mem/plugins/windows.piiat.registry.jsonl` — Tcpip Interface `{89b3e14f-e403-4965-be04-aaeceb0a4e2f}`; ComputerName under `...\Control\ComputerName\ComputerName`.
 - Memory COMPUTERNAME env: `data_store/processed/volatility/memdump.mem/plugins/windows.piiat.processes.jsonl` (EnvVars `COMPUTERNAME=BGP-WS1-CONF`).

--- a/docs/car-provenance/crosslink/host_ip.md
+++ b/docs/car-provenance/crosslink/host_ip.md
@@ -1,6 +1,6 @@
 # Cross-Artefact Linkage Hunt: Hostnames, IPs, MACs & Domains
 
-Dataset: `/opt/github/DX_DFIR/data_store/processed/` (READ-ONLY analysis)
+Dataset: `data_store/processed/` (READ-ONLY analysis)
 Scope: plaso (`log2timeline/jsonl/*`), Windows logs (`windows_logs/`), Zeek (`zeek/*`), Volatility memory (`volatility/memdump.mem/plugins/*` + `car.db`).
 
 ---
@@ -210,10 +210,10 @@ rule GENERIC_Windows_Hostname_NETBIOS
 
 ## 6. Evidence pointers (absolute paths)
 
-- Memory static IP / DNS (BGP-WS1-CONF): `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/plugins/windows.piiat.registry.jsonl` — Tcpip Interface `{89b3e14f-e403-4965-be04-aaeceb0a4e2f}`; ComputerName under `...\Control\ComputerName\ComputerName`.
-- Memory COMPUTERNAME env: `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/plugins/windows.piiat.processes.jsonl` (EnvVars `COMPUTERNAME=BGP-WS1-CONF`).
-- CAR normalised host / empty network tables: `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/car.db`.
-- Zeek DNS/flow/C2: `/opt/github/DX_DFIR/data_store/processed/zeek/DFIRdump_FOR_200_capture_pcap/{conn,dns,http,ssl,x509}.json`; second capture `/opt/github/DX_DFIR/data_store/processed/zeek/ME_FOR_1308_pcapng/conn.json`.
-- 5g-webui FQDN cert: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/5g-webui.jsonl` (`berylia` matches → `/srv/certs/5g-webui.sac.baf.10.berylia.org_cert.crt`).
-- Sysmon host: `/opt/github/DX_DFIR/data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json` (`Computer = DESKTOP-M913391`).
-- LoneWolf host: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (`image_hostname = DESKTOP-PM6C56D`).
+- Memory static IP / DNS (BGP-WS1-CONF): `data_store/processed/volatility/memdump.mem/plugins/windows.piiat.registry.jsonl` — Tcpip Interface `{89b3e14f-e403-4965-be04-aaeceb0a4e2f}`; ComputerName under `...\Control\ComputerName\ComputerName`.
+- Memory COMPUTERNAME env: `data_store/processed/volatility/memdump.mem/plugins/windows.piiat.processes.jsonl` (EnvVars `COMPUTERNAME=BGP-WS1-CONF`).
+- CAR normalised host / empty network tables: `data_store/processed/volatility/memdump.mem/car.db`.
+- Zeek DNS/flow/C2: `data_store/processed/zeek/DFIRdump_FOR_200_capture_pcap/{conn,dns,http,ssl,x509}.json`; second capture `data_store/processed/zeek/ME_FOR_1308_pcapng/conn.json`.
+- 5g-webui FQDN cert: `data_store/processed/log2timeline/jsonl/5g-webui.jsonl` (`berylia` matches → `/srv/certs/5g-webui.sac.baf.10.berylia.org_cert.crt`).
+- Sysmon host: `data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json` (`Computer = DESKTOP-M913391`).
+- LoneWolf host: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (`image_hostname = DESKTOP-PM6C56D`).

--- a/docs/car-provenance/crosslink/identity.md
+++ b/docs/car-provenance/crosslink/identity.md
@@ -1,6 +1,6 @@
 # Identity-Linkage Hunt: SIDs & Usernames as Cross-Artefact Convergence Keys
 
-Dataset: `/opt/github/DX_DFIR/data_store/processed/` — READ-ONLY hunt. All values below are real, pulled from the processed data.
+Dataset: `data_store/processed/` — READ-ONLY hunt. All values below are real, pulled from the processed data.
 
 ## TL;DR
 

--- a/docs/car-provenance/lonewolf-fs-recheck/BACKLOG.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/BACKLOG.md
@@ -3,9 +3,8 @@
 A "find once, done" sweep of every CAR object for Windows filesystem/disk artefacts
 the pipeline does NOT yet turn into the right CAR row — grounded in the real
 LoneWolf Win10 image (`DESKTOP-PM6C56D`, plaso 4.17M events, VSS included).
-Per-object detail: `<object>.md` in this dir. The first-round catalogues
-(`car-provenance/`) and the LS24-corrective (`car-provenance-lonewolf/`) are the
-priors this builds on.
+Per-object detail: one `<object>.md` per CAR object in this dir. The first-round
+property-provenance catalogues in the parent directory are the priors this builds on.
 
 ## The five recurring patterns (this is the real finding)
 Almost every gap is one of five shapes — and most are **cheap re-emits of data plaso

--- a/docs/car-provenance/lonewolf-fs-recheck/email.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/email.md
@@ -23,7 +23,7 @@ populated from disk**.
 
 ## Ground truth — LoneWolf `DESKTOP-PM6C56D.jsonl`
 
-Source: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+Source: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
 (6.6 GB, 4,169,774 rows). User = **`jcloudy` (Jim Cloudy)**. Mail client = **Windows 10
 Mail app** (`microsoft.windowscommunicationsapps` / `Comms.Apps.Messaging` / `Unistore.dll`),
 **not** classic Outlook.

--- a/docs/car-provenance/lonewolf-fs-recheck/file.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/file.md
@@ -1,7 +1,7 @@
 # CAR `file` — FILESYSTEM / disk-artefact provenance, deep sweep (LoneWolf)
 
 Second-pass, filesystem-focused re-audit of the CAR **file** object. Builds on
-`scratchpad/car-provenance-lonewolf/file.md` (which covered LNK / shell items /
+`../file.md` (which covered LNK / shell items /
 jump-list shell-items / USN / Recycle Bin / filestat, the user-from-path gap, the
 LNK "Not a time" drop, and the $MFT-absent finding). This pass hunts the
 **disk/filesystem artefacts that could fill `file` properties but the pipeline is

--- a/docs/car-provenance/lonewolf-fs-recheck/flow.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/flow.md
@@ -105,7 +105,7 @@ Legend — **mined?**: **mapped-0** = an active map exists but has no input rows
 - **hosts file** — filestat sees the file; content is not parsed, and a static name→IP map is not a flow event.
 
 ## Key file references
-- Real data: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`; inventory `scratchpad/car-provenance-fs/_datatypes.txt`.
+- Real data: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (data_type inventory tallied over that file).
 - Mapped-but-empty SRUM: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_srum.py:73`; source decl `piiat_mitrecar/sources_model.py:120`; SRUM two-step lane `ansible/collections/get_sybers.dxdfir/roles/dxdfir_zimmerman/` (output `data_store/processed/zimmerman/` — empty).
 - Plaso lane (no `--parsers`, default preset): `python/get_sybers_dxdfir/plaso.py:312`; argv `roles/dxdfir_plaso/defaults/main.yml`.
 - NetworkList mis-route: `piiat_mitrecar/mappings/plaso_registry.py` (`plaso_is_registry`, all `windows:registry:*`).

--- a/docs/car-provenance/lonewolf-fs-recheck/http.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/http.md
@@ -7,7 +7,7 @@ Zone.Identifier). READ-ONLY. This pass is the FS-artefact complement to the comm
 `docs/car-provenance/http.md` (which is Zeek/BITS/network-centric); it grounds the "browser
 depth beyond Firefox" gap (that doc's ranked item #4) in the **real LoneWolf Win10 image**.
 
-- **Real evidence:** `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+- **Real evidence:** `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
   (LoneWolf `LoneWolf.E01` via Plaso, 6.6 GB). Every count below is a full-file tally.
 - **Engine http maps:** `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_web.py`
   (msiecf / firefox_cache / firefox_places / javaidx), `core.py` (zeek), `evtx_extra.py` (BITS).

--- a/docs/car-provenance/lonewolf-fs-recheck/process.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/process.md
@@ -5,7 +5,7 @@
 a program, its command line, its launching user or its scheduled/autostart recipe — deliberately
 scoped to artefacts the earlier LoneWolf re-check **did not** analyse.
 
-**Builds on (do NOT redo):** `scratchpad/car-provenance-lonewolf/process.md` already settled the
+**Builds on (do NOT redo):** `../process.md` already settled the
 execution-artefact family — **prefetch, amcache, shimcache/appcompatcache, userassist, BAM, SRUM** —
 and the `user`-from-`\Users\<name>\` gap. Those findings stand; this document assumes them and covers
 everything else on disk.
@@ -13,8 +13,8 @@ everything else on disk.
 **Evidence (full-file, not sampled from a fixture):**
 `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB, `LoneWolf.E01` via plaso).
 Host `DESKTOP-PM6C56D`; principal user `jcloudy` (SID domain `S-1-5-21-2734969515-1644526556-1039763013`).
-Every count below is a full-file tally (`scratchpad/car-provenance-fs/datatype_hist.txt`); every quoted
-record is a verbatim real row (`scratchpad/car-provenance-fs/samples.json`).
+Every count below is a full-file tally over that JSONL; every quoted
+record is a verbatim real row from it.
 
 **Maps checked:** `piiat_mitrecar/mappings/{plaso_exec,plaso_registry,plaso_shellitem,plaso_fs_extra,
 plaso_artifacts,jlecmd,recmd}.py`; `piiat_mitrecar/{crosssource.py,relationships.yml,

--- a/docs/car-provenance/lonewolf-fs-recheck/registry.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/registry.md
@@ -2,10 +2,10 @@
 
 Deep-audit of the MITRE CAR **registry** object against the real Windows-10 **LoneWolf**
 disk-registry evidence, focused on **hive content the pipeline drops** rather than the
-per-field basics (those are in `../car-provenance-lonewolf/registry.md`). Every count
+per-field basics (those are in `../registry.md`). Every count
 below is measured this pass over the actual plaso JSONL. READ-ONLY.
 
-- **Evidence:** `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+- **Evidence:** `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
   (6.6 GB, 4,169,774 rows; **1,512,651** are `windows:registry:*`).
 - **Maps under audit:** `third_party/piiat-mitrecar/piiat_mitrecar/mappings/plaso_registry.py`
   (predicate `startswith("windows:registry:")`, action **key_edit**) and `recmd.py`

--- a/docs/car-provenance/lonewolf-fs-recheck/socket.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/socket.md
@@ -1,6 +1,6 @@
 # CAR `socket` — FILESYSTEM/disk Property-Provenance Audit (unmined-artefact hunt)
 
-FS/disk companion to the earlier memory-grounded catalogue (`../car-provenance/socket.md`).
+FS/disk companion to the earlier memory-grounded catalogue (`../socket.md`).
 That pass established the **live/memory** truth: the *only* active socket source in this pipeline is
 Volatility3 `windows.piiat.network`/`netscan` → `socket`/`listen` (memory), and WFP 5158 → `socket`/`bind`
 is built-but-inert. **This pass asks a different question: what DISK artefacts record a bound/listening
@@ -167,7 +167,7 @@ conflates "the firewall would permit this app to listen on 9955" with "this app 
   *action* is a command line; whether that command binds a port is opaque on disk (would require parsing the
   target binary's behaviour). No disk field expresses a task-opened socket.
 
-## 5. Cross-reference to the memory pass (`../car-provenance/socket.md`)
+## 5. Cross-reference to the memory pass (`../socket.md`)
 
 - **Consistent:** that pass found the active socket object is memory-only / `listen`-only / local-end-only,
   with WFP 5158 `bind` inert and `remote_*`/`local_path`/`close` unsourced. This FS pass confirms **disk adds

--- a/docs/car-provenance/lonewolf-fs-recheck/thread.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/thread.md
@@ -248,7 +248,7 @@ unmined by the current pipeline (captured as filenames, never parsed).
 
 ---
 
-## 8. Key files & evidence (absolute paths)
+## 8. Key files & evidence
 
 - Evidence: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB)
 - Canonical model: `car_data_model.json` (L337-363);

--- a/docs/car-provenance/lonewolf-fs-recheck/thread.md
+++ b/docs/car-provenance/lonewolf-fs-recheck/thread.md
@@ -6,7 +6,7 @@
 artefacts** only: WER, crash dumps / minidumps, `hiberfil.sys` / `pagefile.sys` / `MEMORY.DMP`
 (memory-on-disk), prefetch, scheduled tasks — **not** event logs (Sysmon EID 8) and **not** live
 memory (Volatility), both of which are the runtime lanes already catalogued in
-`scratchpad/car-provenance/thread.md` (LS24).
+`../thread.md` (LS24).
 
 **Bottom line up front (the honest headline this pass exists to confirm):**
 `thread` has **near-zero filesystem provenance**. It is a runtime object sourced almost entirely
@@ -24,7 +24,7 @@ start_module, start_module_name, tgt_pid, tgt_tid, uid, user, user_stack_base, u
 (Authoritative: `car_data_model.json` L337-363; `third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`.)
 
 **Evidence (full-file tallies, read verbatim — not a thin fixture):**
-`/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
+`data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl`
 (6.6 GB, LoneWolf `LoneWolf.E01` via plaso). Host `DESKTOP-PM6C56D`; the only real interactive user
 is **`jcloudy`** (+ `defaultuser0` OOBE). 66 distinct `data_type`s in the whole timeline.
 
@@ -250,12 +250,12 @@ unmined by the current pipeline (captured as filenames, never parsed).
 
 ## 8. Key files & evidence (absolute paths)
 
-- Evidence: `/opt/github/DX_DFIR/data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB)
-- Canonical model: `/opt/github/DX_DFIR/car_data_model.json` (L337-363);
-  `/opt/github/DX_DFIR/third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`
+- Evidence: `data_store/processed/log2timeline/jsonl/DESKTOP-PM6C56D.jsonl` (6.6 GB)
+- Canonical model: `car_data_model.json` (L337-363);
+  `third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`
 - Only `thread` producer (runtime, out of scope): `…/piiat_mitrecar/mappings/sysmon.py` (L442-467, EID 8)
 - `fs:stat` → **file** object (never thread): `…/piiat_mitrecar/mappings/plaso_fs_extra.py`
-- Prior runtime catalogue (Sysmon EID 8 + memory lanes): `scratchpad/car-provenance/thread.md`
+- Prior runtime catalogue (Sysmon EID 8 + memory lanes): `../thread.md`
 - Confirmed ABSENT from the pipeline (grep, zero matches): any minidump / WER / crashdump / hiberfil /
   pagefile parser or map across `piiat_mitrecar`, `piiat-mem/piiat_mem`, `sources`, `python/`.
 - Real disk artefacts (all `fs:stat` metadata only, contents unparsed): crash dumps

--- a/docs/car-provenance/socket.md
+++ b/docs/car-provenance/socket.md
@@ -5,7 +5,7 @@ listening events in particular can be helpful in detecting malicious activity."*
 **Canonical fields (10):** `family`, `image_path`, `local_address`, `local_path`, `local_port`, `pid`,
 `protocol`, `remote_address`, `remote_port`, `success`
 **Actions (3):** `bind`, `listen`, `close`
-**Repo:** `/opt/github/DX_DFIR` — READ-ONLY audit, evidence as of 2026-09-07.
+READ-ONLY audit, evidence as of 2026-09-07.
 
 Grounded in:
 - `third_party/piiat-mitrecar/third_party/car/data_model/socket.yaml` + `docs/data_model/socket.md` (semantics + upstream coverage map)

--- a/docs/car-provenance/thread.md
+++ b/docs/car-provenance/thread.md
@@ -7,7 +7,7 @@ READ-ONLY analysis.
 
 ## Canonical object (authoritative)
 
-Source of truth: `/opt/github/DX_DFIR/car_data_model.json` (lines 337-363) and
+Source of truth: `car_data_model.json` (lines 337-363) and
 `third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`.
 
 - **Fields (15):** hostname, src_pid, src_tid, tgt_pid, tgt_tid, stack_base, stack_limit,
@@ -204,17 +204,17 @@ present. Split by lane:
    real event carries none of them directly (`user` is only reachable by inheritance, `uid`/`src_tid`
    not at all). Documentation-vs-reality mismatch worth noting when trusting the upstream coverage map.
 
-## Key files (absolute paths)
+## Key files
 
-- Canonical model: `/opt/github/DX_DFIR/car_data_model.json` (L337-363);
-  `/opt/github/DX_DFIR/third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`
-- Sysmon EID 8 map: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/mappings/sysmon.py` (L442-467)
-- Sysmon source card: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/sources/evtx_sysmon.yaml` (L319-353)
-- Plaso alt-derivation of EID 8: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/adapters/winevt.py` (L95-98)
-- Sysmon-lane enrich (inherit + R5 dual-link): `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/enrich.py` (L257-260, L488-498); rules `/opt/github/DX_DFIR/third_party/piiat-mitrecar/piiat_mitrecar/relationships.yml` (L21-29)
-- Memory threads plugin: `/opt/github/DX_DFIR/third_party/piiat-mem/plugins/windows/piiat/threads.py`
-- Memory CAR map: `/opt/github/DX_DFIR/third_party/piiat-mem/piiat_mem/mappings.py` (L204-222 piiat.threads, L261-272 thrdscan fallback, L99-104 SUPERSEDES)
-- Memory-lane enrich (host id + inherit): `/opt/github/DX_DFIR/third_party/piiat-mem/piiat_mem/enrich.py` (L72, L288-291, L309-324, L377-380)
-- Injection analytics: `/opt/github/DX_DFIR/third_party/piiat-mitrecar/third_party/car/analytics/CAR-2013-10-002.yaml` (LoadLibrary injection); `.../CAR-2021-05-011.yaml` (remote thread into LSASS)
-- R5 relationship doc: `/opt/github/DX_DFIR/docs/CAR-Relations.md` (L154)
-- Evidence checked (both empty of thread data): `/opt/github/DX_DFIR/data_store/processed/volatility/memdump.mem/plugins/` (no threads jsonl); `/opt/github/DX_DFIR/data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json` (EID 1/5 only)
+- Canonical model: `car_data_model.json` (L337-363);
+  `third_party/piiat-mitrecar/third_party/car/data_model/thread.yaml`
+- Sysmon EID 8 map: `third_party/piiat-mitrecar/piiat_mitrecar/mappings/sysmon.py` (L442-467)
+- Sysmon source card: `third_party/piiat-mitrecar/sources/evtx_sysmon.yaml` (L319-353)
+- Plaso alt-derivation of EID 8: `third_party/piiat-mitrecar/piiat_mitrecar/adapters/winevt.py` (L95-98)
+- Sysmon-lane enrich (inherit + R5 dual-link): `third_party/piiat-mitrecar/piiat_mitrecar/enrich.py` (L257-260, L488-498); rules `third_party/piiat-mitrecar/piiat_mitrecar/relationships.yml` (L21-29)
+- Memory threads plugin: `third_party/piiat-mem/plugins/windows/piiat/threads.py`
+- Memory CAR map: `third_party/piiat-mem/piiat_mem/mappings.py` (L204-222 piiat.threads, L261-272 thrdscan fallback, L99-104 SUPERSEDES)
+- Memory-lane enrich (host id + inherit): `third_party/piiat-mem/piiat_mem/enrich.py` (L72, L288-291, L309-324, L377-380)
+- Injection analytics: `third_party/piiat-mitrecar/third_party/car/analytics/CAR-2013-10-002.yaml` (LoadLibrary injection); `.../CAR-2021-05-011.yaml` (remote thread into LSASS)
+- R5 relationship doc: `docs/CAR-Relations.md` (L154)
+- Evidence checked (both empty of thread data): `data_store/processed/volatility/memdump.mem/plugins/` (no threads jsonl); `data_store/processed/windows_logs/unspecified_host/log_EvtxECmd_Output.json` (EID 1/5 only)

--- a/docs/car-provenance/user_session.md
+++ b/docs/car-provenance/user_session.md
@@ -1,6 +1,6 @@
 # CAR `user_session` — Property-Provenance Catalogue
 
-Authoritative "find once, done" map of **every canonical field × every artefact/source that can supply it** for the MITRE CAR **`user_session`** object, as implemented in this repo (`/opt/github/DX_DFIR`). Grounded in the pinned CAR data model, the engine mappings, the generated source YAMLs, and real evidence in `data_store/processed/`.
+Authoritative "find once, done" map of **every canonical field × every artefact/source that can supply it** for the MITRE CAR **`user_session`** object, as implemented in this repo. Grounded in the pinned CAR data model, the engine mappings, the generated source YAMLs, and real evidence in `data_store/processed/`.
 
 - **Object def (pinned):** `third_party/piiat-mitrecar/third_party/car/data_model/user_session.yaml`; `car_data_model.json` (lines 364–388).
 - **Fields (10):** `dest_ip, dest_port, hostname, login_id, login_successful, login_type, src_ip, src_port, uid, user`


### PR DESCRIPTION
Addresses the inline review on #148 (merged) across the `lonewolf-fs-recheck/` and `crosslink/` catalogues. Copilot flagged four files; I swept **all** of them for the same shapes.

- **Dead sibling links.** From inside `lonewolf-fs-recheck/`, a link `../car-provenance/socket.md` resolves to `car-provenance/car-provenance/socket.md` (doubled) — the file it means is the sibling `../socket.md`. Fixed every occurrence. References to the never-committed scratch dirs (`car-provenance-lonewolf/`, `scratchpad/car-provenance*/`) now point at the committed first-round catalogue in the parent dir.
- **Portability.** Stripped absolute `/opt/github/DX_DFIR/…` evidence paths to repo-relative `data_store/processed/…`. Replaced the ephemeral `/tmp/claude-0/.../scratchpad/...` working-files path in `crosslink/cmdlines.md` with a note (the projections are reproducible from `data_store/processed/`).

**Verified:** no residual `/opt/github`, `/tmp`, or `scratchpad/car-provenance` paths, and every `../<file>.md` link resolves to an existing catalogue. There is no CI markdown-link check, so this is correctness/portability of the docs themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)