### PR TITLE
fix(ci): make ansible-lint pass — rename typo + long line (and surface violations)

### DIFF
--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_deploy_sofelk/tasks/deploy.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_deploy_sofelk/tasks/deploy.yml
@@ -27,7 +27,13 @@
 - name: "deploy-sofelk | assert the sof-elk + elasticsearch services are running"
   ansible.builtin.assert:
     that:
-      - dxdfir_deploy_sofelk_state.containers | selectattr('Service', 'equalto', 'sof-elk') | selectattr('State', 'equalto', 'running') | list | length > 0
-      - dxdfir_deploy_sofelk_state.containers | selectattr('Service', 'equalto', 'elasticsearch') | selectattr('State', 'equalto', 'running') | list | length > 0
+      - >-
+          dxdfir_deploy_sofelk_state.containers
+          | selectattr('Service', 'equalto', 'sof-elk')
+          | selectattr('State', 'equalto', 'running') | list | length > 0
+      - >-
+          dxdfir_deploy_sofelk_state.containers
+          | selectattr('Service', 'equalto', 'elasticsearch')
+          | selectattr('State', 'equalto', 'running') | list | length > 0
     fail_msg: "the SOF-ELK stack is not fully running: {{ dxdfir_deploy_sofelk_state.containers | map(attribute='Name') | list }}"
     quiet: true

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/README.md
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/README.md
@@ -30,7 +30,7 @@ as a **single action**. One `<lane>/` folder of detections under the output base
 | `dxdfir_signatures_pipeline` | `elastic` | `elastic` or `sofelk` — selects the output destination (the **playbook** decides this). |
 | `dxdfir_signatures_elastic_out_dir` | `<repo>/data_store/processed/signatures` | Elastic-path output base. |
 | `dxdfir_signatures_sofelk_out_dir` | `<repo>/data_store/processed/sofelk/signatures` | SOF-ELK-path output base. |
-| `dxdxdfir_signatures_lanes` | `[]` (all) | Lanes to run — any of `yara`, `suricata`, `hayabusa`. |
+| `dxdfir_signatures_lanes` | `[]` (all) | Lanes to run — any of `yara`, `suricata`, `hayabusa`. |
 | `dxdfir_signatures_stage_dir` | `""` (evtx processor's stage) | Where the hayabusa lane stages disk-image EVTX extractions; already-staged images are reused, never re-extracted. |
 | `dxdfir_signatures_vss` | `false` | Include Volume Shadow Copies when staging disk images. |
 | `dxdfir_signatures_yara_sources` | `""` (all) | YARA sources to run — comma list of `files,disk,memory`. |
@@ -94,7 +94,7 @@ processor, never in a task `when:`. The verify gate tolerates a zero-detection r
 ```bash
 ansible-playbook playbooks/dxdfir-process-signatures.yml -e dxdfir_signatures_pipeline=elastic
 # one lane:
-ansible-playbook playbooks/dxdfir-process-signatures.yml -e '{"dxdxdfir_signatures_lanes":["yara"]}'
+ansible-playbook playbooks/dxdfir-process-signatures.yml -e '{"dxdfir_signatures_lanes":["yara"]}'
 ```
 
 ## Testing

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
@@ -12,7 +12,7 @@ dxdfir_signatures_sofelk_out_dir: "{{ dxdfir_signatures_repo_root }}/data_store/
 # tasks/process.yml. Override directly to send output to a custom location.
 dxdfir_signatures_out_dir: "{{ dxdfir_signatures_elastic_out_dir if dxdfir_signatures_pipeline == 'elastic' else dxdfir_signatures_sofelk_out_dir }}"
 # Which detection lanes to run; empty = all (yara, suricata, hayabusa).
-dxdxdfir_signatures_lanes: []
+dxdfir_signatures_lanes: []
 # Where the hayabusa lane stages disk-image EVTX extractions (empty => the evtx
 # processor's own stage, data_store/processed/windows_logs/_extracted_evtx —
 # images already staged by either lane are reused, never re-extracted).
@@ -36,7 +36,7 @@ dxdfir_signatures_force: false
 # is the one genuinely per-lane piece; the run/verify/gate skeleton is shared.
 dxdfir_signatures_argv: >-
   {{ ['python3', '-m', 'get_sybers_dxdfir.signatures', '--output-dir', dxdfir_signatures_out_dir, '--repo-root', dxdfir_signatures_repo_root]
-  + (dxdxdfir_signatures_lanes | map('regex_replace', '^', '--only=') | list)
+  + (dxdfir_signatures_lanes | map('regex_replace', '^', '--only=') | list)
   + (['--stage-dir', dxdfir_signatures_stage_dir] if dxdfir_signatures_stage_dir | length > 0 else [])
   + (['--vss'] if dxdfir_signatures_vss | bool else [])
   + (['--yara-sources', dxdfir_signatures_yara_sources] if dxdfir_signatures_yara_sources | length > 0 else [])

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
@@ -35,7 +35,7 @@ argument_specs:
           Resolved output base for the selected pipeline (defaults to the
           elastic/sofelk out dir per dxdfir_signatures_pipeline); override to send
           output to a custom location.
-      dxdxdfir_signatures_lanes:
+      dxdfir_signatures_lanes:
         type: list
         elements: str
         required: false

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/molecule/default/converge.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/molecule/default/converge.yml
@@ -6,7 +6,7 @@
     dxdfir_signatures_pipeline: elastic
     dxdfir_signatures_repo_root: /tmp/dxdfir_signatures_molecule/repo
     dxdfir_signatures_elastic_out_dir: /tmp/dxdfir_signatures_molecule/repo/data_store/processed/signatures
-    dxdxdfir_signatures_lanes: [yara]
+    dxdfir_signatures_lanes: [yara]
     # the fake repo has no python package — point PYTHONPATH at the real repo.
     dxdfir_signatures_python_path: "{{ (playbook_dir + '/../../../../../../../python') | realpath }}"
   tasks:

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/tasks/main.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/tasks/main.yml
@@ -8,9 +8,9 @@
   ansible.builtin.assert:
     that:
       - dxdfir_signatures_pipeline in ['elastic', 'sofelk']
-      - dxdxdfir_signatures_lanes | difference(['yara', 'suricata', 'hayabusa']) | length == 0
+      - dxdfir_signatures_lanes | difference(['yara', 'suricata', 'hayabusa']) | length == 0
     fail_msg: >-
-      dxdfir_signatures needs dxdfir_signatures_pipeline (elastic|sofelk); dxdxdfir_signatures_lanes
+      dxdfir_signatures needs dxdfir_signatures_pipeline (elastic|sofelk); dxdfir_signatures_lanes
       may only contain yara/suricata/hayabusa.
     quiet: true
   tags: [always]

--- a/python/README.md
+++ b/python/README.md
@@ -27,7 +27,7 @@ The Elastic detection rules live as data under `get_sybers_dxdfir/detect/rules/`
 ## The `dxdfir` CLI
 ```bash
 dxdfir process zeek --pipeline elastic  # drive the dxdfir_zeek role (preflight → process → verify)
-dxdfir process signatures -e '{"dxdxdxdfir_signatures_lanes":["yara"]}'
+dxdfir process signatures -e '{"dxdfir_signatures_lanes":["yara"]}'
 dxdfir build-car                        # normalise every processed source into per-source CAR stores
 dxdfir verify-car                       # the CAR correctness gate over the materialised CAR
 dxdfir build-docker                     # build (and hardening-verify) every dxdfir/* tool image

--- a/python/man/dxdfir.1
+++ b/python/man/dxdfir.1
@@ -190,7 +190,7 @@ Pass an extra Ansible variable through to the role; repeatable. Use it to overri
 a role default, e.g.
 .RB \(lq -e\  dxdfir_zeek_pcap_dir=/evidence/pcaps \(rq
 or
-.RB \(lq -e\  \(aq{\(dqdxdxdfir_signatures_lanes\(dq:[\(dqyara\(dq]}\(aq \(rq.
+.RB \(lq -e\  \(aq{\(dqdxdfir_signatures_lanes\(dq:[\(dqyara\(dq]}\(aq \(rq.
 .SS build-car
 .TP
 .BI --in " PATH"
@@ -273,7 +273,7 @@ Reprocess memory images, overriding the input directory:
 .B dxdfir process volatility --force -e dxdfir_volatility_memory_dir=/evidence/mem
 .TP
 Run only the YARA signature lane:
-.B dxdfir process signatures -e \(aq{\(dqdxdxdfir_signatures_lanes\(dq:[\(dqyara\(dq]}\(aq
+.B dxdfir process signatures -e \(aq{\(dqdxdfir_signatures_lanes\(dq:[\(dqyara\(dq]}\(aq
 .TP
 Normalise everything processed into CAR, then gate it:
 .B dxdfir build-car && dxdfir verify-car

--- a/tests/run-checks.sh
+++ b/tests/run-checks.sh
@@ -103,10 +103,13 @@ group "Ansible lint"
 # Production-profile ansible-lint over the collection (config: the collection's
 # .ansible-lint). Skipped when ansible-lint is not installed (CI installs it).
 if command -v ansible-lint >/dev/null 2>&1; then
-    if ansible-lint --profile production >/dev/null 2>&1; then
+    # Capture (don't discard) the output so a failure is diagnosable in the log
+    # instead of an opaque "reported violations" with no detail.
+    if _al_out="$(ansible-lint --profile production 2>&1)"; then
         pass "ansible-lint (production profile) on the collection + container ansible"
     else
         fail "ansible-lint reported violations (run: ansible-lint --profile production)"
+        printf '%s\n' "$_al_out" | sed 's/^/      /'
     fi
 else
     skip "ansible-lint not installed"


### PR DESCRIPTION
`main`'s `checks` job has been red on `ansible-lint --profile production` — every PR since has shown `BLOCKED` and needed an admin override. It is **not** linter-version noise; there were two real, fixable defects, plus a diagnosability gap that hid them.

### Why it was undiagnosable
`tests/run-checks.sh` piped ansible-lint to `/dev/null`, so a failure logged only an opaque *"reported violations"* with no detail. First commit captures the output and prints it (indented) under the fail line. That immediately surfaced:

### The two real violations
1. **`var-naming[no-role-prefix]`** — the `dfir→dxdfir` rename double-prefixed the signatures-lane variable to **`dxdxdfir_signatures_lanes`** (in `defaults`, `tasks`, `argument_specs`, `molecule`, plus README/man examples). Renamed to the correct `dxdfir_signatures_lanes` throughout. The role wiring (→ `--only=` args) and the CLI (`--only`) don't reference the name, so nothing functional changes; 353 python tests still pass.
2. **`yaml[line-length]`** — `dxdfir_deploy_sofelk/tasks/deploy.yml:31` was 161 chars (limit 160). Folded both service-running asserts into block scalars (`>-`), which parse to the identical Jinja expressions (verified); longest line now 130.

### Result
`checks` job is **green** on this branch — ansible-lint passes the production profile. Merging this clears the chronic red for every future PR (no more admin overrides for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)