### PR TITLE
fix(plaso): preserve REG_BINARY registry values via --extract_winreg_binary (B4)

### DIFF
--- a/docs/car-provenance/crosslink/B4-plaso-binary-value-loss.md
+++ b/docs/car-provenance/crosslink/B4-plaso-binary-value-loss.md
@@ -1,0 +1,103 @@
+# B4 — plaso drops REG_BINARY values before the pipeline can normalise them
+
+**Status:** fixed at extraction time (see the fix below). Downstream decoding of the
+recovered bytes into serial/MAC/disk-signature fields is still open (out of B4's scope).
+
+The cross-source value hunt (`ports_serials.md`, `guids.md`) flagged that plaso renders
+Windows registry **REG_BINARY** values as a size summary (`(6 bytes)`, `(224 bytes)`)
+instead of the actual bytes, dropping forensically decisive device-identity values —
+`MountedDevices` drive-letter → device bindings, disk signatures, USB/volume serials —
+*before* the pipeline could normalise them. This documents exactly where that loss
+happens, why it is an extraction-time (not output-time) loss, and the fix.
+
+## Where the loss happens (exact, not inferred)
+
+`log2timeline` (extraction), **not** psort (rendering). In the plaso image
+(`plaso==20260720`), `plaso/parsers/winreg_plugins/interface.py`, method
+`_GetValuesFromKey`:
+
+```python
+elif registry_value.DataIsInteger() or registry_value.DataIsString():
+    value_string = str(value_object)
+elif parser_mediator.extract_winreg_binary_values:
+    value_string = registry_value.data            # raw bytes preserved
+else:
+    # Add a place holder for remaining types such as REG_BINARY and
+    # REG_RESOURCE_REQUIREMENT_LIST.
+    value_data_size = len(value_object)
+    value_string = f"({value_data_size:d} bytes)"  # <-- the loss
+```
+
+`parser_mediator.extract_winreg_binary_values` is fed by the log2timeline CLI option
+`--extract_winreg_binary` (`plaso/cli/helpers/extraction.py`), which **defaults to
+False**. So by default REG_BINARY becomes the string `"(N bytes)"` and the raw bytes are
+never written to the `.plaso` storage db. Because the loss is at parse time, **re-running
+psort cannot recover the bytes** — they are not in the `.plaso` db. It has to be fixed on
+the `log2timeline` step.
+
+This path is taken by the **default** registry plugin (`winreg_default`), which is what
+handles `HKLM\System\MountedDevices` and generic `Tcpip`/device REG_BINARY values (no
+dedicated plugin claims those keys). Note the `NetworkList` plugin (`networks.py`) already
+decodes its own `DefaultGatewayMac` Signatures value to a hex MAC — that specific value is
+not lost; the generic-binary loss is the MountedDevices / default-plugin surface.
+
+The JSON output module was **already** capable of emitting the bytes: for
+`windows:registry:key_value` (and `:service`), `plaso/output/shared_json.py`
+`_FormatValues` base64url-encodes any value whose `data` is `bytes`. So no output-module
+change is needed — the only thing missing was the extraction flag that puts real `bytes`
+(instead of the `"(N bytes)"` string) into `event_data.values`.
+
+## Real, reproduced example (before/after)
+
+Source: `jo-2009-11-20-newComputer.E01` (the M57-JO image behind
+`data_store/processed/log2timeline/jsonl/M57-JO.jsonl`). Extracted its
+`\WINDOWS\system32\config\system` hive with `image_export.py` and parsed it twice.
+
+Key `HKEY_LOCAL_MACHINE\System\MountedDevices`, value `\DosDevices\C:`:
+
+**Before (default — matches the shipped M57-JO.jsonl):**
+```json
+{"data": "(12 bytes)", "data_type": "REG_BINARY", "name": "\\DosDevices\\C:"}
+```
+
+**After (`log2timeline.py --extract_winreg_binary`):**
+```json
+{"data": {"__encoding__": "base64url", "__type__": "bytes",
+          "stream": "xIHEgQB-AAAAAAAA"}, "data_type": "REG_BINARY",
+ "name": "\\DosDevices\\C:"}
+```
+
+`base64url("xIHEgQB-AAAAAAAA")` = `c4 81 c4 81 00 7e 00 00 00 00 00 00` — the 12 bytes are
+the NTFS **disk signature `0x81C481C4`** (LE u32) + **partition offset `32256`** (LE u64),
+which is exactly the `start_offset: 32256` in the event's own path spec. That is the value
+that binds drive letter `C:` to the physical disk — previously thrown away as `(12 bytes)`.
+The USB/removable entries in the same key (`\??\Volume{...}`, `\DosDevices\D:`) likewise
+come back as their full byte streams (device-instance / volume-serial bytes), which is the
+`MountedDevices` USB-serial binding the hunt called out.
+
+## The fix
+
+`python/get_sybers_dxdfir/plaso.py` — add `--extract_winreg_binary` to the `log2timeline`
+argv in `run_plaso`. One option, no new dependency, no plaso patch. Covered by
+`python/tests/test_plaso.py::test_run_plaso_log2timeline_extracts_winreg_binary`.
+
+**Cost:** plaso warns `--extract_winreg_binary` "can make processing significantly slower".
+That is the correct trade for a pipeline whose stated value is device crosslinking — the
+alternative is permanent loss of the serial/MAC/disk-signature at extraction.
+
+## Options evaluated
+
+| option | verdict |
+|---|---|
+| psort output-format change / re-render existing `.plaso` | **No** — bytes aren't in the db when parsed without the flag; loss is upstream of psort. |
+| A different psort output module | **No** — same reason; and `shared_json._FormatValues` already handles bytes. |
+| Post-extraction re-read of specific keys via dfVFS/dfwinreg | Works but is a second bespoke pass; unnecessary given a first-class extraction flag exists. |
+| **`log2timeline --extract_winreg_binary`** | **Chosen** — first-class, comprehensive over all default-plugin REG_BINARY, proven above. |
+
+## Still open (downstream, not B4)
+
+The recovered value is **base64url-encoded raw bytes**, not a decoded serial/MAC/disk
+signature. Turning those bytes into normalised CAR fields (drive-letter→disk-signature,
+`MountedDevices`→USB volume serial, gateway/creator MAC) is a normalisation step for the
+CAR-crosslink epic — B4 only guarantees the bytes now survive extraction so that step is
+possible at all.

--- a/python/get_sybers_dxdfir/plaso.py
+++ b/python/get_sybers_dxdfir/plaso.py
@@ -5,7 +5,10 @@ image (and each VMware VM export) it runs the Plaso two-step in the
 ``log2timeline/plaso`` container:
 
   1. ``log2timeline.py`` parses the image into a durable ``.plaso`` storage db (kept
-     so an analyst can re-run psort later without re-parsing the image).
+     so an analyst can re-run psort later without re-parsing the image). Run with
+     ``--extract_winreg_binary`` so REG_BINARY registry values (MountedDevices
+     drive-letter -> device bindings, device serials, MACs) are stored as raw
+     bytes rather than dropped to a lossy ``(N bytes)`` summary at parse time.
   2. ``psort.py -o l2t_json_dxdfir`` renders the db to json_line with the repo's
      custom output module (dev-scripts/plaso/l2t_json_dxdfir.py), which adds
      image_hostname / username / disk_id / volume_id to EVERY event.
@@ -313,11 +316,28 @@ def run_plaso(mount_dir, src_rel, name, out_dir, module_path, image=_IMAGE) -> d
     with open(log, "w") as logfh:
         # 1) parse image -> .plaso (minimal hardened image:
         #    tool argv passed directly, no caps, no network, read-only rootfs)
+        #
+        #    --extract_winreg_binary: preserve REG_BINARY values as their raw
+        #    bytes in the .plaso db. WITHOUT it, log2timeline's winreg parser
+        #    (winreg_plugins/interface.py:_GetValuesFromKey) drops every binary
+        #    value to a lossy "(N bytes)" summary BEFORE it reaches storage, so
+        #    the raw serial/MAC/disk-signature is gone and psort can never
+        #    recover it. This loses forensically decisive device-identity bytes:
+        #      * HKLM\System\MountedDevices  (\DosDevices\C:/D:/... -> disk
+        #        signature + offset / USB volume serial binding a drive letter
+        #        to a physical device),
+        #      * Tcpip / other REG_BINARY device values handled by the default
+        #        registry plugin.
+        #    With the flag the bytes survive into event_data.values and the JSON
+        #    output module base64url-encodes them (output/shared_json.py:
+        #    _FormatValues), so they are recoverable downstream. Costs some
+        #    extraction speed (plaso warns "significantly slower") — the right
+        #    trade for a DFIR pipeline whose value is device crosslinking.
         subprocess.run(
             container.run(
                 image,
                 ["log2timeline.py", "--status_view", "none", "--partitions", "all",
-                 "--vss-stores", "all",
+                 "--vss-stores", "all", "--extract_winreg_binary",
                  "--storage-file", f"/output/plaso/{name}.plaso", f"/data/{src_rel}"],
                 mounts=[f"{os.path.realpath(mount_dir)}:/data:ro",
                         f"{os.path.realpath(out_dir)}:/output"],

--- a/python/tests/test_plaso.py
+++ b/python/tests/test_plaso.py
@@ -181,3 +181,45 @@ def test_sanitize_host():
 def test_process_no_inputs_is_clean(tmp_path):
     s = plaso.process(str(tmp_path / "in"), "", str(tmp_path / "out"), "module.py")
     assert s["images"] == 0 and s["vms"] == 0 and s["processed"] == 0 and s["failed"] == 0
+
+
+# ---- REG_BINARY preservation (B4) ------------------------------------------
+def test_run_plaso_log2timeline_extracts_winreg_binary(tmp_path, monkeypatch):
+    """log2timeline must run with --extract_winreg_binary.
+
+    Without it, plaso's winreg parser drops every REG_BINARY value to a lossy
+    "(N bytes)" summary at parse time — before it reaches the .plaso db — so the
+    raw device-identity bytes (MountedDevices drive-letter bindings, disk
+    signatures, USB/volume serials, MACs) are unrecoverable downstream. The flag
+    keeps the raw bytes; the JSON output module then base64url-encodes them.
+    """
+    out_dir = tmp_path / "out"
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        # Emulate the two container steps producing their outputs so run_plaso
+        # proceeds past its existence checks: log2timeline writes the .plaso db,
+        # psort writes the raw json_line.
+        calls.append(argv)
+        if "log2timeline.py" in argv:
+            (out_dir / "plaso").mkdir(parents=True, exist_ok=True)
+            (out_dir / "plaso" / "img_E01.plaso").write_bytes(b"PLASO")
+        else:
+            (out_dir / "jsonl").mkdir(parents=True, exist_ok=True)
+            (out_dir / "jsonl" / ".img_E01.raw").write_text(
+                '{"image_hostname": "HOST"}\n')
+
+        class _Completed:  # minimal subprocess.CompletedProcess stand-in
+            returncode = 0
+
+        return _Completed()
+
+    monkeypatch.setattr(plaso.subprocess, "run", fake_run)
+    res = plaso.run_plaso(
+        str(tmp_path / "in"), "img.E01", "img_E01", str(out_dir), "module.py")
+
+    assert res["ok"] is True
+    # First container invocation is log2timeline, and it must carry the flag.
+    log2timeline_argv = calls[0]
+    assert "log2timeline.py" in log2timeline_argv
+    assert "--extract_winreg_binary" in log2timeline_argv


### PR DESCRIPTION
## B4 — plaso drops REG_BINARY values before the pipeline can normalise them

The cross-source value hunt (`docs/car-provenance/crosslink/ports_serials.md`, `guids.md`) flagged that plaso renders Windows registry **REG_BINARY** values as a size summary (`(6 bytes)`, `(224 bytes)`) instead of the actual bytes — dropping forensically decisive device-identity values (`MountedDevices` drive-letter → device bindings, disk signatures, USB/volume serials) **before** the pipeline could normalise them.

### Where the loss happens (exact)
`log2timeline` **extraction**, not psort rendering. In `plaso==20260720`, `plaso/parsers/winreg_plugins/interface.py::_GetValuesFromKey`:

```python
elif parser_mediator.extract_winreg_binary_values:
    value_string = registry_value.data            # raw bytes preserved
else:
    value_data_size = len(value_object)
    value_string = f"({value_data_size:d} bytes)"  # <-- the loss
```

`parser_mediator.extract_winreg_binary_values` is fed by the log2timeline CLI option `--extract_winreg_binary`, which **defaults False**. So the raw bytes are never written to the `.plaso` db — meaning **re-running psort cannot recover them**; it must be fixed on the `log2timeline` step. This path is the default registry plugin (`winreg_default`), which handles `HKLM\System\MountedDevices` and generic `Tcpip`/device REG_BINARY values.

The JSON output module was **already** able to emit the bytes — `plaso/output/shared_json.py::_FormatValues` base64url-encodes any `values` entry whose `data` is `bytes` for `windows:registry:key_value`. The only thing missing was the extraction flag that puts real `bytes` (not the `"(N bytes)"` string) into the event data.

### The fix
Add `--extract_winreg_binary` to the `log2timeline` argv in `run_plaso` (`python/get_sybers_dxdfir/plaso.py`). One option, no plaso patch, no output-module change.

### Verified end-to-end
Extracted the `\WINDOWS\system32\config\system` hive from `jo-2009-11-20-newComputer.E01` (the M57-JO source) and parsed it with and without the flag. Key `HKLM\System\MountedDevices`, value `\DosDevices\C:`:

- **Before:** `{"data": "(12 bytes)", "data_type": "REG_BINARY", ...}`
- **After:** `{"data": {"__encoding__": "base64url", "__type__": "bytes", "stream": "xIHEgQB-AAAAAAAA"}, ...}`

`base64url` decodes to `c4 81 c4 81 00 7e 00 00 00 00 00 00` = disk signature `0x81C481C4` + partition offset `32256` (matches the event's own path-spec `start_offset`) — the value binding `C:` to the physical disk, previously discarded.

### Cost
plaso warns `--extract_winreg_binary` "can make processing significantly slower" — the correct trade for a device-crosslinking pipeline vs. permanent loss of the serial/MAC/disk-signature at extraction.

### Still open (downstream, not B4)
Recovered values are base64url raw bytes, not decoded serial/MAC fields. Turning them into normalised CAR fields is a normalisation step for the CAR-crosslink epic; B4 only guarantees the bytes now survive extraction.

### Tests
`python/tests/test_plaso.py::test_run_plaso_log2timeline_extracts_winreg_binary` asserts the flag is in the log2timeline invocation. Full suite: `352 passed, 2 skipped`.

Findings doc: `docs/car-provenance/crosslink/B4-plaso-binary-value-loss.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)