### PR TITLE
fix(pipeline): wire the signatures/detection lane into the sorted collection

### DIFF
--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
@@ -21,6 +21,11 @@ dxdfir_signatures_stage_dir: ""
 dxdfir_signatures_vss: false
 # YARA sources to run (comma list of files,disk,memory); empty = all.
 dxdfir_signatures_yara_sources: ""
+# The captures the suricata sub-lane replays (empty => the processor default,
+# data_store/raw/pcaps). A collection sets this to its sorted pcaps/ subdir
+# (collection.LANES: signatures -> dxdfir_signatures_pcap_dir); without it a
+# sorted collection's captures never reach suricata.
+dxdfir_signatures_pcap_dir: ""
 # Per-pcap Suricata tuning file (INI template; empty => the processor's default,
 # data_store/dependencies/suricata-tuning.conf). Written as an editable template
 # on first run; while template-only or invalid, HOME_NET is auto-detected per
@@ -41,5 +46,6 @@ dxdfir_signatures_argv: >-
   + (['--vss'] if dxdfir_signatures_vss | bool else [])
   + (['--yara-sources', dxdfir_signatures_yara_sources] if dxdfir_signatures_yara_sources | length > 0 else [])
   + (['--tuning-file', dxdfir_signatures_suricata_tuning_file] if dxdfir_signatures_suricata_tuning_file | length > 0 else [])
+  + (['--pcap-dir', dxdfir_signatures_pcap_dir] if dxdfir_signatures_pcap_dir | length > 0 else [])
   + (['--fetch'] if dxdfir_signatures_fetch | bool else [])
   + (['--force'] if dxdfir_signatures_force | bool else []) }}

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
@@ -69,6 +69,16 @@ argument_specs:
           template on first run; while it holds no real sections — or is not valid —
           HOME_NET is auto-detected per pcap and the derived values are recorded
           into it for the operator to edit. Tuning is reset per pcap.
+      dxdfir_signatures_pcap_dir:
+        type: str
+        required: false
+        default: ""
+        description: >-
+          Directory of captures the suricata sub-lane replays (empty => the
+          processor default, data_store/raw/pcaps). A collection sets this to its
+          sorted pcaps/ subdir (collection.LANES: signatures ->
+          dxdfir_signatures_pcap_dir) so a sorted collection's captures reach
+          suricata; without it the sub-lane finds nothing.
       dxdfir_signatures_fetch:
         type: bool
         required: false

--- a/python/get_sybers_dxdfir/cli.py
+++ b/python/get_sybers_dxdfir/cli.py
@@ -240,7 +240,7 @@ def process(
             counts[lane_name] = counts.get(lane_name, 0) + n
 
     if source is Source.all:
-        lanes = [lane.name for lane in _collection.LANES]     # the five evidence lanes
+        lanes = [lane.name for lane in _collection.LANES]     # evidence lanes + the detection lane (last)
         if collection:
             lanes = [ln for ln in lanes if counts.get(ln, 0) > 0]
             if not lanes:

--- a/python/get_sybers_dxdfir/collection.py
+++ b/python/get_sybers_dxdfir/collection.py
@@ -58,6 +58,13 @@ LANES: tuple[Lane, ...] = (
          ("dxdfir_plaso_input_dir", "dxdfir_plaso_vm_dir")),
     Lane("zimmerman", ("disk_images", "VM_files"),
          ("dxdfir_zimmerman_input_dir", "dxdfir_zimmerman_vm_dir")),
+    # The detection lane (yara/suricata/hayabusa). Listed LAST so `process all`
+    # runs it after the evidence lanes (hayabusa reads the processed evtx stage).
+    # Scoped by the pcaps subdir — the input suricata replays; without this the
+    # suricata sub-lane fell back to the empty data_store/raw/pcaps and produced
+    # nothing on a sorted collection (hayabusa/yara use their own processed/tool
+    # inputs). A collection with pcaps therefore drives the detection lane too.
+    Lane("signatures", ("pcaps",), ("dxdfir_signatures_pcap_dir",)),
 )
 
 # The lane subdirs a collection materialises (order = display order).

--- a/python/get_sybers_dxdfir/signatures/__main__.py
+++ b/python/get_sybers_dxdfir/signatures/__main__.py
@@ -53,6 +53,11 @@ def main(argv: list[str] | None = None) -> int:
                          "editable template on first run; while template-only or "
                          "invalid, the automatable vars are auto-detected per pcap and "
                          "recorded into it. Tuning resets per pcap.")
+    ap.add_argument("--pcap-dir",
+                    help="the directory of captures the suricata lane replays "
+                         "(default data_store/raw/pcaps). A collection scopes this to "
+                         "its sorted pcaps/ subdir (dxdfir_signatures_pcap_dir); without "
+                         "it a sorted collection's captures never reach suricata.")
     args = ap.parse_args(argv)
 
     lanes = tuple(args.only) if args.only else LANES
@@ -62,6 +67,7 @@ def main(argv: list[str] | None = None) -> int:
         "auto_home_net": args.auto_home_net,
         "extra_sets": args.suricata_set or [],
         "tuning_file": args.tuning_file,
+        "pcap_dir": args.pcap_dir,
     }, "hayabusa": {
         "stage_dir": args.stage_dir,
         "vss": args.vss,

--- a/python/tests/test_collection.py
+++ b/python/tests/test_collection.py
@@ -224,3 +224,27 @@ def test_create_on_existing_folder_logs_registered(tmp_path):
     collection.create(tmp_path, "hand")
     events = [e["event"] for e in collection.read_log(tmp_path, "hand")]
     assert "registered" in events and "created" not in events     # registration, not creation
+
+
+# --- the signatures/detection lane is wired to the sorted collection pcaps ----
+
+def test_signatures_lane_registered_for_pcaps():
+    # regression: the signatures lane was ABSENT from LANES, so `process all`
+    # never handed a sorted collection's pcaps/ to suricata (it fell back to the
+    # empty data_store/raw/pcaps). It must map pcaps -> dxdfir_signatures_pcap_dir.
+    sig = next((ln for ln in collection.LANES if ln.name == "signatures"), None)
+    assert sig is not None, "signatures lane missing from LANES"
+    assert sig.subdirs == ("pcaps",)
+    assert sig.input_vars == ("dxdfir_signatures_pcap_dir",)
+    # listed LAST so process all runs it after the evidence lanes
+    assert collection.LANES[-1].name == "signatures"
+
+
+def test_lane_inputs_scopes_signatures_pcaps(tmp_path):
+    collection.create(tmp_path, "case-x")
+    root = collection.collection_dir(tmp_path, "case-x")
+    _write(root / "pcaps" / "c.pcap", _PCAP_MAGIC + b"rest")
+    rows = collection.lane_inputs(tmp_path, "case-x")
+    sig = [(lane, var, str(d), n) for (lane, var, d, n) in rows if lane == "signatures"]
+    assert sig == [("signatures", "dxdfir_signatures_pcap_dir",
+                    str(root / "pcaps"), 1)]

--- a/python/tests/test_signatures.py
+++ b/python/tests/test_signatures.py
@@ -658,3 +658,38 @@ def test_audit_flags_unexpected_and_missing(monkeypatch):
     assert not result["ok"]
     assert any("dxdfir/rogue" in v and "unexpected" in v for v in result["violations"])
     assert not any("sof-elk" in v for v in result["violations"])   # allow-listed
+
+
+# ---- suricata reads the pcap dir it is given (the collection-scoping fix) ----
+_PCAP_MAGIC = b"\xa1\xb2\xc3\xd4"
+
+
+def test_suricata_run_honors_pcap_dir(tmp_path, monkeypatch):
+    # a sorted collection points suricata at its own pcaps/ via pcap_dir; the
+    # lane must discover captures THERE, not only the default data_store/raw/pcaps.
+    pcaps = tmp_path / "collections" / "case" / "pcaps"
+    pcaps.mkdir(parents=True)
+    (pcaps / "c.pcap").write_bytes(_PCAP_MAGIC + b"rest")
+    monkeypatch.setattr(suricata, "_suricata_pass", lambda *a, **k: "")  # no docker
+    res = suricata.run(output_dir=str(tmp_path / "out"), repo_root=str(tmp_path),
+                       pcap_dir=str(pcaps))
+    assert res["note"] != f"no pcaps under {pcaps}"    # it FOUND the capture
+    assert res["failed"] == 1 and res["produced"] == 0  # tried it (stub -> no eve)
+
+
+def test_suricata_run_default_pcap_dir_is_raw_pcaps(tmp_path, monkeypatch):
+    # with no pcap_dir, the default is still data_store/raw/pcaps (unchanged) —
+    # the collection scoping is what supplies the real path.
+    monkeypatch.setattr(suricata, "_suricata_pass", lambda *a, **k: "")
+    res = suricata.run(output_dir=str(tmp_path / "out"), repo_root=str(tmp_path))
+    assert res["note"] == f"no pcaps under {os.path.join(str(tmp_path), 'data_store', 'raw', 'pcaps')}"
+
+
+def test_signatures_cli_plumbs_pcap_dir(tmp_path, monkeypatch):
+    from get_sybers_dxdfir.signatures import __main__ as sig_main
+    captured = {}
+    monkeypatch.setattr(sig_main, "process",
+                        lambda *a, **k: captured.update(k) or {"failed": 0, "processed": 1, "skipped": 0})
+    sig_main.main(["--output-dir", str(tmp_path / "o"), "--repo-root", str(tmp_path),
+                   "--only", "suricata", "--pcap-dir", "/some/pcaps"])
+    assert captured["config"]["suricata"]["pcap_dir"] == "/some/pcaps"


### PR DESCRIPTION
**The broken detection pipeline.** On a *sorted* collection, the suricata sub-lane produced nothing — its output dir was empty after `process all`. Root cause: the **`signatures` lane was absent from `collection.LANES`**, the registry that maps each lane to the sorted-collection subdirs it reads and the Ansible input var that points there.

Consequences of the gap:
- `dxdfir process all <collection>` builds its lane list from `LANES`, so it **never ran the detection lane at all**.
- Nothing scoped suricata's pcap input, so `suricata.run` fell back to the empty default `data_store/raw/pcaps` while the sorted captures sat in `raw/collections/<name>/pcaps/`.
- Hayabusa "worked" only because it reads the *processed* evtx stage, not raw; zeek worked because it *is* in `LANES` (`dxdfir_zeek_pcap_dir`).

The collection was sorted correctly — the wiring for the detection lane was simply never built.

## Fix (mirrors how every evidence lane is wired)
- **`collection.LANES`** — add `Lane("signatures", ("pcaps",), ("dxdfir_signatures_pcap_dir",))`, **last** so `process all` runs detection *after* the evidence lanes (hayabusa then sees the processed evtx). `lane_inputs` now scopes the collection's `pcaps/` to the signatures lane, and `process all` includes it whenever the collection has captures.
- **signatures CLI** — `--pcap-dir` → `config["suricata"]["pcap_dir"]`.
- **`dxdfir_signatures` role** — `dxdfir_signatures_pcap_dir` default + argument_spec; `--pcap-dir` threaded into `dxdfir_signatures_argv` when set.
- **`suricata.run`** already honoured `pcap_dir`; the `raw/pcaps` default is unchanged (the collection scoping supplies the real path).

## Tests
`signatures` registered in `LANES` (and last); `lane_inputs` scopes its `pcaps/`; `suricata.run` honours a given `pcap_dir` and keeps the `raw/pcaps` default; the CLI plumbs `--pcap-dir` into the suricata config. Full python suite **359 passed**.

This unblocks the suricata side of the hayabusa+suricata line-up: `process all` on the pcap-bearing collection now feeds the C2 capture (the `berylia.org` traffic) to suricata, whose alerts then line up against the CAR flow rows (DNS/SNI/cert resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)