### PR TITLE
feat(suricata): provision the ET Open ruleset on --fetch

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -81,6 +81,22 @@ Terms still bind the operator who fetches, and they are layered:
 - DetectRaptor's **VQL artifacts and CSV lookups are not fetched** — they need a
   Velociraptor server this pipeline does not run.
 
+### Emerging Threats Open (Suricata rules) — fetched, not redistributed
+
+**This repository ships none of it.** The Suricata lane's `--fetch`
+(`get_sybers_dxdfir/signatures/suricata_rules.py`) downloads the
+[ET Open](https://rules.emergingthreats.net/open/) ruleset — the version-pinned
+tarball published per Suricata engine release — and concatenates its `*.rules`
+into `data_store/dependencies/suricata-rules/suricata.rules`, which is
+deny-by-default gitignored. Only the source URL lives in this repository, so no
+redistribution obligation attaches — the same position as DetectRaptor above.
+
+- ET Open is a **rolling feed** (rebuilt daily), so the pin is the engine-version
+  URL, not a content hash; the fetch is HTTPS + structural validation, the trust
+  model the official `suricata-update` uses.
+- The ruleset carries **Proofpoint's ET Open licence** (BSD-style, non-commercial
+  attribution terms); those terms bind the operator who fetches, not this repo.
+
 ---
 
 ---

--- a/python/get_sybers_dxdfir/signatures/suricata.py
+++ b/python/get_sybers_dxdfir/signatures/suricata.py
@@ -504,13 +504,25 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
     res = {"lane": "suricata", "produced": 0, "skipped": 0, "failed": 0, "note": None,
            "tuning": {}}
 
+    # --fetch (online only) provisions the ET Open ruleset when the dir has none,
+    # the Suricata analogue of the yara lane's DetectRaptor fetch. Best-effort: a
+    # failed fetch (air-gapped / upstream down) is a note, never a lane failure —
+    # suricata still runs on any bundled rules.
+    if fetch:
+        from . import suricata_rules
+        try:
+            res["rules_fetch"] = suricata_rules.fetch(rules_dir)
+        except Exception as exc:                       # noqa: BLE001 — best-effort provisioning
+            res["rules_fetch"] = {"tool": "et-open", "error": str(exc)}
+
     rules_file = None
     for cur, _dirs, files in os.walk(rules_dir):
         if "suricata.rules" in files:
             rules_file = os.path.join(cur, "suricata.rules")
             break
     if not rules_file:
-        res["note"] = "no suricata.rules — using the image's bundled rules"
+        res["note"] = "no suricata.rules — using the image's bundled rules " \
+                      "(run with --fetch online to provision ET Open)"
 
     pcaps = discover(pcap_dir)
     if not pcaps:

--- a/python/get_sybers_dxdfir/signatures/suricata_rules.py
+++ b/python/get_sybers_dxdfir/signatures/suricata_rules.py
@@ -1,0 +1,115 @@
+"""Emerging Threats Open ruleset provisioning for the Suricata lane.
+
+The suricata lane needs rules to alert; the hardened dxdfir/suricata image ships
+none. This module fetches the free **ET Open** ruleset and concatenates its
+``*.rules`` into one ``<rules-dir>/suricata.rules`` — the file
+:func:`suricata.run` looks for and mounts. The yara lane's ``--fetch`` provisions
+DetectRaptor the same way (see :mod:`detectraptor`); this is its Suricata analogue.
+
+**Why no content sha256 pin** (unlike DetectRaptor): ET Open is a *rolling* feed —
+the tarball at a version URL is rebuilt daily, so a content hash would be stale
+within a day. Instead we pin the ENGINE-VERSION URL (the stable addressing ET
+publishes per Suricata release) and fetch it over HTTPS, then structurally
+validate (it must be a gzip tar that yields ``*.rules`` text) — the same trust
+model as the official ``suricata-update``. An air-gapped run drops its own
+ruleset into the rules dir instead (``suricata.run`` finds any ``suricata.rules``
+and never calls this); ``--fetch`` is online-only by contract.
+
+Stdlib only (urllib, tarfile, io), like the rest of the signatures package.
+
+    python -m get_sybers_dxdfir.signatures.suricata_rules --rules-dir <suricata-rules>
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import tarfile
+import urllib.request
+
+# Pinned upstream addressing: ET Open, by Suricata engine version. ET publishes a
+# rolling tarball per version; we pin the VERSION path (stable), not the content
+# (it rolls daily — see the module docstring). To advance: bump _SURICATA_VER to
+# match the dxdfir/suricata image's engine.
+_SURICATA_VER = "7.0.3"
+_ET_OPEN_URL = f"https://rules.emergingthreats.net/open/suricata-{_SURICATA_VER}/emerging.rules.tar.gz"
+_RULES_FILE = "suricata.rules"
+
+
+def extract_rules(tar_bytes: bytes) -> tuple[str, int]:
+    """Concatenate every ``*.rules`` member of an ET Open ``.tar.gz`` into one
+    ruleset text. Returns (text, file_count). Pure — the download is separate, so
+    the merge is unit-testable without the network. Raises on a non-tar / a tar
+    with no ``.rules`` (a truncated or wrong download must not write an empty
+    ruleset that would silently disable alerting)."""
+    chunks: list[str] = []
+    n = 0
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if not member.isfile() or not member.name.endswith(".rules"):
+                continue
+            fh = tar.extractfile(member)
+            if fh is None:
+                continue
+            text = fh.read().decode("utf-8", errors="replace")
+            chunks.append(f"# --- {os.path.basename(member.name)} ---\n{text.rstrip()}\n")
+            n += 1
+    if n == 0:
+        raise ValueError("ET Open archive contained no .rules files "
+                         "(truncated or unexpected download)")
+    return "\n".join(chunks), n
+
+
+def _download(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=180) as resp:  # noqa: S310 — pinned https URL
+        return resp.read()
+
+
+def fetch(rules_dir: str, *, url: str = _ET_OPEN_URL, force: bool = False) -> dict:
+    """Provision ``<rules_dir>/suricata.rules`` from ET Open.
+
+    Skips if the ruleset already exists (delete it or pass ``force=True`` to
+    refresh). Downloads the pinned-version tarball, extracts+concatenates its
+    ``.rules``, and writes them atomically. Returns a summary; raises on a bad
+    download (so a failed fetch is loud, never a silently-empty ruleset)."""
+    out = os.path.join(rules_dir, _RULES_FILE)
+    if os.path.exists(out) and os.path.getsize(out) > 0 and not force:
+        return {"tool": "et-open", "output": out, "skipped": True}
+    text, n = extract_rules(_download(url))
+    header = (
+        "# Emerging Threats Open ruleset — fetched by get_sybers_dxdfir, do not edit.\n"
+        f"# Source: {url}\n"
+        f"# {n} rule files concatenated. ET Open is a rolling feed; re-fetch to update.\n"
+        "# Licence: ET Open (BSD-style) — see THIRD_PARTY_NOTICES.md.\n\n"
+    )
+    os.makedirs(rules_dir, exist_ok=True)
+    tmp = out + ".part"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(header + text)
+    os.replace(tmp, out)
+    rule_lines = sum(1 for ln in text.splitlines()
+                     if ln.strip() and not ln.lstrip().startswith("#"))
+    return {"tool": "et-open", "output": out, "skipped": False,
+            "rule_files": n, "rules": rule_lines, "source": url}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="get_sybers_dxdfir.signatures.suricata_rules",
+        description="Fetch the ET Open ruleset (pinned Suricata version) into "
+                    "<rules-dir>/suricata.rules.")
+    ap.add_argument("--rules-dir", required=True,
+                    help="Suricata rules dir (normally data_store/dependencies/suricata-rules)")
+    ap.add_argument("--url", default=_ET_OPEN_URL, help="override the ET Open tarball URL")
+    ap.add_argument("--force", action="store_true", help="refresh an existing ruleset")
+    args = ap.parse_args(argv)
+    res = fetch(args.rules_dir, url=args.url, force=args.force)
+    json.dump(res, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tests/test_signatures.py
+++ b/python/tests/test_signatures.py
@@ -693,3 +693,63 @@ def test_signatures_cli_plumbs_pcap_dir(tmp_path, monkeypatch):
     sig_main.main(["--output-dir", str(tmp_path / "o"), "--repo-root", str(tmp_path),
                    "--only", "suricata", "--pcap-dir", "/some/pcaps"])
     assert captured["config"]["suricata"]["pcap_dir"] == "/some/pcaps"
+
+
+# ---- ET Open ruleset provisioning (the suricata --fetch wiring) ------------
+import io as _io
+import tarfile as _tarfile
+from get_sybers_dxdfir.signatures import suricata_rules
+
+
+def _tar_gz(files: dict) -> bytes:
+    buf = _io.BytesIO()
+    with _tarfile.open(fileobj=buf, mode="w:gz") as t:
+        for name, data in files.items():
+            info = _tarfile.TarInfo(name)
+            info.size = len(data)
+            t.addfile(info, _io.BytesIO(data))
+    return buf.getvalue()
+
+
+def test_extract_rules_concatenates_only_rules_members():
+    blob = _tar_gz({
+        "rules/emerging-malware.rules": b"alert tcp any any -> any any (msg:\"m\"; sid:1;)\n",
+        "rules/emerging-dns.rules": b"alert dns any any -> any any (msg:\"d\"; sid:2;)\n",
+        "classification.config": b"config: not a rule\n",   # excluded
+    })
+    text, n = suricata_rules.extract_rules(blob)
+    assert n == 2
+    assert "sid:1;" in text and "sid:2;" in text
+    assert "not a rule" not in text
+
+
+def test_extract_rules_rejects_an_archive_with_no_rules():
+    import pytest
+    with pytest.raises(ValueError):
+        suricata_rules.extract_rules(_tar_gz({"classification.config": b"x"}))
+
+
+def test_fetch_writes_ruleset_and_is_idempotent(tmp_path, monkeypatch):
+    blob = _tar_gz({"rules/a.rules": b"alert ip any any -> any any (msg:\"a\"; sid:9;)\n"})
+    monkeypatch.setattr(suricata_rules, "_download", lambda url: blob)
+    res = suricata_rules.fetch(str(tmp_path))
+    out = tmp_path / "suricata.rules"
+    assert out.is_file() and "sid:9;" in out.read_text() and res["rule_files"] == 1
+    # exists -> skipped; force -> refreshed
+    assert suricata_rules.fetch(str(tmp_path))["skipped"] is True
+    assert suricata_rules.fetch(str(tmp_path), force=True)["skipped"] is False
+
+
+def test_suricata_run_fetches_etopen_when_asked(tmp_path, monkeypatch):
+    called = {}
+    def _fake_fetch(rules_dir, **k):
+        open(os.path.join(rules_dir, "suricata.rules"), "w").write("alert ip any any -> any any (sid:1;)")
+        called["dir"] = rules_dir
+        return {"tool": "et-open", "rule_files": 1}
+    monkeypatch.setattr(suricata_rules, "fetch", _fake_fetch)
+    monkeypatch.setattr(suricata, "_suricata_pass", lambda *a, **k: "")
+    pcaps = tmp_path / "p"; pcaps.mkdir()
+    (pcaps / "c.pcap").write_bytes(_PCAP_MAGIC + b"x")
+    res = suricata.run(output_dir=str(tmp_path / "o"), repo_root=str(tmp_path),
+                       pcap_dir=str(pcaps), fetch=True)
+    assert called and res["rules_fetch"]["rule_files"] == 1   # fetch happened


### PR DESCRIPTION
Wires suricata up properly. The lane could replay captures (after #159) but **never alerted** — the hardened `dxdfir/suricata` image ships no rules and nothing fetched any, so it emitted only protocol records (0 alerts). This adds ruleset provisioning, mirroring the yara lane's DetectRaptor `--fetch`.

- **`signatures/suricata_rules.py`** — fetch **ET Open** (the free Suricata ruleset), the version-pinned tarball ET publishes per Suricata engine release, and concatenate its `*.rules` into `<rules-dir>/suricata.rules` (the file `suricata.run` mounts with `-S`). `extract_rules` is pure/unit-tested; a download yielding no `.rules` **raises** rather than writing a silently-empty ruleset that would disable alerting.
- **No content sha256 pin** (unlike DetectRaptor, deliberately): ET Open is a **rolling daily feed**, so a content hash would be stale within a day. The pin is the **engine-version URL**; trust is HTTPS + structural validation — the same model as the official `suricata-update`. Documented in the module + `THIRD_PARTY_NOTICES`.
- **`suricata.run`** — when `fetch=True` and the rules dir is empty, provision ET Open. **Best-effort**: an air-gapped/offline fetch is a note, never a lane failure (suricata still runs on any bundled rules). The `--fetch` plumbing already flows `CLI → process → run`, so no role/CLI change was needed.
- **`THIRD_PARTY_NOTICES`** — ET Open fetched-not-redistributed section (rolling feed, engine-version pin, Proofpoint ET Open licence binds the fetcher).

## Tests
`extract_rules` concatenates only `.rules` members and rejects a `.rules`-less archive; `fetch` writes the ruleset, is idempotent, and refreshes on `--force`; `suricata.run` provisions ET Open when asked. Full python suite **363 passed**.

## Effect
`dxdfir process signatures <collection> --fetch` (online) now gives suricata a real ruleset — so the DFIRdump C2 traffic (`100.101.0.42` / `scoring-c2.berylia.org`) actually **alerts**, completing the suricata half of the hayabusa+suricata line-up against CAR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)