### PR TITLE
fix(pipeline): scope every detection sub-lane input to the sorted collection

### DIFF
--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
@@ -26,6 +26,13 @@ dxdfir_signatures_yara_sources: ""
 # (collection.LANES: signatures -> dxdfir_signatures_pcap_dir); without it a
 # sorted collection's captures never reach suricata.
 dxdfir_signatures_pcap_dir: ""
+# Disk images the yara disk scan + hayabusa image-EVTX extraction read (empty =>
+# processor default data_store/raw/disk_images). A collection scopes this to its
+# sorted disk_images/ subdir (collection.LANES: dxdfir_signatures_disk_dir).
+dxdfir_signatures_disk_dir: ""
+# Memory images the yara memory scan reads (empty => data_store/raw/memory). A
+# collection scopes this to its sorted memory/ subdir (dxdfir_signatures_memory_dir).
+dxdfir_signatures_memory_dir: ""
 # Per-pcap Suricata tuning file (INI template; empty => the processor's default,
 # data_store/dependencies/suricata-tuning.conf). Written as an editable template
 # on first run; while template-only or invalid, HOME_NET is auto-detected per
@@ -47,5 +54,7 @@ dxdfir_signatures_argv: >-
   + (['--yara-sources', dxdfir_signatures_yara_sources] if dxdfir_signatures_yara_sources | length > 0 else [])
   + (['--tuning-file', dxdfir_signatures_suricata_tuning_file] if dxdfir_signatures_suricata_tuning_file | length > 0 else [])
   + (['--pcap-dir', dxdfir_signatures_pcap_dir] if dxdfir_signatures_pcap_dir | length > 0 else [])
+  + (['--disk-dir', dxdfir_signatures_disk_dir] if dxdfir_signatures_disk_dir | length > 0 else [])
+  + (['--memory-dir', dxdfir_signatures_memory_dir] if dxdfir_signatures_memory_dir | length > 0 else [])
   + (['--fetch'] if dxdfir_signatures_fetch | bool else [])
   + (['--force'] if dxdfir_signatures_force | bool else []) }}

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/defaults/main.yml
@@ -28,10 +28,11 @@ dxdfir_signatures_yara_sources: ""
 dxdfir_signatures_pcap_dir: ""
 # Disk images the yara disk scan + hayabusa image-EVTX extraction read (empty =>
 # processor default data_store/raw/disk_images). A collection scopes this to its
-# sorted disk_images/ subdir (collection.LANES: dxdfir_signatures_disk_dir).
+# sorted disk_images/ subdir (collection.LANES: signatures -> dxdfir_signatures_disk_dir).
 dxdfir_signatures_disk_dir: ""
 # Memory images the yara memory scan reads (empty => data_store/raw/memory). A
-# collection scopes this to its sorted memory/ subdir (dxdfir_signatures_memory_dir).
+# collection scopes this to its sorted memory/ subdir
+# (collection.LANES: signatures -> dxdfir_signatures_memory_dir).
 dxdfir_signatures_memory_dir: ""
 # Per-pcap Suricata tuning file (INI template; empty => the processor's default,
 # data_store/dependencies/suricata-tuning.conf). Written as an editable template

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
@@ -79,6 +79,23 @@ argument_specs:
           sorted pcaps/ subdir (collection.LANES: signatures ->
           dxdfir_signatures_pcap_dir) so a sorted collection's captures reach
           suricata; without it the sub-lane finds nothing.
+      dxdfir_signatures_disk_dir:
+        type: str
+        required: false
+        default: ""
+        description: >-
+          Directory of disk images the yara disk scan and the hayabusa image-EVTX
+          extraction read (empty => the processor default,
+          data_store/raw/disk_images). A collection sets this to its sorted
+          disk_images/ subdir (collection.LANES: dxdfir_signatures_disk_dir).
+      dxdfir_signatures_memory_dir:
+        type: str
+        required: false
+        default: ""
+        description: >-
+          Directory of memory images the yara memory scan reads (empty => the
+          processor default, data_store/raw/memory). A collection sets this to its
+          sorted memory/ subdir (collection.LANES: dxdfir_signatures_memory_dir).
       dxdfir_signatures_fetch:
         type: bool
         required: false

--- a/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
+++ b/ansible/collections/get_sybers.dxdfir/roles/dxdfir_signatures/meta/argument_specs.yml
@@ -87,7 +87,7 @@ argument_specs:
           Directory of disk images the yara disk scan and the hayabusa image-EVTX
           extraction read (empty => the processor default,
           data_store/raw/disk_images). A collection sets this to its sorted
-          disk_images/ subdir (collection.LANES: dxdfir_signatures_disk_dir).
+          disk_images/ subdir (collection.LANES: signatures -> dxdfir_signatures_disk_dir).
       dxdfir_signatures_memory_dir:
         type: str
         required: false
@@ -95,7 +95,7 @@ argument_specs:
         description: >-
           Directory of memory images the yara memory scan reads (empty => the
           processor default, data_store/raw/memory). A collection sets this to its
-          sorted memory/ subdir (collection.LANES: dxdfir_signatures_memory_dir).
+          sorted memory/ subdir (collection.LANES: signatures -> dxdfir_signatures_memory_dir).
       dxdfir_signatures_fetch:
         type: bool
         required: false

--- a/python/get_sybers_dxdfir/collection.py
+++ b/python/get_sybers_dxdfir/collection.py
@@ -59,12 +59,15 @@ LANES: tuple[Lane, ...] = (
     Lane("zimmerman", ("disk_images", "VM_files"),
          ("dxdfir_zimmerman_input_dir", "dxdfir_zimmerman_vm_dir")),
     # The detection lane (yara/suricata/hayabusa). Listed LAST so `process all`
-    # runs it after the evidence lanes (hayabusa reads the processed evtx stage).
-    # Scoped by the pcaps subdir — the input suricata replays; without this the
-    # suricata sub-lane fell back to the empty data_store/raw/pcaps and produced
-    # nothing on a sorted collection (hayabusa/yara use their own processed/tool
-    # inputs). A collection with pcaps therefore drives the detection lane too.
-    Lane("signatures", ("pcaps",), ("dxdfir_signatures_pcap_dir",)),
+    # runs it after the evidence lanes. Every sub-lane input is scoped to the
+    # collection, so none falls back to an empty data_store/raw/<x> default on a
+    # sorted collection: pcaps -> suricata replay; disk_images -> yara disk scan +
+    # hayabusa image-EVTX extraction; memory -> yara memory scan. (hayabusa's
+    # loose-EVTX scan already walks raw/ recursively, so logs/winevt is covered
+    # without a var.) The lane runs whenever ANY of these subdirs has evidence.
+    Lane("signatures", ("pcaps", "disk_images", "memory"),
+         ("dxdfir_signatures_pcap_dir", "dxdfir_signatures_disk_dir",
+          "dxdfir_signatures_memory_dir")),
 )
 
 # The lane subdirs a collection materialises (order = display order).

--- a/python/get_sybers_dxdfir/signatures/__main__.py
+++ b/python/get_sybers_dxdfir/signatures/__main__.py
@@ -58,6 +58,15 @@ def main(argv: list[str] | None = None) -> int:
                          "(default data_store/raw/pcaps). A collection scopes this to "
                          "its sorted pcaps/ subdir (dxdfir_signatures_pcap_dir); without "
                          "it a sorted collection's captures never reach suricata.")
+    ap.add_argument("--disk-dir",
+                    help="the directory of disk images the yara disk scan and the "
+                         "hayabusa image-EVTX extraction read (default "
+                         "data_store/raw/disk_images). A collection scopes this to its "
+                         "sorted disk_images/ subdir.")
+    ap.add_argument("--memory-dir",
+                    help="the directory of memory images the yara memory scan reads "
+                         "(default data_store/raw/memory). A collection scopes this to "
+                         "its sorted memory/ subdir.")
     args = ap.parse_args(argv)
 
     lanes = tuple(args.only) if args.only else LANES
@@ -71,6 +80,10 @@ def main(argv: list[str] | None = None) -> int:
     }, "hayabusa": {
         "stage_dir": args.stage_dir,
         "vss": args.vss,
+        "disk_dir": args.disk_dir,           # image-EVTX extraction source
+    }, "yara": {
+        "disk_dir": args.disk_dir,           # disk scan source
+        "memory_dir": args.memory_dir,       # memory scan source
     }}
     if args.yara_sources:
         srcs = tuple(s.strip() for s in args.yara_sources.split(",") if s.strip())
@@ -78,7 +91,7 @@ def main(argv: list[str] | None = None) -> int:
         if bad:
             ap.error(f"--yara-sources: unknown source(s) {','.join(bad)} "
                      "(choose from files,disk,memory)")
-        config["yara"] = {"sources": srcs}
+        config["yara"]["sources"] = srcs      # merge — keep the scoped disk/memory dirs
     summary = process(
         args.output_dir, lanes, repo_root=args.repo_root,
         fetch=args.fetch, force=args.force, config=config,

--- a/python/tests/test_collection.py
+++ b/python/tests/test_collection.py
@@ -228,23 +228,31 @@ def test_create_on_existing_folder_logs_registered(tmp_path):
 
 # --- the signatures/detection lane is wired to the sorted collection pcaps ----
 
-def test_signatures_lane_registered_for_pcaps():
+def test_signatures_lane_registered_with_all_detection_inputs():
     # regression: the signatures lane was ABSENT from LANES, so `process all`
-    # never handed a sorted collection's pcaps/ to suricata (it fell back to the
-    # empty data_store/raw/pcaps). It must map pcaps -> dxdfir_signatures_pcap_dir.
+    # never handed a sorted collection's inputs to the detection sub-lanes (each
+    # fell back to an empty data_store/raw/<x>). It maps EVERY input the detection
+    # lanes consume: pcaps -> suricata, disk_images -> yara/hayabusa, memory -> yara.
     sig = next((ln for ln in collection.LANES if ln.name == "signatures"), None)
     assert sig is not None, "signatures lane missing from LANES"
-    assert sig.subdirs == ("pcaps",)
-    assert sig.input_vars == ("dxdfir_signatures_pcap_dir",)
+    assert sig.subdirs == ("pcaps", "disk_images", "memory")
+    assert sig.input_vars == ("dxdfir_signatures_pcap_dir",
+                              "dxdfir_signatures_disk_dir",
+                              "dxdfir_signatures_memory_dir")
     # listed LAST so process all runs it after the evidence lanes
     assert collection.LANES[-1].name == "signatures"
 
 
-def test_lane_inputs_scopes_signatures_pcaps(tmp_path):
+def test_lane_inputs_scopes_every_signatures_input(tmp_path):
     collection.create(tmp_path, "case-x")
     root = collection.collection_dir(tmp_path, "case-x")
     _write(root / "pcaps" / "c.pcap", _PCAP_MAGIC + b"rest")
+    _write(root / "disk_images" / "d.E01", _EWF_MAGIC)
+    _write(root / "memory" / "m.mem", b"MEM")
     rows = collection.lane_inputs(tmp_path, "case-x")
-    sig = [(lane, var, str(d), n) for (lane, var, d, n) in rows if lane == "signatures"]
-    assert sig == [("signatures", "dxdfir_signatures_pcap_dir",
-                    str(root / "pcaps"), 1)]
+    sig = {var: (str(d), n) for (lane, var, d, n) in rows if lane == "signatures"}
+    assert sig == {
+        "dxdfir_signatures_pcap_dir": (str(root / "pcaps"), 1),
+        "dxdfir_signatures_disk_dir": (str(root / "disk_images"), 1),
+        "dxdfir_signatures_memory_dir": (str(root / "memory"), 1),
+    }

--- a/python/tests/test_signatures.py
+++ b/python/tests/test_signatures.py
@@ -753,3 +753,30 @@ def test_suricata_run_fetches_etopen_when_asked(tmp_path, monkeypatch):
     res = suricata.run(output_dir=str(tmp_path / "o"), repo_root=str(tmp_path),
                        pcap_dir=str(pcaps), fetch=True)
     assert called and res["rules_fetch"]["rule_files"] == 1   # fetch happened
+
+
+def test_signatures_cli_plumbs_disk_and_memory_dirs(tmp_path, monkeypatch):
+    # --disk-dir/--memory-dir must reach BOTH sub-lanes that consume them:
+    # yara (disk + memory scans) and hayabusa (image-EVTX extraction, disk only).
+    from get_sybers_dxdfir.signatures import __main__ as sig_main
+    captured = {}
+    monkeypatch.setattr(sig_main, "process",
+                        lambda *a, **k: captured.update(k) or {"failed": 0, "processed": 1, "skipped": 0})
+    sig_main.main(["--output-dir", str(tmp_path / "o"), "--repo-root", str(tmp_path),
+                   "--disk-dir", "/d", "--memory-dir", "/m"])
+    cfg = captured["config"]
+    assert cfg["yara"]["disk_dir"] == "/d" and cfg["yara"]["memory_dir"] == "/m"
+    assert cfg["hayabusa"]["disk_dir"] == "/d"
+
+
+def test_signatures_cli_yara_sources_keeps_scoped_dirs(tmp_path, monkeypatch):
+    # a --yara-sources selection must NOT clobber the scoped disk/memory dirs
+    from get_sybers_dxdfir.signatures import __main__ as sig_main
+    captured = {}
+    monkeypatch.setattr(sig_main, "process",
+                        lambda *a, **k: captured.update(k) or {"failed": 0, "processed": 1, "skipped": 0})
+    sig_main.main(["--output-dir", str(tmp_path / "o"), "--repo-root", str(tmp_path),
+                   "--disk-dir", "/d", "--yara-sources", "disk,memory"])
+    cfg = captured["config"]
+    assert cfg["yara"]["sources"] == ("disk", "memory")
+    assert cfg["yara"]["disk_dir"] == "/d"    # not clobbered by the sources merge


### PR DESCRIPTION
Follow-up to #159 (which wired suricata's pcaps): **yara and hayabusa had the identical gap.** Their disk/memory inputs defaulted to the empty `data_store/raw/disk_images` and `raw/memory` instead of the sorted collection's subdirs, so on a sorted collection the yara disk/memory scans and hayabusa's image-EVTX extraction found nothing.

That's why the whole detection lane was hollow: **yara produced zero output and the DetectRaptor rules were never even exercised**; suricata was empty (the #159 gap + no ruleset, see #161); only hayabusa produced alerts, and only because its loose-EVTX scan already walks `raw/` recursively and its rules are image-bundled.

## Fix — extend the signatures collection mapping to EVERY detection input
- **`collection.LANES`** — signatures now maps `("pcaps","disk_images","memory")` → `(dxdfir_signatures_pcap_dir, _disk_dir, _memory_dir)`. The lane runs whenever any has evidence; each sub-lane input is collection-scoped.
- **signatures CLI** — `--disk-dir` (→ yara disk scan **and** hayabusa image-EVTX) and `--memory-dir` (→ yara memory scan); `--yara-sources` now **merges** so it no longer clobbers the scoped dirs.
- **`dxdfir_signatures` role** — `dxdfir_signatures_disk_dir` / `_memory_dir` defaults + argument_specs, threaded into the argv.
- `yara.run` / `hayabusa.run` already accept `disk_dir`/`memory_dir` — no change.

## Tests
signatures maps all three subdirs (and is last); `lane_inputs` scopes all three; the CLI plumbs disk/memory to yara + hayabusa and `--yara-sources` keeps the scoped dirs. Full python suite **361 passed**.

With #159 + #161 + this, `dxdfir process all <collection> --fetch` runs **every** detection lane against the collection's own evidence with real rulesets — the complete "wire all the detection lanes in".

🤖 Generated with [Claude Code](https://claude.com/claude-code)