### PR TITLE
feat(stix): behaviour-sightings — detections as Sightings of ATT&CK over the spindle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,26 @@ is `0`, anything may change without notice.
 - `tests/run-checks.sh` (and the `checks` workflow) now run the Python unit
   tests when pytest is installed.
 
+### Added
+- **`dxdfir stix behaviour-sightings`** — joins the detection lanes
+  (suricata / hayabusa / yara) to the CAR entities they touch, against the
+  finished `car.db` stores, and emits each join as a STIX 2.1 **Sighting of the
+  ATT&CK attack-pattern** the detection names, over an `observed-data` keyed on
+  the matched CAR row's spindle `guid` (the behaviour timeline as the primary
+  axis), with the host as `where_sighted_refs`. suricata → the `flow` for the
+  alert's connection pair (a C2 IP read as its resolved `dest_fqdn`); hayabusa →
+  the `process` by ProcessGuid; yara → the `process` by pid or `file` by hash.
+  Reuses the exchange's object builders and validation, so a behaviour bundle
+  merges object-for-object with `stix export` and PIIAT's projection. Documented
+  in `docs/research/09-behaviour-sightings.md`.
+
+### Fixed
+- The YARA **memory** lane's Volatility renderer defaulted to a nonexistent
+  `dev-scripts/volatility/` path (the lane had never run), so
+  `dxdfir process signatures --yara-sources memory` could not scan; it now
+  resolves the renderer the vendored PIIAT-Mem tool owns
+  (`third_party/piiat-mem/jsonl_dfir_renderer.py`).
+
 ## [0.6.0] - 2026-08-30
 
 ### Added

--- a/docs/research/09-behaviour-sightings.md
+++ b/docs/research/09-behaviour-sightings.md
@@ -1,0 +1,102 @@
+# Step 09 — Behaviour sightings (detections as Sightings of ATT&CK over the spindle)
+
+> Part of the CAR cross-source linkage & detection research arc — see [README](README.md) for the full map.
+
+**Status:** implemented (`python/get_sybers_dxdfir/stix/behaviour.py`, CLI `dxdfir stix behaviour-sightings`); demonstrated end-to-end on `ls24-sample`.
+
+## The gap
+
+[Step 08](08-detection-correlation.md) proved the correlation *by hand* — a
+suricata alert on `100.101.0.42` lines up with the CAR flow that resolves it to
+`scoring-c2.berylia.org`; a hayabusa T1059 record lines up with a CAR process.
+But nothing *emitted* that join. The engine already projects its **own** CAR
+analytics as STIX Sightings of ATT&CK attack-patterns over the spindle
+observed-data (`piiat_mitrecar/stix.py` + `analytics.py`) — but the DX detection
+lanes (suricata / hayabusa / yara) were never fused onto that behaviour axis. The
+DX exchange's `stix export` sights the rule *indicator* over observed-data minted
+from the detection's **own** fields, carrying the CAR guid only as an extension
+string — it never anchors to the spindle entity.
+
+The north star wants the other shape: **emit the detection↔CAR-entity joins as
+STIX Sightings of the ATT&CK attack-patterns, over the spindle-identified
+observed-data — the behaviour timeline as the primary axis.**
+
+## What was built
+
+A bridge — `dxdfir stix behaviour-sightings --car <car.db|tree> --detections
+<dir> --case <id>` — that:
+
+1. **Parses the raw lane output.** suricata EVE `alert` events (technique from
+   `alert.metadata.mitre_technique_id`), hayabusa timeline (technique from
+   `MitreTags`/`OtherTags`, ProcessGuid from `Details.PGUID`), YARA
+   memory/disk/file matches.
+2. **Joins each to the CAR entity it touches**, against the finished `car.db`
+   stores: suricata → the `flow` for the alert's **connection pair** (both
+   endpoints), hayabusa → the `process` by ProcessGuid (case-folded, else
+   `(host, pid)`), YARA → the `process` by pid or the `file` by hash.
+3. **Emits one Sighting per (detection, entity, technique)** whose
+   `sighting_of_ref` **is the ATT&CK attack-pattern** — MITRE's authoritative id
+   (via the committed `attack_index`), referenced not shipped (BP §5.2) — over an
+   `observed-data` **keyed on the matched CAR row's spindle `guid`** (so every
+   detector that touches an entity references the *same* observation), with the
+   host as `where_sighted_refs`. A flow observation resolves the C2 IP to its
+   `dest_fqdn` as a `domain-name` SCO with `resolves_to_refs` — the alert read
+   beyond its own source.
+
+It reuses the exchange's object builders, bundle assembly and validation
+(`stix/objects.py`, `stix/export.py`), so a behaviour bundle merges
+object-for-object with the `stix export` and PIIAT bundles. Nothing is invented:
+a detection that names no resolvable technique, or joins no CAR entity, is
+counted and skipped — never given a fabricated attack-pattern or entity. Root
+pytest **373**, including 8 golden-vector tests for the bridge.
+
+## What we found on `ls24-sample`
+
+Joined the three detection lanes (`data_store/processed/signatures/`) to the
+ls24 CAR stores (zeek `flow`, evtx `process`, memory `process`):
+
+- **100 detections, every one joined a CAR entity** — 85 distinct entities
+  flagged across the network, evtx and memory sources. The cross-source join is
+  total: the pipeline names an entity for every alert.
+- **1 Sighting of an ATT&CK attack-pattern:** hayabusa RecordID **5261**
+  (`Cmd.EXE Missing Space Characters Execution Anomaly`, the DOSfuscated
+  execution) → a **Sighting of `attack-pattern--970a3432…` (T1059.001)** over the
+  evtx process's spindle observed-data (the `cmd.exe` file SCO, SHA-256), where
+  sighted on **`DESKTOP-M913391`**. The bundle validates with **0 errors, 0
+  warnings** (ATT&CK ids resolve as the permitted non-local references).
+- **99 joined, but no ATT&CK tag to sight.** The 14 suricata alerts all join the
+  **specific C2 connection** `10.27.33.61 ↔ 100.101.0.42` — the flow that
+  resolves to `scoring-c2.berylia.org` — but the ET Open rules that fired
+  (`ET INFO SSH-2.0-Go…`, `ET SCAN … Masscan`) carry no `mitre_technique_id`, so
+  there is nothing to sight; the join is recorded, not invented into a technique.
+  The 85 info-level hayabusa records and the YARA memory matches (DetectRaptor —
+  e.g. a `DisableAntiSpyware` Defender-tamper indicator in `svchost`) likewise
+  join a process without an ATT&CK tag.
+
+The one attack-pattern sighting *is* the north star realised end-to-end on real
+data: a threat detection, lit up as a **behaviour** (T1059.001), anchored to the
+cross-source-resolved CAR entity rather than to the evtx record it came from.
+
+## What it enables
+
+The bundle is the substrate for the **generative** half of the project. Each
+Sighting is a behaviour observed over the cascade; the shapes these sightings
+take — a technique over a spindle entity with its resolved network/host/memory
+context — are exactly what new CAR analytics should be **generated into**,
+codified against the broader mapped data sources rather than the ones MITRE's
+stock analytics assume.
+
+## Follow-ups
+
+- **A technique-sparse corpus.** Only 1 of the 100 ls24 detections named a
+  resolvable ATT&CK technique. Richer sightings need either ATT&CK-tagged
+  rulesets (ET Open PRO / Sigma with `tags`) or the engine's own CAR analytics
+  feeding the same bridge — both slot in without a shape change.
+- **The `lonewolf` disk line-up.** This run is `ls24-sample` (network + evtx +
+  memory). The single-host `lonewolf` disk line-up ([Step 06](06-behaviour-timeline.md))
+  needs a **mount-enabled host** (`/dev/fuse`) so hayabusa image-EVTX extraction
+  and yara-on-disk can run against its `car.db`; the bridge itself is ready for
+  it unchanged.
+- **Joined-but-untagged detections.** The 99 joins are real cross-source links
+  that today produce only a report count; emitting them as evidence (observed
+  behaviour without an attack-pattern) is a candidate extension.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -37,6 +37,7 @@ Two problems stood in the way, and the value hunt named them precisely:
 | 6 | [The behaviour timeline (and psort vs CAR)](06-behaviour-timeline.md) | 2.7M-event behaviour timeline over the full LoneWolf disk; the layer distinction |
 | 7 | [Wiring the detection lanes into the collection](07-detection-lane-wiring.md) | `process all --fetch` runs suricata/yara/hayabusa on the collection's evidence |
 | 8 | [Detection ↔ CAR correlation](08-detection-correlation.md) | suricata + hayabusa alerts joined to the resolved/normalized CAR entities |
+| 9 | [Behaviour sightings](09-behaviour-sightings.md) | the join emitted — detections as STIX Sightings of ATT&CK attack-patterns over the spindle observed-data |
 
 ## How the pieces compose
 
@@ -75,5 +76,6 @@ while `ls24-sample` carries the network + host detections used in Step 8.
 - **Engine (PIIAT-MitreCar):** #57/#58/#59 volume GUID, #60 MAC, #61 DNS + #65
   SSL, #66 x509, #63/#65 timeliner robustness, #54 behaviour layer (prior).
 - **DX_DFIR:** #153 plaso byte-preservation, #152/#154 YARA ruleset, #159/#161/#162
-  detection-lane wiring, plus the submodule pin bumps that carried each engine
-  change onto `main`.
+  detection-lane wiring, #163 this research journey, the behaviour-sightings bridge
+  (`stix/behaviour.py`) + the yara memory-lane renderer fix, plus the submodule pin
+  bumps that carried each engine change onto `main`.

--- a/python/get_sybers_dxdfir/signatures/yara.py
+++ b/python/get_sybers_dxdfir/signatures/yara.py
@@ -301,8 +301,13 @@ def run(*, output_dir, repo_root, fetch=False, force=False,
     disk_dir = disk_dir or os.path.join(ds, "raw", "disk_images")
     memory_dir = memory_dir or os.path.join(ds, "raw", "memory")
     symbols_dir = symbols_dir or os.path.join(ds, "dependencies", "volatility3-symbols")
+    # The jsonl_dfir renderer is owned by the vendored PIIAT-Mem tool (the same
+    # renderer the volatility PROCESSOR drives through `python -m piiat_mem`); the
+    # memory scan bind-mounts it into the hardened dxdfir/volatility image, whose
+    # baked wrapper (/opt/dfir/vol_wrapper.py) loads it. It lives in the submodule,
+    # not in a dev-scripts/ tree.
     renderer = renderer or os.path.join(
-        repo_root, "dev-scripts", "volatility", "jsonl_dfir_renderer.py")
+        repo_root, "third_party", "piiat-mem", "jsonl_dfir_renderer.py")
     os.makedirs(output_dir, exist_ok=True)
 
     res = {"lane": "yara", "sources": list(sources), "produced": 0, "skipped": 0,

--- a/python/get_sybers_dxdfir/stix/behaviour.py
+++ b/python/get_sybers_dxdfir/stix/behaviour.py
@@ -1,0 +1,502 @@
+"""Behaviour sightings — the detection lanes joined to the CAR entities they touch.
+
+The north star is not *"run MITRE's CAR analytics"* — it is to let **threat
+detections light up behaviour over the cascaded, cross-source-resolved data**. A
+Suricata alert is one IP 5-tuple; a Hayabusa alert is one evtx record; a YARA hit
+is one process. On their own they say *what* fired, not *which entity across the
+rest of the evidence* it belongs to. This module performs that join — against the
+finished CAR stores (``car.db``) the engine wrote — and emits each join as a STIX
+2.1 **Sighting of the ATT&CK attack-pattern** the detection names, anchored to an
+``observed-data`` **keyed on the matched CAR row's spindle ``guid``** (the same
+behaviour-timeline entity every source of evidence converges onto).
+
+Where :mod:`.export` sights the rule *indicator* over observed-data minted from
+the detection's OWN fields, this sights the **attack-pattern** (BP §5.2:
+MITRE's authoritative object id, referenced not copied — the consumer's ATT&CK
+import holds it) over observed-data built from the **CAR entity** — so a bare C2
+IP reads as its resolved domain and the connection, and an evtx record reads as
+the process and its executable. The observed-data's identity IS the spindle guid
+(``case_scoped_id`` keyed on it), so every detector that touches the same entity
+references the SAME observation — the behaviour timeline as the primary axis.
+
+Only what the evidence carries becomes STIX: a detection that names no resolvable
+technique, or that joins to no CAR entity, is counted and skipped — never given an
+invented attack-pattern or a fabricated entity. Reuses the exchange's object
+builders (:mod:`.objects`), the authoritative ATT&CK index (:mod:`.attack_index`)
+and :mod:`.export`'s bundle assembly / validation, so a behaviour bundle merges
+object-for-object with the detection-export and PIIAT bundles.
+
+Join keys (offline, against ``car.db`` directly — the Elastic-native provenance
+join of ``detect/rules/*.car_join`` is a later phase):
+
+    suricata  alert src/dest IP        -> CAR ``flow`` (src_ip / dest_ip)
+    hayabusa  Sysmon ProcessGuid       -> CAR ``process`` (guid), else (host, pid)
+    yara      memory match PID (+host) -> CAR ``process`` (pid)
+              file/disk match hash     -> CAR ``file`` (sha256 / md5 / sha1)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from . import objects as o
+from .attack_index import AttackIndex, load_attack_index
+from .export import make_bundle, summarise, validate_bundle
+
+# CAR object tables the join reads (the engine's per-object store, one table per
+# CAR object — see PIIAT-MitreCar store.py). Only these carry a joinable subject.
+_FLOW_COLS = ("guid", "timestamp", "hostname", "fqdn", "src_ip", "dest_ip", "src_port",
+              "dest_port", "transport_protocol", "application_protocol", "dest_fqdn", "src_fqdn")
+_PROCESS_COLS = ("guid", "timestamp", "hostname", "fqdn", "pid", "command_line", "exe",
+                 "image_path", "user", "sid", "md5_hash", "sha1_hash", "sha256_hash")
+_FILE_COLS = ("guid", "timestamp", "hostname", "fqdn", "file_name", "file_path",
+              "md5_hash", "sha1_hash", "sha256_hash")
+
+
+# --------------------------------------------------------------------- CAR entities
+@dataclass(frozen=True)
+class CarRow:
+    """One matched CAR entity: its spindle ``guid``, its object table, the host it
+    belongs to, the observation instant and the columns the SCO builders need."""
+    object_type: str                     # flow / process / file
+    guid: str
+    host: str | None
+    timestamp: str | None                # STIX-normalised (UTC, ms) or None
+    cols: dict
+
+    @property
+    def label(self) -> str:
+        """A short human name for the entity (for a sighting's description)."""
+        c = self.cols
+        if self.object_type == "flow":
+            dst = c.get("dest_fqdn") or c.get("dest_ip")
+            return f"{c.get('src_ip') or '?'} -> {dst or '?'}"
+        if self.object_type == "process":
+            return os.path.basename(str(c.get("exe") or c.get("image_path") or "")) or f"pid {c.get('pid')}"
+        return os.path.basename(str(c.get("file_path") or c.get("file_name") or "")) or self.guid
+
+
+def _norm_ip(value) -> str | None:
+    obj = o.ip_address(value)
+    return obj["value"] if obj else None
+
+
+class CarIndex:
+    """Every joinable CAR entity across one or more ``car.db`` stores, indexed by
+    the keys the detection lanes carry. Built once, queried per detection."""
+
+    def __init__(self) -> None:
+        self.flows_by_ip: dict[str, list[CarRow]] = {}
+        self.flows_by_pair: dict[frozenset[str], list[CarRow]] = {}
+        self.process_by_guid: dict[str, CarRow] = {}
+        self.process_by_host_pid: dict[tuple[str, int], CarRow] = {}
+        self.process_by_pid: dict[int, list[CarRow]] = {}
+        self.file_by_hash: dict[str, CarRow] = {}
+        self.stores: list[str] = []
+
+    # -- ingest --------------------------------------------------------------
+    def add_store(self, car_db: str) -> None:
+        self.stores.append(car_db)
+        db = sqlite3.connect(f"file:{car_db}?mode=ro", uri=True)
+        try:
+            tables = {r[0] for r in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+            if "flow" in tables:
+                for row in self._rows(db, "flow", _FLOW_COLS):
+                    self._add_flow(row)
+            if "process" in tables:
+                for row in self._rows(db, "process", _PROCESS_COLS):
+                    self._add_process(row)
+            if "file" in tables:
+                for row in self._rows(db, "file", _FILE_COLS):
+                    self._add_file(row)
+        finally:
+            db.close()
+
+    @staticmethod
+    def _rows(db, table, cols) -> Iterable[dict]:
+        have = {r[1] for r in db.execute(f'PRAGMA table_info("{table}")')}
+        picked = [c for c in cols if c in have]
+        if "guid" not in picked:
+            return
+        for r in db.execute(f'SELECT {",".join(picked)} FROM "{table}"'):
+            yield dict(zip(picked, r))
+
+    def _row(self, object_type: str, c: dict) -> CarRow | None:
+        guid = c.get("guid")
+        if not guid:
+            return None
+        host = c.get("hostname") or c.get("fqdn")
+        return CarRow(object_type, str(guid), str(host) if host else None,
+                      o.stix_timestamp(c.get("timestamp")), c)
+
+    def _add_flow(self, c: dict) -> None:
+        row = self._row("flow", c)
+        if row is None:
+            return
+        src, dst = _norm_ip(c.get("src_ip")), _norm_ip(c.get("dest_ip"))
+        for ip in (src, dst):
+            if ip:
+                self.flows_by_ip.setdefault(ip, []).append(row)
+        if src and dst:
+            self.flows_by_pair.setdefault(frozenset((src, dst)), []).append(row)
+
+    def _add_process(self, c: dict) -> None:
+        row = self._row("process", c)
+        if row is None:
+            return
+        # ProcessGuid is the strongest key; keep the FIRST (a process's create wins
+        # over its later spoke events, which repeat the guid).
+        self.process_by_guid.setdefault(row.guid.lower(), row)
+        pid = _int(c.get("pid"))
+        if pid is not None:
+            self.process_by_pid.setdefault(pid, []).append(row)
+            if row.host:
+                self.process_by_host_pid.setdefault((row.host.lower(), pid), row)
+
+    def _add_file(self, c: dict) -> None:
+        row = self._row("file", c)
+        if row is None:
+            return
+        for h in (c.get("sha256_hash"), c.get("sha1_hash"), c.get("md5_hash")):
+            if h:
+                self.file_by_hash.setdefault(str(h).lower(), row)
+
+    # -- query ---------------------------------------------------------------
+    def match(self, det: "Detection") -> list[CarRow]:
+        """The CAR entities ``det`` touches (de-duplicated by guid, first-seen)."""
+        found: list[CarRow] = []
+        seen: set[str] = set()
+
+        def take(row: CarRow | None) -> None:
+            if row is not None and row.guid not in seen:
+                seen.add(row.guid)
+                found.append(row)
+
+        if det.source == "suricata":
+            # the specific connection (both endpoints) is the precise join; only when
+            # the alert names a single endpoint do we widen to every flow it touched.
+            pair = frozenset(det.ips)
+            if len(pair) >= 2 and pair in self.flows_by_pair:
+                for row in self.flows_by_pair[pair]:
+                    take(row)
+            else:
+                for ip in det.ips:
+                    for row in self.flows_by_ip.get(ip, ()):
+                        take(row)
+        elif det.source == "hayabusa":
+            if det.process_guid:
+                take(self.process_by_guid.get(det.process_guid.lower()))
+            if not found and det.host and det.pid is not None:
+                take(self.process_by_host_pid.get((det.host.lower(), det.pid)))
+        elif det.source == "yara":
+            for h in det.hashes:
+                take(self.file_by_hash.get(h.lower()))
+            if not found and det.pid is not None:
+                if det.host and (det.host.lower(), det.pid) in self.process_by_host_pid:
+                    take(self.process_by_host_pid.get((det.host.lower(), det.pid)))
+                else:
+                    for row in self.process_by_pid.get(det.pid, ()):
+                        take(row)
+        return found
+
+
+def _int(value) -> int | None:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+# ------------------------------------------------------------------- detections
+@dataclass
+class Detection:
+    """One normalised detection firing from a lane's raw output."""
+    source: str                          # suricata / hayabusa / yara
+    detection_id: str                    # the rules-as-code id (sig-*)
+    name: str                            # the human title (signature / rule / title)
+    techniques: list[str] = field(default_factory=list)
+    timestamp: str | None = None
+    host: str | None = None
+    ips: list[str] = field(default_factory=list)
+    process_guid: str | None = None
+    pid: int | None = None
+    process: str | None = None
+    hashes: list[str] = field(default_factory=list)
+    matched: dict = field(default_factory=dict)
+
+
+def suricata_detections(path: str) -> list[Detection]:
+    """Suricata EVE ``alert`` events -> detections. ATT&CK ids come from ET Open's
+    ``alert.metadata.mitre_technique_id`` (BP: the reference projection)."""
+    out: list[Detection] = []
+    for rec in _jsonl(path):
+        if rec.get("event_type") != "alert":
+            continue
+        alert = rec.get("alert") or {}
+        meta = alert.get("metadata") or {}
+        techs = o.technique_ids(meta.get("mitre_technique_id")) or o.technique_ids(meta)
+        ips = [ip for ip in (_norm_ip(rec.get("src_ip")), _norm_ip(rec.get("dest_ip"))) if ip]
+        out.append(Detection(
+            source="suricata", detection_id="sig-suricata-alert",
+            name=str(alert.get("signature") or "Suricata IDS alert"),
+            techniques=techs, timestamp=o.stix_timestamp(rec.get("timestamp")),
+            ips=ips, matched={"ips": ips, "signature_id": alert.get("signature_id")}))
+    return out
+
+
+# Hayabusa's JSON profile names the ProcessGuid / PID inside Details; the ATT&CK
+# ids ride in MitreTags (the ¦-separated profile) or, failing that, OtherTags.
+def hayabusa_detections(path: str) -> list[Detection]:
+    """Hayabusa Sigma-over-EVTX timeline -> detections (Sysmon process events carry
+    the ProcessGuid the CAR process is keyed on)."""
+    out: list[Detection] = []
+    for rec in _jsonl(path):
+        details = rec.get("Details") if isinstance(rec.get("Details"), dict) else {}
+        extra = rec.get("ExtraFieldInfo") if isinstance(rec.get("ExtraFieldInfo"), dict) else {}
+        techs = o.technique_ids(rec.get("MitreTags")) or o.technique_ids(rec.get("OtherTags"))
+        out.append(Detection(
+            source="hayabusa", detection_id="sig-hayabusa-high",
+            name=str(rec.get("RuleTitle") or "Hayabusa detection"),
+            techniques=techs, timestamp=o.stix_timestamp(rec.get("Timestamp")),
+            host=_str(rec.get("Computer")),
+            process_guid=_str(details.get("PGUID") or details.get("ProcessGuid") or extra.get("ProcessGuid")),
+            pid=_int(details.get("PID")), process=_str(details.get("Proc")),
+            hashes=_hashes_from_hayabusa(details.get("Hashes")),
+            matched={"record_id": rec.get("RecordID"), "channel": rec.get("Channel"),
+                     "event_id": rec.get("EventID"), "level": rec.get("Level")}))
+    return out
+
+
+def yara_detections(path: str) -> list[Detection]:
+    """YARA matches (``memory.jsonl`` / ``disk.jsonl`` / ``matches.jsonl``) ->
+    detections. The parsed match carries a rule + PID/process (memory) or a
+    target path (file/disk); ATT&CK ids are not in the parsed output."""
+    out: list[Detection] = []
+    for rec in _jsonl(path):
+        if rec.get("tool") != "yara" or not rec.get("rule"):
+            continue
+        out.append(Detection(
+            source="yara", detection_id="sig-yara-match", name=str(rec.get("rule")),
+            techniques=o.technique_ids(rec.get("rule")), host=_str(rec.get("host")),
+            pid=_int(rec.get("pid")), process=_str(rec.get("process")),
+            matched={"rule": rec.get("rule"), "yara_source": rec.get("source"),
+                     "target": rec.get("target"), "pid": rec.get("pid")}))
+    return out
+
+
+_DETECTION_FILES = {
+    "suricata": (suricata_detections, ("suricata",), (".eve.jsonl",)),
+    "hayabusa": (hayabusa_detections, ("hayabusa",), ("timeline.jsonl",)),
+    "yara": (yara_detections, ("yara",), ("memory.jsonl", "disk.jsonl", "matches.jsonl")),
+}
+
+
+def load_detections(detections_dir: str) -> list[Detection]:
+    """Every lane's output under ``<detections_dir>/<lane>/`` -> detections. A lane
+    with no output contributes nothing (never an error)."""
+    dets: list[Detection] = []
+    for lane, (parser, subdirs, suffixes) in _DETECTION_FILES.items():
+        for sub in subdirs:
+            base = os.path.join(detections_dir, sub)
+            if not os.path.isdir(base):
+                continue
+            for name in sorted(os.listdir(base)):
+                if any(name.endswith(sfx) for sfx in suffixes):
+                    dets.extend(parser(os.path.join(base, name)))
+    return dets
+
+
+# --------------------------------------------------------------- objects
+def _entity_observation(row: CarRow, case: str, put, created_by: str) -> str | None:
+    """The matched CAR entity as ONE connected ``observed-data`` graph, keyed on
+    its spindle ``guid`` (so every detector that touches the entity references the
+    same observation). ``None`` when the row carries nothing observable."""
+    when = row.timestamp
+    if not when:
+        return None
+    c = row.cols
+    if row.object_type == "flow":
+        src, dst = o.ip_address(c.get("src_ip")), o.ip_address(c.get("dest_ip"))
+        if not (src or dst):
+            return None
+        graph: list[str] = []
+        if src and dst:
+            base = "ipv6" if dst["type"] == "ipv6-addr" else "ipv4"
+            protos = [base] + [p for p in (c.get("transport_protocol"), c.get("application_protocol")) if p]
+            traffic = o.network_traffic(put(src), put(dst), src_port=_int(c.get("src_port")),
+                                        dst_port=_int(c.get("dest_port")), protocols=protos)
+            graph += [put(traffic), src["id"], dst["id"]]
+        else:
+            graph.append(put(src or dst))
+        # the spindle-resolved name on the flow — the "expand the alert beyond its
+        # source": the C2 IP read as its domain (DNS + SNI, cross-source).
+        dom = o.domain_name(c.get("dest_fqdn"))
+        if dom and dst:
+            dom["resolves_to_refs"] = [dst["id"]]
+            graph.append(put(dom))
+        return put(o.observed_data(case, row.guid, "network", graph, when, when, created_by=created_by))
+    if row.object_type in ("process", "file"):
+        name = os.path.basename(str(c.get("exe") or c.get("image_path") or c.get("file_path")
+                                    or c.get("file_name") or "")) or None
+        hashes = {k: c.get(v) for k, v in (("MD5", "md5_hash"), ("SHA-1", "sha1_hash"),
+                                           ("SHA-256", "sha256_hash")) if c.get(v)}
+        f = o.file_observable(name, hashes)
+        if f is None:
+            return None
+        return put(o.observed_data(case, row.guid, row.object_type, [put(f)], when, when, created_by=created_by))
+    return None
+
+
+def behaviour_objects(detections: Iterable[Detection], car: CarIndex, *, case_id: str,
+                      producer: str = o.DEFAULT_PRODUCER, tlp: str | None = "amber",
+                      attack: AttackIndex | None = None,
+                      contact: str | None = o.DEFAULT_CONTACT) -> tuple[dict[str, dict], dict]:
+    """The object graph for ``detections`` joined to ``car``, keyed by id, plus a
+    report. One ``sighting`` of the ATT&CK attack-pattern per (detection, entity,
+    technique), over the entity's spindle-keyed ``observed-data``."""
+    attack = attack or load_attack_index()
+    marking_ref = o.tlp_marking_ref(tlp) if tlp and str(tlp).lower() not in ("none", "no", "off", "") else None
+    objs: dict[str, dict] = {}
+    report = {"detections": 0, "sightings": 0, "entities": 0, "skipped": {},
+              "techniques": {"resolved": {}, "substituted": {}, "unresolved": []}}
+
+    def put(obj: dict) -> str:
+        o.mark(obj, marking_ref)
+        objs.setdefault(obj["id"], obj)
+        return obj["id"]
+
+    def skip(reason: str) -> None:
+        report["skipped"][reason] = report["skipped"].get(reason, 0) + 1
+
+    created_by = put(o.producer_identity(producer, contact))
+    put(o.extension_definition(created_by))
+    matched_guids: set[str] = set()
+    for det in detections:
+        report["detections"] += 1
+        # The cross-source join is judged FIRST: which CAR entity (if any) this
+        # detection touches is the point — "expand the alert beyond its source" —
+        # independent of whether the detection also names an ATT&CK technique.
+        rows = car.match(det)
+        if not rows:
+            skip("no_car_entity")
+            continue
+        for row in rows:                        # every entity a detection flags counts
+            matched_guids.add(row.guid)
+        resolved = [(t, attack.resolve(t)) for t in dict.fromkeys(det.techniques)]
+        for tid, r in resolved:
+            if r is None and tid not in report["techniques"]["unresolved"]:
+                report["techniques"]["unresolved"].append(tid)
+        resolved = [(t, r) for t, r in resolved if r is not None]
+        if not resolved:
+            # the join is real (e.g. a suricata alert on the resolved C2 flow), but
+            # the detection names no ATT&CK technique, so there is nothing to sight.
+            skip("joined_no_technique")
+            continue
+        when = det.timestamp
+        for row in rows:
+            od = _entity_observation(row, case_id, put, created_by)
+            if od is None:
+                skip("entity_not_observable")
+                continue
+            where = [put(o.host_identity(row.host, created_by))] if row.host else None
+            created = when or row.timestamp
+            for tid, res in resolved:
+                report["techniques"]["resolved"][tid] = res.technique.id
+                if res.substituted:
+                    report["techniques"]["substituted"][tid] = res.technique.external_id
+                key = f"{det.detection_id}|{row.guid}|{tid}"
+                put(o.sighting(
+                    case_id, key, res.technique.id, created=created, created_by=created_by,
+                    first_seen=when or row.timestamp, last_seen=when or row.timestamp,
+                    observed_data_refs=[od], where_sighted_refs=where,
+                    description=f"{det.name} — {row.label} ({res.technique.name})",
+                    dx={"case_id": case_id, "detection_id": det.detection_id, "source": det.source,
+                        "car_guid": row.guid, "car_object": row.object_type, "technique": tid,
+                        "signature": det.name, "matched": det.matched or None}))
+                report["sightings"] += 1
+    report["entities"] = len(matched_guids)
+    return objs, report
+
+
+def build_behaviour_bundle(detections: Iterable[Detection], car: CarIndex, **kw) -> tuple[dict, dict]:
+    """``detections`` joined to ``car`` -> ``(bundle, report)``."""
+    objs, report = behaviour_objects(detections, car, **kw)
+    return make_bundle(objs), report
+
+
+def run_behaviour(*, car_paths: Iterable[str], detections_dir: str, case_id: str,
+                  out: str | None = None, producer: str = o.DEFAULT_PRODUCER,
+                  tlp: str | None = "amber", attack_index: str | None = None) -> tuple[dict, dict]:
+    """Read the CAR stores + the lane outputs, join, assemble, validate, write
+    (if ``out``). Returns ``(summary, bundle)``; ``summary['ok']`` is False when
+    validation failed (nothing is written then)."""
+    car = CarIndex()
+    for p in _car_dbs(car_paths):
+        car.add_store(p)
+    detections = load_detections(detections_dir)
+    attack = load_attack_index(attack_index)
+    bundle, report = build_behaviour_bundle(detections, car, case_id=case_id, producer=producer,
+                                            tlp=tlp, attack=attack)
+    errors, warnings = validate_bundle(bundle, external_ids=attack.ids)
+    summary = {"tool": "stix-behaviour-sightings", "case_id": case_id,
+               "car_stores": car.stores, "detections_dir": detections_dir,
+               "report": report, "attack_version": attack.attack_version,
+               "summary": summarise(bundle), "bundle_id": bundle.get("id"),
+               "validation": {"errors": errors, "warnings": warnings},
+               "bundle": None, "ok": not errors}
+    if not errors and out:
+        from .export import write_bundle
+        write_bundle(bundle, out)
+        summary["bundle"] = out
+    return summary, bundle
+
+
+# ------------------------------------------------------------------- small helpers
+def _car_dbs(paths: Iterable[str]) -> list[str]:
+    """Resolve each path to the ``car.db`` files under it (a file is taken as-is; a
+    directory is walked for every ``car.db``)."""
+    found: list[str] = []
+    for p in paths:
+        if os.path.isfile(p):
+            found.append(p)
+        elif os.path.isdir(p):
+            for cur, _dirs, files in os.walk(p):
+                if "car.db" in files:
+                    found.append(os.path.join(cur, "car.db"))
+    return sorted(dict.fromkeys(found))
+
+
+def _jsonl(path: str) -> Iterable[dict]:
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(rec, dict):
+                yield rec
+
+
+def _str(value) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _hashes_from_hayabusa(value) -> list[str]:
+    """Sysmon's ``Hashes`` field ("SHA256=...,MD5=...") or a dict -> raw digests."""
+    out: list[str] = []
+    if isinstance(value, dict):
+        out = [str(v) for v in value.values() if v]
+    elif isinstance(value, str):
+        for part in value.replace(";", ",").split(","):
+            _algo, _, digest = part.partition("=")
+            if digest:
+                out.append(digest.strip())
+    return [h for h in out if h]

--- a/python/get_sybers_dxdfir/stix/cli.py
+++ b/python/get_sybers_dxdfir/stix/cli.py
@@ -90,6 +90,53 @@ def export(
         raise typer.Exit(1)
 
 
+@app.command(name="behaviour-sightings")
+def behaviour_sightings(
+    car: list[Path] = typer.Option(
+        ..., "--car", help="A source's car.db, or a tree to walk for every car.db (repeatable). The "
+                           "finished CAR stores the detections are joined to."),
+    detections: Path = typer.Option(
+        ..., "--detections", help="The detection-lane output dir (its suricata/ hayabusa/ yara/ subdirs), "
+                                  "e.g. data_store/processed/signatures."),
+    out: Path = typer.Option(None, "--out", help="Write the bundle here (default: stdout)."),
+    case: str = typer.Option(..., "--case", help="Case id scoping the observation/sighting ids."),
+    tlp: str = typer.Option(None, "--tlp", help="TLP marking on exported objects: " + "|".join(TLP_LEVELS) + "|none."),
+    producer: str = typer.Option(None, "--producer", help="Producer identity name (default: DX_DFIR)."),
+    attack_index: Path = typer.Option(
+        None, "--attack-index", help="ATT&CK index / STIX bundle (default: the committed index)."),
+    compact: bool = typer.Option(False, "--compact", help="Single-line JSON output instead of indented."),
+) -> None:
+    """Join the detection lanes to the CAR entities they touch and emit each as a
+    STIX 2.1 Sighting of the ATT&CK attack-pattern over the matched CAR row's
+    spindle-identified observed-data — the behaviour timeline as the primary axis.
+    """
+    from . import behaviour as _behaviour
+    from .objects import DEFAULT_PRODUCER
+    if not detections.is_dir():
+        typer.secho(f"--detections is not a directory: {detections}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2)
+    try:
+        summary, bundle_doc = _behaviour.run_behaviour(
+            car_paths=[str(p) for p in car], detections_dir=str(detections), case_id=case,
+            out=str(out) if out else None, producer=producer or DEFAULT_PRODUCER,
+            tlp=tlp, attack_index=str(attack_index) if attack_index else None)
+    except (OSError, ValueError) as e:
+        typer.secho(f"behaviour-sightings failed: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(2) from None
+
+    indent = None if compact else 2
+    to_stdout = not out and summary["ok"]
+    if to_stdout:
+        sys.stdout.write(json.dumps(bundle_doc, indent=indent, ensure_ascii=False, default=str) + "\n")
+        sys.stderr.write(json.dumps(summary, indent=indent, ensure_ascii=False, default=str) + "\n")
+    else:
+        sys.stdout.write(json.dumps(summary, indent=indent, ensure_ascii=False, default=str) + "\n")
+    if not summary["ok"]:
+        for problem in summary["validation"]["errors"]:
+            typer.secho(f"   • {problem}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(1)
+
+
 @app.command()
 def pull(
     out: Path = typer.Option(

--- a/python/tests/test_stix_behaviour_bridge.py
+++ b/python/tests/test_stix_behaviour_bridge.py
@@ -1,0 +1,247 @@
+"""Unit tests for the behaviour-sightings bridge (detections -> CAR entities ->
+STIX Sightings of ATT&CK attack-patterns over spindle-identified observed-data).
+
+No network, no docker: a synthetic ``car.db`` (the engine's per-object schema) and
+hand-written lane output exercise the join and the emitted object graph. The
+shape under test: the sighting sights the ATT&CK attack-pattern (MITRE's own id,
+referenced not shipped), its observed-data is keyed on the matched CAR row's
+spindle ``guid`` (so two detectors on one entity share the observation), the
+observed host is a where-sighted identity, and the bundle validates clean with
+ATT&CK ids as the permitted non-local references.
+"""
+import json
+import sqlite3
+import uuid
+
+import pytest
+
+from get_sybers_dxdfir.stix import attack_index, behaviour, export, objects
+
+# Real techniques that resolve in the committed ATT&CK index.
+T_SCAN = "T1046"        # Network Service Discovery — the masscan-style suricata alert
+T_EXEC = "T1059"        # Command and Scripting Interpreter — the DOSfuscated cmd hayabusa alert
+
+FLOW_GUID = "flow-guid-0001"
+PROC_GUID = "{11111111-2222-3333-4444-555555555555}"
+C2_IP = "100.101.0.42"
+C2_FQDN = "scoring-c2.berylia.org"
+HOST = "DESKTOP-M913391"
+WHEN = "2024-01-19T05:34:22.833000Z"
+
+
+def _make_car_db(path):
+    db = sqlite3.connect(path)
+    db.execute("CREATE TABLE flow (guid TEXT, timestamp TEXT, hostname TEXT, fqdn TEXT, src_ip TEXT, "
+               "dest_ip TEXT, src_port INT, dest_port INT, transport_protocol TEXT, "
+               "application_protocol TEXT, dest_fqdn TEXT, src_fqdn TEXT)")
+    db.execute("INSERT INTO flow VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+               (FLOW_GUID, "2024-01-19 05:34:22.000 +00:00", HOST, None, "10.0.0.5", C2_IP,
+                44100, 22, "tcp", "ssh", C2_FQDN, None))
+    db.execute("CREATE TABLE process (guid TEXT, timestamp TEXT, hostname TEXT, fqdn TEXT, pid INT, "
+               "command_line TEXT, exe TEXT, image_path TEXT, user TEXT, sid TEXT, "
+               "md5_hash TEXT, sha1_hash TEXT, sha256_hash TEXT)")
+    db.execute("INSERT INTO process VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+               (PROC_GUID, WHEN, HOST, None, 4242, "cmd  /c whoami", r"C:\Windows\System32\cmd.exe",
+                r"C:\Windows\System32\cmd.exe", "JDH", "S-1-5-21-1", None, None,
+                "a" * 64))
+    db.execute("CREATE TABLE file (guid TEXT, timestamp TEXT, hostname TEXT, fqdn TEXT, file_name TEXT, "
+               "file_path TEXT, md5_hash TEXT, sha1_hash TEXT, sha256_hash TEXT)")
+    db.commit()
+    db.close()
+
+
+def _write_detections(root):
+    (root / "suricata").mkdir()
+    (root / "hayabusa").mkdir()
+    (root / "yara").mkdir()
+    # suricata: an alert to the C2 IP carrying the masscan technique in ET metadata
+    with open(root / "suricata" / "cap.eve.jsonl", "w") as fh:
+        fh.write(json.dumps({
+            "event_type": "alert", "timestamp": "2024-01-19T05:34:22.500000+0000",
+            "src_ip": "10.0.0.5", "dest_ip": C2_IP, "dest_port": 22, "proto": "TCP",
+            "alert": {"signature": "ET SCAN NETWORK Outgoing Masscan detected", "signature_id": 2024364,
+                      "category": "Detection of a Network Scan",
+                      "metadata": {"mitre_technique_id": [T_SCAN]}}}) + "\n")
+        fh.write(json.dumps({"event_type": "flow", "src_ip": "10.0.0.5", "dest_ip": C2_IP}) + "\n")  # not an alert
+    # hayabusa: the high T1059 record on the process (Sysmon ProcessGuid = PGUID)
+    with open(root / "hayabusa" / "timeline.jsonl", "w") as fh:
+        fh.write(json.dumps({
+            "Timestamp": "2024-01-19 05:34:22.833 +00:00", "RuleTitle": "Cmd.EXE Missing Space Anomaly",
+            "Level": "high", "Computer": HOST, "Channel": "Sysmon", "EventID": 1, "RecordID": 5261,
+            "MitreTags": [f"{T_EXEC} ¦ T1204.002"],
+            "Details": {"Cmdline": "cmd /c whoami", "Proc": r"C:\Windows\System32\cmd.exe",
+                        "PGUID": PROC_GUID, "PID": 4242}}) + "\n")
+        fh.write(json.dumps({  # an info record with no technique -> no attack-pattern
+            "Timestamp": WHEN, "RuleTitle": "Proc Exec", "Level": "info", "Computer": HOST,
+            "Channel": "Sysmon", "EventID": 1, "RecordID": 5209, "OtherTags": ["sysmon"],
+            "Details": {"PGUID": PROC_GUID, "PID": 4242}}) + "\n")
+    # yara: a memory match on the process pid (rule name carries no technique)
+    with open(root / "yara" / "memory.jsonl", "w") as fh:
+        fh.write(json.dumps({"tool": "yara", "source": "memory", "rule": "SUSP_cmd_obfuscation",
+                             "pid": 4242, "process": "cmd.exe", "target": "memdump.mem"}) + "\n")
+
+
+@pytest.fixture()
+def car_and_detections(tmp_path):
+    car_db = tmp_path / "car.db"
+    _make_car_db(str(car_db))
+    det_dir = tmp_path / "signatures"
+    det_dir.mkdir()
+    _write_detections(det_dir)
+    return str(car_db), str(det_dir)
+
+
+# ------------------------------------------------------------------- the join
+def test_car_index_joins_by_ip_guid_and_pid(car_and_detections):
+    car_db, _ = car_and_detections
+    idx = behaviour.CarIndex()
+    idx.add_store(car_db)
+    # suricata: dest IP -> the flow
+    suri = behaviour.Detection(source="suricata", detection_id="sig-suricata-alert",
+                               name="x", ips=[C2_IP])
+    assert [r.object_type for r in idx.match(suri)] == ["flow"]
+    assert idx.match(suri)[0].guid == FLOW_GUID
+    # hayabusa: ProcessGuid -> the process
+    haya = behaviour.Detection(source="hayabusa", detection_id="sig-hayabusa-high",
+                               name="x", process_guid=PROC_GUID, host=HOST, pid=4242)
+    assert idx.match(haya)[0].guid == PROC_GUID
+    # yara: pid -> the process
+    ya = behaviour.Detection(source="yara", detection_id="sig-yara-match", name="x", pid=4242, host=HOST)
+    assert idx.match(ya)[0].guid == PROC_GUID
+
+
+def test_detection_parsers_extract_techniques_and_keys(car_and_detections):
+    _, det_dir = car_and_detections
+    dets = behaviour.load_detections(det_dir)
+    by_src = {d.source: d for d in dets if d.techniques}
+    assert by_src["suricata"].techniques == [T_SCAN]
+    assert C2_IP in by_src["suricata"].ips        # both endpoints indexed; the C2 IP joins the flow
+    haya = next(d for d in dets if d.source == "hayabusa" and d.techniques)
+    assert haya.techniques[0] == T_EXEC and haya.process_guid == PROC_GUID and haya.pid == 4242
+    # the info hayabusa row parses but carries no technique
+    assert any(d.source == "hayabusa" and not d.techniques for d in dets)
+
+
+# --------------------------------------------------------------- the sightings
+def test_sighting_of_attack_pattern_over_spindle_observed_data(car_and_detections):
+    car_db, det_dir = car_and_detections
+    idx = behaviour.CarIndex()
+    idx.add_store(car_db)
+    ai = attack_index.load_attack_index()
+    dets = behaviour.load_detections(det_dir)
+    objs, report = behaviour.behaviour_objects(dets, idx, case_id="case-1", attack=ai)
+
+    sightings = [x for x in objs.values() if x["type"] == "sighting"]
+    ap_scan = ai.resolve(T_SCAN).technique.id
+    ap_exec = ai.resolve(T_EXEC).technique.id
+
+    # every sighting sights an ATT&CK attack-pattern (never an indicator/SCO)
+    assert sightings, "expected at least the masscan + cmd sightings"
+    for s in sightings:
+        assert s["sighting_of_ref"].startswith("attack-pattern--")
+    sighted = {s["sighting_of_ref"] for s in sightings}
+    assert ap_scan in sighted and ap_exec in sighted
+
+    # the suricata sighting's observed-data is keyed on the FLOW's spindle guid
+    od_flow_id = objects.case_scoped_id("observed-data", "case-1", FLOW_GUID, "network")
+    scan_sight = next(s for s in sightings if s["sighting_of_ref"] == ap_scan)
+    assert scan_sight["observed_data_refs"] == [od_flow_id]
+    assert objects.extension_of(scan_sight)["car_guid"] == FLOW_GUID
+    assert objects.extension_of(scan_sight)["car_object"] == "flow"
+
+    # that observed-data resolves the C2 IP to its domain (the cross-source expand)
+    od_flow = objs[od_flow_id]
+    scos = [objs[r] for r in od_flow["object_refs"]]
+    domains = [s for s in scos if s["type"] == "domain-name"]
+    addrs = [s for s in scos if s["type"] == "ipv4-addr"]
+    assert any(d["value"] == C2_FQDN for d in domains)
+    assert any(a["value"] == C2_IP for a in addrs)
+    dom = domains[0]
+    assert dom.get("resolves_to_refs") and dom["resolves_to_refs"][0] in {a["id"] for a in addrs}
+
+    # the cmd sighting is where-sighted on the host, over the PROCESS spindle guid
+    od_proc_id = objects.case_scoped_id("observed-data", "case-1", PROC_GUID, "process")
+    exec_sight = next(s for s in sightings if s["sighting_of_ref"] == ap_exec)
+    assert exec_sight["observed_data_refs"] == [od_proc_id]
+    host_id = objects.host_identity(HOST, "x")["id"]
+    assert exec_sight["where_sighted_refs"] == [host_id]
+    assert objs[host_id]["type"] == "identity"
+
+    # the report counts what joined + the info row with no technique
+    assert report["sightings"] == len(sightings)
+    assert report["entities"] == 2                       # the flow and the process
+    # the info hayabusa + the (technique-less) yara match joined an entity but
+    # carry no ATT&CK technique -> counted as joined, never as no_car_entity
+    assert report["skipped"].get("joined_no_technique", 0) >= 1
+    assert report["skipped"].get("no_car_entity", 0) == 0
+
+
+def test_shared_observed_data_across_detectors(car_and_detections):
+    """hayabusa (T1059) and — if it resolved a technique — yara both touch the same
+    process; whichever sights it references the ONE process observed-data (spindle
+    guid = the shared key)."""
+    car_db, det_dir = car_and_detections
+    idx = behaviour.CarIndex()
+    idx.add_store(car_db)
+    dets = behaviour.load_detections(det_dir)
+    objs, _ = behaviour.behaviour_objects(dets, idx, case_id="case-1")
+    od_proc_id = objects.case_scoped_id("observed-data", "case-1", PROC_GUID, "process")
+    proc_sightings = [x for x in objs.values() if x["type"] == "sighting"
+                      and x.get("observed_data_refs") == [od_proc_id]]
+    assert proc_sightings, "the cmd sighting anchors to the process observed-data"
+    # exactly one observed-data object exists for the process guid (shared, not duplicated)
+    assert sum(1 for x in objs.values()
+               if x["type"] == "observed-data" and x["id"] == od_proc_id) == 1
+
+
+def test_bundle_validates_clean_with_attack_ids_as_external(car_and_detections):
+    car_db, det_dir = car_and_detections
+    idx = behaviour.CarIndex()
+    idx.add_store(car_db)
+    ai = attack_index.load_attack_index()
+    dets = behaviour.load_detections(det_dir)
+    bundle, _ = behaviour.build_behaviour_bundle(dets, idx, case_id="case-1", attack=ai)
+    errors, warnings = export.validate_bundle(bundle, external_ids=ai.ids)
+    assert errors == []
+    # the attack-pattern references are non-local by design (external_ids) -> no warning about them
+    assert not [w for w in warnings if "attack-pattern--" in w]
+
+
+def test_ids_are_deterministic(car_and_detections):
+    car_db, det_dir = car_and_detections
+    ai = attack_index.load_attack_index()
+
+    def run():
+        idx = behaviour.CarIndex()
+        idx.add_store(car_db)
+        b, _ = behaviour.build_behaviour_bundle(behaviour.load_detections(det_dir), idx,
+                                                case_id="case-1", attack=ai)
+        return sorted(o["id"] for o in b["objects"])
+    assert run() == run()
+
+
+def test_run_behaviour_writes_bundle(tmp_path, car_and_detections):
+    car_db, det_dir = car_and_detections
+    out = tmp_path / "behaviour.json"
+    summary, bundle = behaviour.run_behaviour(
+        car_paths=[car_db], detections_dir=det_dir, case_id="case-1", out=str(out))
+    assert summary["ok"] and summary["validation"]["errors"] == []
+    assert summary["bundle"] == str(out) and out.is_file()
+    assert summary["summary"]["sightings"] >= 2
+    on_disk = json.loads(out.read_text())
+    assert on_disk["type"] == "bundle" and on_disk["id"] == bundle["id"]
+
+
+def test_no_car_entity_is_skipped_not_invented(tmp_path):
+    """A detection that joins to nothing produces no sighting (never a fabricated
+    entity) and is counted."""
+    car_db = tmp_path / "car.db"
+    _make_car_db(str(car_db))
+    idx = behaviour.CarIndex()
+    idx.add_store(str(car_db))
+    orphan = behaviour.Detection(source="suricata", detection_id="sig-suricata-alert",
+                                 name="ET nothing", techniques=[T_SCAN], ips=["203.0.113.9"],
+                                 timestamp=WHEN)
+    objs, report = behaviour.behaviour_objects([orphan], idx, case_id="c")
+    assert not [x for x in objs.values() if x["type"] == "sighting"]
+    assert report["skipped"].get("no_car_entity") == 1


### PR DESCRIPTION
## What

Completes the detection → **behaviour** path teased in the research arc (Step 08's follow-up): the raw detection lanes joined to the CAR entities they touch, each join emitted as a STIX 2.1 **Sighting of the ATT&CK attack-pattern**, anchored to an `observed-data` **keyed on the matched CAR row's spindle `guid`** — the behaviour timeline as the primary axis — where-sighted on the host.

Where `dxdfir stix export` sights the rule *indicator* over observed-data minted from the detection's own fields, this sights the **attack-pattern** (MITRE's authoritative id, referenced not shipped) over observed-data built from the **CAR entity**, so a bare C2 IP reads as its resolved domain and an evtx record reads as the process and its executable.

## Changes

- **`python/get_sybers_dxdfir/stix/behaviour.py`** (new) + CLI `dxdfir stix behaviour-sightings --car <car.db|tree> --detections <dir> --case <id>`. Parses suricata EVE / hayabusa timeline / yara matches, joins to `car.db` (suricata → `flow` by the alert's **connection pair**; hayabusa → `process` by ProcessGuid, else `(host,pid)`; yara → `process` by pid / `file` by hash), emits the attack-pattern Sighting over spindle-keyed observed-data. Reuses `stix/objects.py` builders + `stix/export.py` bundle assembly/validation, so a behaviour bundle merges object-for-object with `stix export` and PIIAT's projection. Nothing invented — a detection with no resolvable technique or no CAR entity is counted and skipped.
- **fix(signatures):** the YARA **memory** lane's Volatility renderer defaulted to a nonexistent `dev-scripts/volatility/` path (the lane had never run) — corrected to the vendored PIIAT-Mem renderer, so `dxdfir process signatures --yara-sources memory` runs. The ansible lane relies on this default (it never passes `--renderer`).
- **docs/research/09-behaviour-sightings.md** + README index/ledger.

## Tests

8 golden-vector tests (synthetic `car.db` mirroring the engine schema + real detection formats) asserting: the sighting sights an attack-pattern, observed-data keyed on the spindle guid, the resolved-domain SCO on the flow, host where-sighted, clean validation with ATT&CK ids as the permitted non-local refs, deterministic ids, and no-invented-entity on a miss. **Root pytest: 373 pass.**

## Proven on `ls24-sample`

100 detections, every one joined a CAR entity (85 distinct). hayabusa RecordID **5261** (DOSfuscated `cmd /c`) → a **Sighting of `attack-pattern--970a3432…` (T1059.001)** over the evtx process's spindle observed-data (`cmd.exe` + SHA-256), where-sighted `DESKTOP-M913391`; **0 validation errors/warnings**. The 14 suricata C2 alerts join the resolved `scoring-c2.berylia.org` flow but carry no ATT&CK tag on those ET Open rules (recorded, not invented).

Pure DX python + docs; no engine/submodule change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)