### PR TITLE
Re-pin the engine at Byakugan integration's squash-merge commit

### DIFF
--- a/byakugan.ref
+++ b/byakugan.ref
@@ -22,4 +22,4 @@
 # Format: readers take the FIRST non-comment, non-blank line as the ref. Keep
 # it a full 40-hex sha — never a branch or tag — so checkouts are reproducible.
 # ==============================================================================
-b76955dffd09ffb9fa0c4dca5affc349b7e89f16
+c14c25bed0b7e7a0f5cc2009001b6c5aa1bb7c7f


### PR DESCRIPTION
Follow-up to #168 (merged). Byakugan#72 landed as a **squash** (`c14c25be`), so the pin #168 carried (`b76955d`) now survives only on Byakugan's PR branch — if that branch is deleted, every provisioning path (`setup-environment.sh`, smoke CI, the offline bundle) dies at an unfetchable sha. This one-line change re-points `byakugan.ref` at the squash commit on Byakugan's `integration`.

Safety of the swap: the squash tree is **byte-identical** to the validated pin (same git tree hash `bd64c48e`), and the full validation was re-proven against a checkout of the new pin anyway — 356 pytest with the engine e2e running the Go ingestion path (zero skips) and 43/43 repo checks.

Worth merging promptly, before any branch cleanup on the Byakugan side. (When Byakugan promotes `integration` → `main`, a merge-commit promote keeps `c14c25be` reachable and nothing more is needed; a squash promote would need one more re-pin like this one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m5uaSJmuLDTisHtHPqsoA

---
_Generated by [Claude Code](https://claude.ai/code/session_015m5uaSJmuLDTisHtHPqsoA)_