### PR TITLE
Re-pin the engine at Byakugan main's promote commit

### DIFF
--- a/byakugan.ref
+++ b/byakugan.ref
@@ -22,4 +22,4 @@
 # Format: readers take the FIRST non-comment, non-blank line as the ref. Keep
 # it a full 40-hex sha — never a branch or tag — so checkouts are reproducible.
 # ==============================================================================
-c14c25bed0b7e7a0f5cc2009001b6c5aa1bb7c7f
+0282a6421fed05b39a146f2e1acf351a94566396


### PR DESCRIPTION
Final pin move: Byakugan#73 promoted `integration` → `main` as a squash (`0282a64`), so `byakugan.ref` follows onto the main lineage — the previous pin (`c14c25be`) survives only on Byakugan's `integration` branch, and deleting that branch would strand every provisioning path at an unfetchable sha. With this, the pin sits on Byakugan `main` permanently and no further re-pins are ever needed.

Safety: the promote tree is **byte-identical** to the pinned one (git tree hash `bd64c48e` on both), and validation was re-proven against a checkout of the new pin regardless — 356 pytest with the engine e2e running the Go ingestion path (zero skips) and 43/43 repo checks.

After this merges, Byakugan's `integration` branch and both repos' old `claude/*` branches can be safely deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m5uaSJmuLDTisHtHPqsoA

---
_Generated by [Claude Code](https://claude.ai/code/session_015m5uaSJmuLDTisHtHPqsoA)_