### PR TITLE
feat(cli): landing dashboard for a bare `dxdfir` + one-command build/link

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -23,7 +23,7 @@ install: ## go install as `dxdfir` (into $GOBIN / $GOPATH/bin)
 	$(GO) install ./cmd/dxdfir
 
 link: build ## build, then put a `dxdfir` shortcut on PATH (same layout as setup-environment.sh; uses sudo when not root)
-	$(SUDO) mkdir -p "$(GO_BIN_DIR)"
+	$(SUDO) mkdir -p "$(GO_BIN_DIR)" "$(LINK_DIR)"
 	$(SUDO) install -m0755 "$(BIN)" "$(GO_BIN_DIR)/dxdfir"
 	$(SUDO) ln -sf "$(GO_BIN_DIR)/dxdfir" "$(LINK_DIR)/dxdfir"
 	$(SUDO) install -Dm644 man/dxdfir.1 "$(MAN_DIR)/dxdfir.1" 2>/dev/null \

--- a/go/Makefile
+++ b/go/Makefile
@@ -3,13 +3,32 @@ GO      ?= go
 BIN     ?= dxdfir
 PREFIX  ?=
 
-.PHONY: build install check fmt vet tidy clean
+# `make link` install layout — the SAME as scripts/setup-environment.sh, so a
+# rebuild after a code edit drops the new binary exactly where the provisioned
+# host already points. Override any of these on the command line if needed.
+# (Keep these assignments comment-free: a trailing `# ...` here would leak the
+# whitespace before it into the value and corrupt the install paths.)
+GO_BIN_DIR ?= /opt/dxdfir/bin
+LINK_DIR   ?= /usr/local/bin
+MAN_DIR    ?= /usr/local/share/man/man1
+# Auto-elevate only when not already root (empty $(SUDO) is a no-op prefix).
+SUDO       ?= $(shell [ "$$(id -u)" -eq 0 ] || echo sudo)
+
+.PHONY: build install link check fmt fmt-check vet tidy clean
 
 build: ## build ./dxdfir
 	$(GO) build -o $(BIN) ./cmd/dxdfir
 
-install: ## go install as `dxdfir`
+install: ## go install as `dxdfir` (into $GOBIN / $GOPATH/bin)
 	$(GO) install ./cmd/dxdfir
+
+link: build ## build, then put a `dxdfir` shortcut on PATH (same layout as setup-environment.sh; uses sudo when not root)
+	$(SUDO) mkdir -p "$(GO_BIN_DIR)"
+	$(SUDO) install -m0755 "$(BIN)" "$(GO_BIN_DIR)/dxdfir"
+	$(SUDO) ln -sf "$(GO_BIN_DIR)/dxdfir" "$(LINK_DIR)/dxdfir"
+	$(SUDO) install -Dm644 man/dxdfir.1 "$(MAN_DIR)/dxdfir.1" 2>/dev/null \
+		|| echo "note: man page not installed (read: man ./man/dxdfir.1)"
+	@echo "linked: $(LINK_DIR)/dxdfir -> $(GO_BIN_DIR)/dxdfir   —   run it anywhere:  dxdfir"
 
 check: fmt-check vet build ## gofmt -l, go vet, build
 

--- a/go/README.md
+++ b/go/README.md
@@ -60,9 +60,18 @@ honest progress signal without un-swallowing the tools' firehose of output.
 ```sh
 cd go
 make            # build ./dxdfir
+make link       # build + put a `dxdfir` shortcut on PATH (rebuild-after-edit; uses sudo when not root)
 make install    # go install to $GOBIN / $GOPATH/bin as `dxdfir`
 make check      # gofmt -l, go vet, go build
 ```
+
+`make link` is the quick way to rebuild after a code change and have `dxdfir`
+runnable anywhere without the full filepath: it builds, installs the binary to
+`/opt/dxdfir/bin/dxdfir`, and symlinks `/usr/local/bin/dxdfir` to it — the exact
+layout `scripts/setup-environment.sh` provisions, so it reuses (or creates) the
+same shortcut. Override the destinations with `make link GO_BIN_DIR=… LINK_DIR=…`.
+(`make install` uses `go install`, which lands in `$GOBIN`/`$GOPATH/bin` and only
+works as a shortcut if that directory is already on your `PATH`.)
 
 Requires Go ≥ 1.24. Dependencies (termui, cobra, go-ansible) are pinned in `go.mod`.
 

--- a/go/internal/cli/home.go
+++ b/go/internal/cli/home.go
@@ -101,8 +101,17 @@ func gatherCollections(r *repo.Repo) (colls []model.CollInfo, note, hardErr stri
 		return nil, "", "collection registry unavailable: " + firstNonEmptyLine(msg)
 	}
 	var st collStatus
-	if json.Unmarshal([]byte(stdout), &st) != nil {
-		return nil, "", "collection status could not be parsed"
+	if e := json.Unmarshal([]byte(stdout), &st); e != nil {
+		// Surface what actually came back (a warning printed on stdout, say)
+		// instead of a bare "could not be parsed".
+		hint := firstNonEmptyLine(stdout)
+		if hint == "" {
+			hint = firstNonEmptyLine(stderr)
+		}
+		if hint == "" {
+			hint = e.Error()
+		}
+		return nil, "", "collection status could not be parsed: " + hint
 	}
 
 	for _, c := range st.Registered {

--- a/go/internal/cli/home.go
+++ b/go/internal/cli/home.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/get-sybers/dx_dfir/go/internal/health"
+	"github.com/get-sybers/dx_dfir/go/internal/model"
+	"github.com/get-sybers/dx_dfir/go/internal/plain"
+	"github.com/get-sybers/dx_dfir/go/internal/repo"
+	"github.com/get-sybers/dx_dfir/go/internal/run"
+	"github.com/get-sybers/dx_dfir/go/internal/termdetect"
+	"github.com/get-sybers/dx_dfir/go/internal/tui"
+)
+
+// collBudget bounds the full collection-registry scan. It walks every registered
+// collection to tally lane counts, which is fast on a normal host but slow over a
+// large/networked evidence store; past the budget the dashboard shows an instant
+// directory-name listing instead so it never hangs on the welcome screen.
+const collBudget = 5 * time.Second
+
+// runHome renders the landing dashboard for a bare `dxdfir`: a welcome header,
+// the environment-readiness panel (the checks that must be green before evidence
+// can be processed), the tracked collections, and the staged evidence per lane.
+// It is deliberately tolerant — a missing repo, absent python, or an unreadable
+// registry each degrade to a visible amber/red row rather than an error exit, so
+// the dashboard's whole job (telling the operator what is and isn't ready) still
+// works on a half-provisioned host.
+func runHome(env *Env, version string) error {
+	h := model.Home{Version: version}
+	// Best-effort repo detection: nil is a first-class state the checks report on.
+	r, _ := repo.Detect(env.RepoRoot)
+	if r != nil {
+		h.RepoRoot = r.Root
+	}
+
+	// Gather the three panels concurrently, each bounded, so the slowest source
+	// (the collection scan over the evidence store) caps the whole wait rather
+	// than summing with the readiness probes.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); h.Checks = health.Probe(r) }()
+	if r != nil {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			h.Collections, h.CollNote, h.CollErr = gatherCollections(r)
+		}()
+		go func() { defer wg.Done(); h.Lanes = gatherLanes(r) }()
+	} else {
+		h.CollErr = "repo not located - collections and evidence unavailable"
+	}
+	wg.Wait()
+
+	if !env.ForcePlain && termdetect.UseTUI(env.ForceTUI) {
+		if err := tui.RunHome(h); !errors.Is(err, tui.ErrNoTTY) {
+			return err
+		}
+		// dashboard declined (not a terminal, or too small) — fall through to plain.
+	}
+	plain.PrintHome(os.Stdout, h)
+	return nil
+}
+
+// gatherCollections reads the collection registry the same way `collection list`
+// does, but quietly and within a time budget: any failure is returned as a
+// message for the panel instead of being printed and turned into an error exit.
+// Returns (collections, note, hardErr) — note accompanies a list, hardErr
+// replaces it. When the full scan overruns the budget it degrades to an instant
+// listing of the collection directory names so tracked collections still show.
+func gatherCollections(r *repo.Repo) (colls []model.CollInfo, note, hardErr string) {
+	py, err := repo.Python()
+	if err != nil {
+		if fast := fastCollections(r); len(fast) > 0 {
+			return fast, "python unavailable - names only (from data_store/raw/collections/)", ""
+		}
+		return nil, "", "python unavailable - collections cannot be read"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), collBudget)
+	defer cancel()
+	full := []string{"-m", "get_sybers_dxdfir.collection", "--repo-root", r.Root, "status"}
+	stdout, stderr, err := run.Capture(ctx, run.Plan{Bin: py, Args: full, Dir: r.Root})
+	if err != nil {
+		// Timed out scanning the evidence store: fall back to instant dir names.
+		if ctx.Err() == context.DeadlineExceeded {
+			if fast := fastCollections(r); len(fast) > 0 {
+				return fast, "registry scan slow over the evidence store - names only; `dxdfir collection list` for counts", ""
+			}
+			return nil, "", "collection registry slow to respond - try `dxdfir collection list`"
+		}
+		msg := strings.TrimSpace(stderr)
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, "", "collection registry unavailable: " + firstNonEmptyLine(msg)
+	}
+	var st collStatus
+	if json.Unmarshal([]byte(stdout), &st) != nil {
+		return nil, "", "collection status could not be parsed"
+	}
+
+	for _, c := range st.Registered {
+		colls = append(colls, collInfo(c, st.Active, ""))
+	}
+	for _, c := range st.Unregistered {
+		colls = append(colls, collInfo(c, st.Active, "unregistered"))
+	}
+	for _, name := range st.Candidates {
+		colls = append(colls, model.CollInfo{Name: name, Lanes: "dropzone", Tag: "candidate"})
+	}
+	return colls, "", ""
+}
+
+// fastCollections lists the collection directory names under
+// data_store/raw/collections/ without descending into them — an instant fallback
+// when the full registry scan is too slow. Names only; no lane counts or active
+// marker (those need the walk the fast path skips).
+func fastCollections(r *repo.Repo) []model.CollInfo {
+	entries, err := os.ReadDir(r.Path("data_store", "raw", "collections"))
+	if err != nil {
+		return nil
+	}
+	var out []model.CollInfo
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue // skip the .registry.db and other dotfiles
+		}
+		// Total -1 / empty Lanes => "unknown", so renderers don't imply 0 files.
+		out = append(out, model.CollInfo{Name: e.Name(), Total: -1})
+	}
+	return out
+}
+
+func collInfo(c collSummary, active, tag string) model.CollInfo {
+	sha := ""
+	if c.Sha1 != nil && *c.Sha1 != "" {
+		sha = trunc(*c.Sha1, 12)
+	}
+	return model.CollInfo{
+		Name:   c.Name,
+		Total:  c.Total,
+		Lanes:  laneDetail(c.Lanes),
+		Sha1:   sha,
+		Active: c.Name == active,
+		Tag:    tag,
+	}
+}
+
+// gatherLanes counts staged evidence per processing lane over data_store/raw/,
+// reusing the same lane definitions `list lanes` prints.
+func gatherLanes(r *repo.Repo) []model.LaneCount {
+	raw := r.Path("data_store", "raw")
+	out := make([]model.LaneCount, 0, len(evidenceLanes))
+	for _, lane := range evidenceLanes {
+		count := 0
+		for _, sub := range lane.subs {
+			d := filepath.Join(raw, sub)
+			if dirExists(d) {
+				count += countFilesByExt(d, lane.exts)
+			}
+		}
+		out = append(out, model.LaneCount{
+			Name:   lane.name,
+			Count:  count,
+			Loc:    strings.Join(lane.subs, ", ") + "/",
+			Staged: count > 0,
+		})
+	}
+	return out
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, ln := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(ln); t != "" {
+			return t
+		}
+	}
+	return s
+}

--- a/go/internal/cli/root.go
+++ b/go/internal/cli/root.go
@@ -53,10 +53,23 @@ func NewRootCmd(version string) *cobra.Command {
 		Long: "DX_DFIR forensic processing pipeline — process evidence, build + verify CAR, validate.\n\n" +
 			"A Go/termui front-end over the get_sybers.dxdfir Ansible collection and the\n" +
 			"get_sybers_dxdfir Python processors. Long-running processing and collection\n" +
-			"creation render a live dashboard on a terminal; output stays plain when piped.",
+			"creation render a live dashboard on a terminal; output stays plain when piped.\n\n" +
+			"Run `dxdfir` with no command for a landing dashboard: environment readiness\n" +
+			"(the checks that must be green before processing), tracked collections, and\n" +
+			"staged evidence.",
 		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		// A bare `dxdfir` (no subcommand) renders the landing dashboard: version,
+		// environment readiness, tracked collections, staged evidence. An unknown
+		// verb still errors as before rather than silently opening the dashboard.
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return Fail(2, "unknown command %q for dxdfir — see `dxdfir --help`", args[0])
+			}
+			return runHome(env, version)
+		},
 		// Make the get_sybers_dxdfir package importable by every child python we
 		// shell out to, from a bare checkout as well as an installed environment:
 		// prepend <repo>/python to PYTHONPATH once, before any verb runs. Silent

--- a/go/internal/health/health.go
+++ b/go/internal/health/health.go
@@ -80,7 +80,7 @@ func checkPython(r *repo.Repo) model.Check {
 		// broken interpreter. Warn (a gate that is not OK blocks READY) rather
 		// than claim the environment is usable.
 		c.State = model.CheckWarn
-		c.Detail = "found at " + py + ", but `python --version` failed or timed out"
+		c.Detail = "found at " + py + ", but `" + filepath.Base(py) + " --version` failed or timed out"
 		return c
 	}
 	c.State = model.CheckOK

--- a/go/internal/health/health.go
+++ b/go/internal/health/health.go
@@ -1,0 +1,297 @@
+// Package health probes the local environment for the preconditions the DX_DFIR
+// pipeline needs before it can process evidence, so the home dashboard can show
+// a green/amber/red readiness panel. Every probe is bounded by a short timeout
+// and they run concurrently, so a slow or hung tool (a stuck docker daemon, say)
+// never holds the whole dashboard hostage.
+package health
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/get-sybers/dx_dfir/go/internal/model"
+	"github.com/get-sybers/dx_dfir/go/internal/repo"
+	"github.com/get-sybers/dx_dfir/go/internal/run"
+)
+
+// probeTimeout bounds any single external probe (a --version call, docker info).
+// Generous enough for a cold python/ansible start, short enough that the whole
+// concurrent sweep still returns promptly when one tool is wedged.
+const probeTimeout = 5 * time.Second
+
+// Probe runs every readiness check concurrently against the resolved repo (which
+// may be nil when the checkout could not be located) and returns them in a
+// stable display order: gating preconditions first, lane-specific capabilities
+// last.
+func Probe(r *repo.Repo) []model.Check {
+	probes := []func(*repo.Repo) model.Check{
+		checkRepo,
+		checkPython,
+		checkProcessors,
+		checkAnsible,
+		checkCollection,
+		checkDocker,
+		checkPiiatMem,
+		checkByakugan,
+	}
+	out := make([]model.Check, len(probes))
+	var wg sync.WaitGroup
+	for i, fn := range probes {
+		wg.Add(1)
+		go func(i int, fn func(*repo.Repo) model.Check) {
+			defer wg.Done()
+			out[i] = fn(r)
+		}(i, fn)
+	}
+	wg.Wait()
+	return out
+}
+
+// --- gating preconditions (must be green before `process`) ---
+
+func checkRepo(r *repo.Repo) model.Check {
+	c := model.Check{Name: "repo", Gate: true}
+	if r == nil {
+		c.State = model.CheckFail
+		c.Detail = "no DX_DFIR checkout found - pass --repo-root or set $DFIR_REPO_ROOT"
+		return c
+	}
+	c.State = model.CheckOK
+	c.Detail = r.Root
+	return c
+}
+
+func checkPython(r *repo.Repo) model.Check {
+	c := model.Check{Name: "python3", Gate: true}
+	py, err := repo.Python()
+	if err != nil {
+		c.State = model.CheckFail
+		c.Detail = "no python interpreter on PATH (set $DXDFIR_PYTHON or install python3)"
+		return c
+	}
+	out, _, ok := capture(py, "--version")
+	c.State = model.CheckOK
+	if ver := firstLine(out); ok && ver != "" {
+		c.Detail = strings.TrimSpace(ver) + " (" + py + ")"
+	} else {
+		c.Detail = py
+	}
+	return c
+}
+
+// checkProcessors verifies the get_sybers_dxdfir package is importable — the
+// processor package every lane and the collection registry depend on. It imports
+// exactly as a driven child would: PYTHONPATH-prepended <repo>/python.
+func checkProcessors(r *repo.Repo) model.Check {
+	c := model.Check{Name: "processors", Gate: true}
+	py, err := repo.Python()
+	if err != nil {
+		c.State = model.CheckFail
+		c.Detail = "python interpreter unavailable"
+		return c
+	}
+	var env []string
+	if r != nil {
+		env = []string{"PYTHONPATH=" + pythonPath(r)}
+	}
+	const script = "import get_sybers_dxdfir as m,sys; sys.stdout.write(getattr(m,'__version__',''))"
+	out, errOut, ok := captureEnv(env, py, "-c", script)
+	if !ok {
+		c.State = model.CheckFail
+		c.Detail = "get_sybers_dxdfir not importable - run scripts/setup-environment.sh (pip install ./python)"
+		if msg := lastMeaningful(errOut); msg != "" {
+			c.Detail = "import failed: " + msg
+		}
+		return c
+	}
+	c.State = model.CheckOK
+	if v := strings.TrimSpace(out); v != "" {
+		c.Detail = "get_sybers_dxdfir " + v
+	} else {
+		c.Detail = "get_sybers_dxdfir importable"
+	}
+	return c
+}
+
+func checkAnsible(r *repo.Repo) model.Check {
+	c := model.Check{Name: "ansible", Gate: true}
+	ap, err := repo.AnsiblePlaybook()
+	if err != nil {
+		c.State = model.CheckFail
+		c.Detail = "ansible-playbook not found - it ships with the get_sybers_dxdfir install"
+		return c
+	}
+	out, _, ok := capture(ap, "--version")
+	c.State = model.CheckOK
+	if ver := firstLine(out); ok && ver != "" {
+		c.Detail = strings.TrimSpace(ver)
+	} else {
+		c.Detail = ap
+	}
+	return c
+}
+
+func checkCollection(r *repo.Repo) model.Check {
+	c := model.Check{Name: "collection", Gate: true}
+	if r == nil {
+		c.State = model.CheckFail
+		c.Detail = "repo not located"
+		return c
+	}
+	dir := r.CollectionDir()
+	if isDir(dir) {
+		c.State = model.CheckOK
+		c.Detail = "get_sybers.dxdfir (" + repo.CollectionPath + ")"
+		return c
+	}
+	c.State = model.CheckFail
+	c.Detail = "get_sybers.dxdfir collection missing at " + dir
+	return c
+}
+
+// checkDocker gates on both the CLI being present and the daemon being
+// reachable: the processing lanes run in the pipeline's docker images, so a
+// missing daemon blocks `process` even though the binary is installed.
+func checkDocker(r *repo.Repo) model.Check {
+	c := model.Check{Name: "docker", Gate: true}
+	if _, err := exec.LookPath("docker"); err != nil {
+		c.State = model.CheckFail
+		c.Detail = "docker not on PATH"
+		return c
+	}
+	out, _, ok := capture("docker", "info", "--format", "{{.ServerVersion}}")
+	if ok && strings.TrimSpace(out) != "" {
+		c.State = model.CheckOK
+		c.Detail = "engine " + strings.TrimSpace(firstLine(out))
+		return c
+	}
+	c.State = model.CheckFail
+	c.Detail = "daemon unreachable - is dockerd running / are you in the docker group?"
+	return c
+}
+
+// --- lane-specific capabilities (warn, not a hard gate) ---
+
+// checkPiiatMem reports whether the vendored PIIAT-Mem submodule is initialised;
+// the volatility lane reads its tree, so an uninitialised submodule narrows the
+// pipeline to the other lanes rather than blocking it.
+func checkPiiatMem(r *repo.Repo) model.Check {
+	c := model.Check{Name: "piiat-mem", Gate: false}
+	if r == nil {
+		c.State = model.CheckWarn
+		c.Detail = "repo not located"
+		return c
+	}
+	dir := r.Path("third_party", "piiat-mem")
+	if isNonEmptyDir(dir) {
+		c.State = model.CheckOK
+		c.Detail = "submodule initialised (volatility lane)"
+		return c
+	}
+	c.State = model.CheckWarn
+	c.Detail = "submodule not initialised - volatility lane unavailable (git submodule update --init)"
+	return c
+}
+
+// checkByakugan reports whether the external Byakugan engine is provisioned and
+// its parse binary built. It is needed only for the CAR build/timeline verbs, so
+// its absence is a warning, never a process gate. Resolution mirrors the python
+// seam and setup script: $BYAKUGAN_ROOT, else the `byakugan` dir beside the repo.
+func checkByakugan(r *repo.Repo) model.Check {
+	c := model.Check{Name: "byakugan", Gate: false}
+	root := byakuganRoot(r)
+	if root == "" {
+		c.State = model.CheckWarn
+		c.Detail = "engine root unknown (repo not located)"
+		return c
+	}
+	if !isDir(root) {
+		c.State = model.CheckWarn
+		c.Detail = "engine not provisioned at " + root + " (needed for build-car)"
+		return c
+	}
+	if !isExecutable(filepath.Join(root, "go", "bin", "byakugan-parse")) {
+		c.State = model.CheckWarn
+		c.Detail = "engine present, parse binary not built (make -C " + root + "/go build)"
+		return c
+	}
+	c.State = model.CheckOK
+	c.Detail = "engine at " + root
+	return c
+}
+
+// byakuganRoot resolves the engine checkout the same way mitrecar.py does.
+func byakuganRoot(r *repo.Repo) string {
+	if v := os.Getenv("BYAKUGAN_ROOT"); v != "" {
+		return v
+	}
+	if r == nil {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(r.Root), "byakugan")
+}
+
+// --- helpers ---
+
+func pythonPath(r *repo.Repo) string {
+	pp := r.Path("python")
+	if cur := os.Getenv("PYTHONPATH"); cur != "" {
+		pp += string(os.PathListSeparator) + cur
+	}
+	return pp
+}
+
+func capture(bin string, args ...string) (stdout, stderr string, ok bool) {
+	return captureEnv(nil, bin, args...)
+}
+
+func captureEnv(env []string, bin string, args ...string) (stdout, stderr string, ok bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+	out, errOut, err := run.Capture(ctx, run.Plan{Bin: bin, Args: args, Env: env})
+	return out, errOut, err == nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// lastMeaningful returns the last non-blank line of a python traceback — the
+// "ModuleNotFoundError: ..." line, not the framing above it.
+func lastMeaningful(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+func isDir(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
+func isNonEmptyDir(p string) bool {
+	f, err := os.Open(p)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	names, _ := f.Readdirnames(1)
+	return len(names) > 0
+}
+
+func isExecutable(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir() && fi.Mode()&0o111 != 0
+}

--- a/go/internal/health/health.go
+++ b/go/internal/health/health.go
@@ -75,9 +75,17 @@ func checkPython(r *repo.Repo) model.Check {
 		return c
 	}
 	out, _, ok := capture(py, "--version")
+	if !ok {
+		// Found on PATH but it will not even print its version — a wedged or
+		// broken interpreter. Warn (a gate that is not OK blocks READY) rather
+		// than claim the environment is usable.
+		c.State = model.CheckWarn
+		c.Detail = "found at " + py + ", but `python --version` failed or timed out"
+		return c
+	}
 	c.State = model.CheckOK
-	if ver := firstLine(out); ok && ver != "" {
-		c.Detail = strings.TrimSpace(ver) + " (" + py + ")"
+	if ver := strings.TrimSpace(firstLine(out)); ver != "" {
+		c.Detail = ver + " (" + py + ")"
 	} else {
 		c.Detail = py
 	}
@@ -102,10 +110,12 @@ func checkProcessors(r *repo.Repo) model.Check {
 	const script = "import get_sybers_dxdfir as m,sys; sys.stdout.write(getattr(m,'__version__',''))"
 	out, errOut, ok := captureEnv(env, py, "-c", script)
 	if !ok {
+		// Keep the actionable remediation; fold the traceback tail in as context
+		// rather than replacing the hint with it.
 		c.State = model.CheckFail
-		c.Detail = "get_sybers_dxdfir not importable - run scripts/setup-environment.sh (pip install ./python)"
+		c.Detail = "not importable - run scripts/setup-environment.sh (pip install ./python)"
 		if msg := lastMeaningful(errOut); msg != "" {
-			c.Detail = "import failed: " + msg
+			c.Detail = "not importable (" + msg + ") - run scripts/setup-environment.sh (pip install ./python)"
 		}
 		return c
 	}
@@ -127,9 +137,14 @@ func checkAnsible(r *repo.Repo) model.Check {
 		return c
 	}
 	out, _, ok := capture(ap, "--version")
+	if !ok {
+		c.State = model.CheckWarn
+		c.Detail = "found at " + ap + ", but `ansible-playbook --version` failed or timed out"
+		return c
+	}
 	c.State = model.CheckOK
-	if ver := firstLine(out); ok && ver != "" {
-		c.Detail = strings.TrimSpace(ver)
+	if ver := strings.TrimSpace(firstLine(out)); ver != "" {
+		c.Detail = ver
 	} else {
 		c.Detail = ap
 	}

--- a/go/internal/model/home.go
+++ b/go/internal/model/home.go
@@ -1,0 +1,77 @@
+package model
+
+// This file holds the model for the landing dashboard shown by a bare `dxdfir`
+// (version + environment readiness + tracked collections + staged evidence).
+// Unlike Snapshot, it is not a progress stream — it is a single point-in-time
+// picture assembled once by the cli layer and rendered by tui or plain. It lives
+// in the model package for the same reason Snapshot does: both presenters and
+// the assembler depend on it, and it imports neither termui nor os/exec.
+
+// CheckState is the outcome of one environment readiness probe.
+type CheckState string
+
+const (
+	CheckOK   CheckState = "ok"   // precondition satisfied
+	CheckWarn CheckState = "warn" // usable, but a lane/capability is unavailable
+	CheckFail CheckState = "fail" // a gating precondition is not met
+)
+
+// Check is one environment readiness probe on the home dashboard.
+type Check struct {
+	Name   string     // short label, e.g. "docker"
+	State  CheckState // ok / warn / fail
+	Detail string     // resolved path or version on success; the reason on failure
+	// Gate is true when this precondition must be green before `process` can run.
+	// A failing non-gate check (warn) narrows what is available (a specific lane
+	// or the CAR build) without blocking the pipeline as a whole.
+	Gate bool
+}
+
+// CollInfo is one tracked collection summarised for the home dashboard, mirroring
+// the fields `dxdfir collection list` shows.
+type CollInfo struct {
+	Name   string
+	Total  int
+	Lanes  string // "evtx:3, zeek:1", or "empty"
+	Sha1   string // short sha1, or "" when the evidence is not hashed yet
+	Active bool   // the selected active collection
+	Tag    string // "", "unregistered", or "candidate"
+}
+
+// LaneCount is staged evidence for one processing lane over data_store/raw/.
+type LaneCount struct {
+	Name   string
+	Count  int
+	Loc    string // the raw/ subdir(s) it reads, e.g. "logs/winevt/"
+	Staged bool   // Count > 0
+}
+
+// Home is the presenter-agnostic model for the landing dashboard. It is
+// assembled by the cli layer (readiness probes + a collection-registry query +
+// a staged-evidence walk) and rendered by the tui or plain presenter.
+type Home struct {
+	Version     string
+	RepoRoot    string // "" when the checkout could not be located
+	Checks      []Check
+	Collections []CollInfo
+	Lanes       []LaneCount
+	// CollErr is set when the collection registry could not be read at all (e.g.
+	// the processor package is not importable yet); the panel shows it INSTEAD of
+	// a list.
+	CollErr string
+	// CollNote is an informational line shown ALONGSIDE the collection list — used
+	// when the fast directory-name fallback ran because the full registry scan was
+	// too slow over the evidence store (names shown, per-lane counts omitted).
+	CollNote string
+}
+
+// Ready reports whether every gating check passed — i.e. the pipeline's
+// preconditions for processing evidence are all met.
+func (h Home) Ready() bool {
+	for _, c := range h.Checks {
+		if c.Gate && c.State != CheckOK {
+			return false
+		}
+	}
+	return true
+}

--- a/go/internal/model/home_test.go
+++ b/go/internal/model/home_test.go
@@ -1,0 +1,28 @@
+package model
+
+import "testing"
+
+func TestHomeReady(t *testing.T) {
+	ok := Check{Name: "a", State: CheckOK, Gate: true}
+	warnGate := Check{Name: "b", State: CheckWarn, Gate: true}
+	failGate := Check{Name: "c", State: CheckFail, Gate: true}
+	// A non-gate check that is failing must NOT hold readiness back.
+	failLane := Check{Name: "lane", State: CheckWarn, Gate: false}
+
+	cases := []struct {
+		name   string
+		checks []Check
+		want   bool
+	}{
+		{"all gates ok, lane warn", []Check{ok, ok, failLane}, true},
+		{"a gate warns", []Check{ok, warnGate}, false},
+		{"a gate fails", []Check{ok, failGate}, false},
+		{"no checks", nil, true},
+		{"only a failing lane (no gates)", []Check{failLane}, true},
+	}
+	for _, c := range cases {
+		if got := (Home{Checks: c.checks}).Ready(); got != c.want {
+			t.Errorf("%s: Ready() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/go/internal/plain/home.go
+++ b/go/internal/plain/home.go
@@ -1,0 +1,118 @@
+package plain
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/get-sybers/dx_dfir/go/internal/model"
+	"github.com/get-sybers/dx_dfir/go/internal/style"
+)
+
+// PrintHome renders the landing dashboard as plain lines — the non-TTY form of
+// what tui.RunHome draws. It is what a bare `dxdfir` prints under a pipe, a dumb
+// terminal, or --no-tui, and it is written to stdout (like `list`) so the
+// welcome/readiness report is a first-class, greppable payload.
+func PrintHome(w io.Writer, h model.Home) {
+	fmt.Fprintln(w, style.Bold(fmt.Sprintf("dxdfir %s", h.Version))+"   DX_DFIR forensic pipeline")
+	if h.RepoRoot != "" {
+		fmt.Fprintln(w, style.Grey("repo  "+h.RepoRoot))
+	} else {
+		fmt.Fprintln(w, style.Yellow("repo  not located - pass --repo-root or set $DFIR_REPO_ROOT"))
+	}
+	fmt.Fprintln(w, "")
+
+	// readiness banner
+	total, failing := 0, 0
+	for _, c := range h.Checks {
+		if c.Gate {
+			total++
+			if c.State != model.CheckOK {
+				failing++
+			}
+		}
+	}
+	if h.Ready() {
+		fmt.Fprintln(w, style.Green(fmt.Sprintf("%s READY - %d/%d preconditions met.", style.GlyphOK, total, total)))
+	} else {
+		fmt.Fprintln(w, style.Red(fmt.Sprintf("%s NOT READY - %d of %d gate check(s) failing.", style.GlyphErr, failing, total)))
+	}
+
+	fmt.Fprintln(w, style.Bold("Readiness")+style.Grey("   (* = optional lane/capability, not a process gate)"))
+	for _, c := range h.Checks {
+		name := c.Name
+		if !c.Gate {
+			name += "*"
+		}
+		mark, colour := homeMark(c.State)
+		fmt.Fprintf(w, "  %s %-13s %s\n", colour(mark), name, c.Detail)
+	}
+	fmt.Fprintln(w, "")
+
+	// collections
+	fmt.Fprintln(w, style.Bold("Collections"))
+	switch {
+	case h.CollErr != "":
+		fmt.Fprintln(w, "  "+style.Yellow(h.CollErr))
+	case len(h.Collections) == 0:
+		fmt.Fprintln(w, "  "+style.Grey("none yet - register one:  dxdfir register <name>"))
+	default:
+		if h.CollNote != "" {
+			fmt.Fprintln(w, "  "+style.Grey(h.CollNote))
+		}
+		for _, c := range h.Collections {
+			mark := " "
+			if c.Active {
+				mark = style.Yellow(style.GlyphStar)
+			}
+			count := fmt.Sprintf("%4d", c.Total)
+			switch {
+			case c.Total < 0:
+				count = style.Grey("   ?")
+			case c.Total > 0:
+				count = style.Green(count)
+			default:
+				count = style.Grey(count)
+			}
+			lanes := c.Lanes
+			if lanes == "" {
+				lanes = "-"
+			}
+			line := fmt.Sprintf(" %s %-22s %s file(s)  [%s]", mark, c.Name, count, lanes)
+			if c.Sha1 != "" {
+				line += "  sha1:" + c.Sha1
+			}
+			if c.Tag != "" {
+				line += "  " + style.Yellow(c.Tag)
+			}
+			fmt.Fprintln(w, line)
+		}
+	}
+	fmt.Fprintln(w, "")
+
+	// staged evidence
+	fmt.Fprintln(w, style.Bold("Staged evidence")+style.Grey("   (data_store/raw/ - what `process` reads)"))
+	for _, l := range h.Lanes {
+		count := fmt.Sprintf("%5d", l.Count)
+		note := ""
+		if l.Staged {
+			count = style.Green(count)
+		} else {
+			count = style.Grey(count)
+			note = style.Grey("  (not staged)")
+		}
+		fmt.Fprintf(w, "  %-13s %s file(s)  %s%s\n", l.Name, count, l.Loc, note)
+	}
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, style.Cyan(style.GlyphHint+" process: dxdfir process <source>   |   register: dxdfir register <name>   |   help: dxdfir --help"))
+}
+
+func homeMark(s model.CheckState) (string, func(string) string) {
+	switch s {
+	case model.CheckOK:
+		return style.GlyphOK, style.Green
+	case model.CheckWarn:
+		return style.GlyphWarn, style.Yellow
+	default:
+		return style.GlyphErr, style.Red
+	}
+}

--- a/go/internal/tui/home.go
+++ b/go/internal/tui/home.go
@@ -1,0 +1,324 @@
+package tui
+
+import (
+	"fmt"
+
+	ui "github.com/gizak/termui/v3"
+	"github.com/gizak/termui/v3/widgets"
+
+	"github.com/get-sybers/dx_dfir/go/internal/model"
+)
+
+// RunHome draws the landing dashboard for a bare `dxdfir`: a welcome header, the
+// environment-readiness panel (green before anything can be processed), the
+// tracked collections, and the staged evidence per lane. Unlike the process /
+// collection dashboards it renders a single assembled snapshot and simply waits
+// for the operator to dismiss it — there is no job to stream. Returns ErrNoTTY
+// when the terminal cannot host it, so the caller falls back to the plain view.
+func RunHome(h model.Home) (retErr error) {
+	if err := ui.Init(); err != nil {
+		return ErrNoTTY
+	}
+	closed := false
+	closeUI := func() {
+		if !closed {
+			ui.Close()
+			closed = true
+		}
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			closeUI()
+			panic(r)
+		}
+	}()
+	defer closeUI()
+
+	w, ht := ui.TerminalDimensions()
+	if w < minCols || ht < minRows {
+		closeUI()
+		return ErrNoTTY // too small for the dashboard — render plain instead
+	}
+
+	v := newHomeView(h)
+	v.layout(w, ht)
+	ui.Render(v.drawables()...)
+
+	for e := range ui.PollEvents() {
+		switch e.ID {
+		case "q", "<C-c>", "<Escape>", "<Enter>", "<Space>":
+			return nil
+		case "<Resize>":
+			if r, ok := e.Payload.(ui.Resize); ok {
+				if r.Width < minCols || r.Height < minRows {
+					closeUI()
+					return ErrNoTTY
+				}
+				v.layout(r.Width, r.Height)
+				ui.Clear()
+				ui.Render(v.drawables()...)
+			}
+		case "<C-l>":
+			ui.Clear()
+			ui.Render(v.drawables()...)
+		}
+	}
+	return nil
+}
+
+type homeView struct {
+	header *widgets.Paragraph
+	banner *widgets.Paragraph
+	checks *widgets.Table
+	colls  *widgets.Table
+	lanes  *widgets.Table
+	footer *widgets.Paragraph
+
+	h    model.Home
+	w, y int
+	draw []ui.Drawable
+}
+
+func newHomeView(h model.Home) *homeView {
+	v := &homeView{
+		header: widgets.NewParagraph(),
+		banner: widgets.NewParagraph(),
+		checks: widgets.NewTable(),
+		colls:  widgets.NewTable(),
+		lanes:  widgets.NewTable(),
+		footer: widgets.NewParagraph(),
+		h:      h,
+	}
+	v.header.Border = false
+	v.banner.Border = false
+	v.footer.Border = false
+	v.header.TextStyle = styleFg(colWhite)
+	v.footer.TextStyle = styleFg(colGrey)
+	for _, t := range []*widgets.Table{v.checks, v.colls, v.lanes} {
+		t.RowSeparator = false
+		t.FillRow = true
+	}
+	v.checks.Title = "readiness - green before processing"
+	v.colls.Title = "collections"
+	v.lanes.Title = "staged evidence (data_store/raw)"
+	return v
+}
+
+func (v *homeView) drawables() []ui.Drawable { return v.draw }
+
+// layout budgets the vertical space top-down: the header, banner and readiness
+// panel are always shown; collections and staged evidence fill whatever remains,
+// so the dashboard degrades gracefully on a short terminal.
+func (v *homeView) layout(w, h int) {
+	v.w = w
+	v.buildHeader(w)
+	v.buildBanner(w)
+	v.buildChecks(w)
+	v.buildColls(w)
+	v.buildLanes(w)
+	v.buildFooter(w)
+
+	v.header.SetRect(0, 0, w, 2)
+	v.banner.SetRect(0, 2, w, 3)
+	v.draw = []ui.Drawable{v.header, v.banner}
+	y := 3
+
+	footerTop := h - 1
+
+	// readiness: always shown; height caps at what fits above the footer.
+	checksH := len(v.h.Checks) + 2 // rows + top/bottom border
+	if y+checksH > footerTop {
+		checksH = maxInt(3, footerTop-y)
+	}
+	v.checks.SetRect(0, y, w, y+checksH)
+	v.draw = append(v.draw, v.checks)
+	y += checksH
+
+	// collections + staged evidence share the remainder, evidence sized to its
+	// own content first, collections taking the rest.
+	avail := footerTop - y
+	if avail >= 4 {
+		lanesH := 0
+		if len(v.h.Lanes) > 0 {
+			lanesH = minInt(len(v.h.Lanes)+2, avail-3) // leave >=3 for collections
+			lanesH = maxInt(0, lanesH)
+		}
+		collsH := avail - lanesH
+		if collsH >= 3 {
+			v.colls.SetRect(0, y, w, y+collsH)
+			v.draw = append(v.draw, v.colls)
+			y += collsH
+		} else {
+			lanesH = avail // no room to split; give it all to evidence
+		}
+		if lanesH >= 3 {
+			v.lanes.SetRect(0, y, w, y+lanesH)
+			v.draw = append(v.draw, v.lanes)
+			y += lanesH
+		}
+	}
+
+	v.footer.SetRect(0, footerTop, w, footerTop+1)
+	v.draw = append(v.draw, v.footer)
+}
+
+func (v *homeView) buildHeader(w int) {
+	root := v.h.RepoRoot
+	if root == "" {
+		root = "repo not located - pass --repo-root or set $DFIR_REPO_ROOT"
+	}
+	l1 := fmt.Sprintf("dxdfir %s   DX_DFIR forensic pipeline", v.h.Version)
+	l2 := "repo  " + root
+	v.header.Text = sanitize(truncRight(l1, w)) + "\n" + sanitize(truncRight(l2, w))
+}
+
+func (v *homeView) buildBanner(w int) {
+	total, failing := 0, 0
+	for _, c := range v.h.Checks {
+		if c.Gate {
+			total++
+			if c.State != model.CheckOK {
+				failing++
+			}
+		}
+	}
+	if v.h.Ready() {
+		v.banner.Text = sanitize(truncRight(fmt.Sprintf(
+			"%s READY - %d/%d preconditions met.  Process evidence:  dxdfir process <source>",
+			glyphFor(model.CheckOK), total, total), w))
+		v.banner.TextStyle = styleBold(colGreen)
+		return
+	}
+	v.banner.Text = sanitize(truncRight(fmt.Sprintf(
+		"%s NOT READY - %d of %d gate check(s) failing; resolve the [x] rows below.",
+		glyphFor(model.CheckFail), failing, total), w))
+	v.banner.TextStyle = styleBold(colRed)
+}
+
+func (v *homeView) buildChecks(w int) {
+	inner := w - 2
+	nameW := 12
+	tokenW := 5                                // "[ok]" + a trailing space so termui's cell padding never clips it
+	detailW := maxInt(6, inner-tokenW-nameW-2) // 3 cols => 2 separators
+	v.checks.ColumnWidths = []int{tokenW, nameW, detailW}
+
+	rows := make([][]string, 0, len(v.h.Checks))
+	styles := map[int]ui.Style{}
+	for i, c := range v.h.Checks {
+		name := c.Name
+		if !c.Gate {
+			name = c.Name + "*" // starred: capability, not a hard gate
+		}
+		rows = append(rows, []string{glyphFor(c.State), name, sanitize(c.Detail)})
+		styles[i] = styleFg(colorFor(c.State))
+	}
+	v.checks.Rows = rows
+	v.checks.RowStyles = styles
+	v.checks.Title = "readiness - green before processing   (* = optional lane/capability)"
+}
+
+func (v *homeView) buildColls(w int) {
+	inner := w - 2
+	if v.h.CollErr != "" {
+		v.colls.ColumnWidths = []int{inner}
+		v.colls.Rows = [][]string{{sanitize(v.h.CollErr)}}
+		v.colls.RowStyles = map[int]ui.Style{0: styleFg(colYellow)}
+		return
+	}
+	if len(v.h.Collections) == 0 {
+		v.colls.ColumnWidths = []int{inner}
+		v.colls.Rows = [][]string{{"no collections yet - register one:  dxdfir register <name>"}}
+		v.colls.RowStyles = map[int]ui.Style{0: styleFg(colGrey)}
+		return
+	}
+	markW, nameW, countW := 2, 22, 8
+	detailW := maxInt(6, inner-markW-nameW-countW-3) // 4 cols => 3 separators
+	v.colls.ColumnWidths = []int{markW, nameW, countW, detailW}
+
+	rows := make([][]string, 0, len(v.h.Collections))
+	styles := map[int]ui.Style{}
+	for i, c := range v.h.Collections {
+		mark := " "
+		col := colWhite
+		if c.Active {
+			mark = "*"
+			col = colYellow
+		}
+		detail := ""
+		if c.Lanes != "" {
+			detail = "[" + c.Lanes + "]"
+		}
+		if c.Sha1 != "" {
+			detail += "  sha1:" + c.Sha1
+		}
+		if c.Tag != "" {
+			detail += "  " + c.Tag
+			if col == colWhite {
+				col = colGrey
+			}
+		}
+		count := "?"
+		if c.Total >= 0 {
+			count = fmt.Sprintf("%d file(s)", c.Total)
+		}
+		rows = append(rows, []string{mark, c.Name, count, sanitize(detail)})
+		styles[i] = styleFg(col)
+	}
+	if v.h.CollNote != "" {
+		styles[len(rows)] = styleFg(colGrey)
+		rows = append(rows, []string{"", "note", "", sanitize(v.h.CollNote)})
+	}
+	v.colls.Rows = rows
+	v.colls.RowStyles = styles
+}
+
+func (v *homeView) buildLanes(w int) {
+	inner := w - 2
+	nameW, countW := 14, 12
+	locW := maxInt(6, inner-nameW-countW-2)
+	v.lanes.ColumnWidths = []int{nameW, countW, locW}
+
+	rows := make([][]string, 0, len(v.h.Lanes))
+	styles := map[int]ui.Style{}
+	for i, l := range v.h.Lanes {
+		col := colGrey
+		note := ""
+		if l.Staged {
+			col = colGreen
+		} else {
+			note = "  (not staged)"
+		}
+		rows = append(rows, []string{l.Name, fmt.Sprintf("%d file(s)", l.Count), sanitize(l.Loc + note)})
+		styles[i] = styleFg(col)
+	}
+	v.lanes.Rows = rows
+	v.lanes.RowStyles = styles
+}
+
+func (v *homeView) buildFooter(w int) {
+	v.footer.Text = sanitize(truncRight(
+		"q/Esc quit    process: dxdfir process <source>    collections: dxdfir register <name>    help: dxdfir --help", w))
+}
+
+// glyphFor maps a check state to the ASCII status token (runewidth-safe).
+func glyphFor(s model.CheckState) string {
+	switch s {
+	case model.CheckOK:
+		return "[ok]"
+	case model.CheckWarn:
+		return "[!] "
+	default:
+		return "[x] "
+	}
+}
+
+func colorFor(s model.CheckState) ui.Color {
+	switch s {
+	case model.CheckOK:
+		return colGreen
+	case model.CheckWarn:
+		return colYellow
+	default:
+		return colRed
+	}
+}


### PR DESCRIPTION
## What
Running `dxdfir` with no subcommand now renders a **landing dashboard** instead of the cobra usage dump — the TUI you were expecting when you run `dxdfir`.

It shows:
- **Header** — version + resolved repo root.
- **Readiness banner** — a green `READY` / red `NOT READY` summary.
- **Readiness panel** — the checks that must be green before anything can be processed.
- **Collections** — the tracked collections.
- **Staged evidence** — per-lane file counts over `data_store/raw/`.
- **Footer** — the next-step hints.

It draws the termui dashboard on an interactive terminal and degrades to a plain, greppable report under a pipe / `--no-tui` / a dumb terminal — reusing the same tui-vs-plain decision the `process`/`collection` dashboards already use. `--help`, `--version`, subcommands, and the unknown-command error are all unchanged.

## Readiness checks
Eight probes, run **concurrently and each time-bounded** so a wedged tool never hangs the screen:

**Gating (must be green before `process`):** `repo`, `python3`, `processors` (get_sybers_dxdfir importable), `ansible` (ansible-playbook), `collection` (in-tree get_sybers.dxdfir), `docker` (daemon reachable).
**Starred capabilities (warn only — narrow what's available):** `piiat-mem*` (volatility lane), `byakugan*` (CAR build/timeline).

## Why it's bounded
`collection status` walks every collection to tally lanes; over a large/networked evidence store that took **>60s** here. So the registry scan is bounded (5s) and falls back to an **instant directory-name listing** ("names only; `dxdfir collection list` for counts") rather than hanging the welcome screen. All three panels are gathered concurrently, so the slowest source caps the wait instead of summing — the dashboard appears in ~1s on a normal host.

## `make link` — easy rebuild + PATH shortcut
`cd go && make link` builds the front-end and puts a `dxdfir` shortcut on PATH in one command, using the **same layout as `scripts/setup-environment.sh`** (`/opt/dxdfir/bin` + a `/usr/local/bin/dxdfir` symlink + man page). Rebuild after a code edit → runnable anywhere without the full filepath. Documented in `go/README.md`.

## New files
- `internal/health/health.go` — the concurrent, bounded probes.
- `internal/model/home.go` (+ `home_test.go`) — the presenter-agnostic model + readiness logic.
- `internal/tui/home.go` — the termui renderer.
- `internal/plain/home.go` — the plain-text renderer.
- `internal/cli/home.go` — assembles the model; `root.go` wires the bare-invocation `RunE`.

## Test
`go build`, `go vet`, `go test ./...`, `gofmt -l` all clean. Verified the plain fallback and — through a PTY with a set window size — the full termui render (alt-screen, 256-colour, bordered readiness/collections tables, intact `[ok]` tokens, ASCII-only dynamic text). `make link` deploys the build to the `dxdfir` shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJ7qymdmkEqM4YszuRWi1T