### PR TITLE
feat(collection): native registry writes — select/unselect/unregister (Phase 2 of #174)

### DIFF
--- a/go/internal/cli/collection.go
+++ b/go/internal/cli/collection.go
@@ -257,17 +257,11 @@ func newCollectionUnregisterCmd(env *Env) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			py, err := repo.Python()
+			removed, err := collection.Unregister(r.Root, args[0])
 			if err != nil {
-				return Fail(127, "%v", err)
+				return Fail(2, "%v", err)
 			}
-			var res struct {
-				Removed bool `json:"removed"`
-			}
-			if err := collQuery(r, py, &res, "unregister", args[0]); err != nil {
-				return err
-			}
-			if res.Removed {
+			if removed {
 				fmt.Println(style.Green(style.GlyphOK + " unregistered '" + args[0] + "' — evidence + log untouched."))
 			} else {
 				fmt.Println(style.Yellow(style.GlyphInfo + " '" + args[0] + "' was not registered — nothing to do."))
@@ -287,12 +281,8 @@ func newCollectionSelectCmd(env *Env) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			py, err := repo.Python()
-			if err != nil {
-				return Fail(127, "%v", err)
-			}
-			if err := collQuery(r, py, nil, "select", args[0]); err != nil {
-				return err
+			if err := collection.Select(r.Root, args[0]); err != nil {
+				return Fail(2, "%v", err)
 			}
 			fmt.Println(style.Yellow(style.GlyphStar + " active collection is now '" + args[0] + "'"))
 			return nil
@@ -309,20 +299,14 @@ func newCollectionUnselectCmd(env *Env) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			py, err := repo.Python()
+			prev, err := collection.Unselect(r.Root)
 			if err != nil {
-				return Fail(127, "%v", err)
+				return Fail(2, "%v", err)
 			}
-			var res struct {
-				Previous *string `json:"previous"`
-			}
-			if err := collQuery(r, py, &res, "unselect"); err != nil {
-				return err
-			}
-			if res.Previous == nil {
+			if prev == "" {
 				fmt.Println("no active collection was set.")
 			} else {
-				fmt.Println(style.Green(style.GlyphOK + " cleared active collection (was '" + *res.Previous + "')"))
+				fmt.Println(style.Green(style.GlyphOK + " cleared active collection (was '" + prev + "')"))
 			}
 			return nil
 		},

--- a/go/internal/cli/collection.go
+++ b/go/internal/cli/collection.go
@@ -24,11 +24,12 @@ import (
 
 // ---- shared query types ----
 //
-// status / lanes / state are now read natively by internal/collection (no Python
-// round-trip; the registry is read directly and lanes are counted concurrently).
+// status / lanes / state are read natively by internal/collection (no Python
+// round-trip; the registry is read directly and lanes are counted concurrently),
+// and the registry-mutating writes select / unselect / unregister are native too.
 // These aliases keep the rest of the cli — rendering, process scoping — unchanged.
-// Writes (register/sort/hash/select/unselect/unregister) still shell out via
-// collQuery; see epic #174.
+// Only register/sort/hash still shell out via collQuery / collect.Runner; see
+// epic #174.
 
 type (
 	collSummary = collection.Summary

--- a/go/internal/collection/collection_test.go
+++ b/go/internal/collection/collection_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -162,5 +163,103 @@ func TestNoRegistry(t *testing.T) {
 	}
 	if len(st.Unregistered) != 1 || st.Unregistered[0].Name != "hand" {
 		t.Errorf("unregistered = %+v, want [hand]", st.Unregistered)
+	}
+}
+
+// eventCount returns the number of rows in the events table for name/event.
+func eventCount(t *testing.T, repo, name, event string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(repo, "data_store", "raw", "collections", registryName)+"?mode=ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM events WHERE name=? AND event=?", name, event).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func TestWrites(t *testing.T) {
+	repo := t.TempDir()
+	colls := filepath.Join(repo, "data_store", "raw", "collections")
+	for _, n := range []string{"a", "b"} {
+		touch(t, filepath.Join(colls, n, ".collection"))     // marker shadow
+		touch(t, filepath.Join(colls, n, "pcaps", "x.pcap")) // evidence
+	}
+	// "a" starts selected, "b" not.
+	seedRegistry(t, filepath.Join(colls, registryName), map[string]bool{"a": true, "b": false})
+
+	// --- Select ---
+	if err := Select(repo, "b"); err != nil {
+		t.Fatalf("Select(b): %v", err)
+	}
+	if st, _ := GetStatus(repo); st.Active != "b" {
+		t.Errorf("after Select(b) active=%q, want b", st.Active)
+	}
+	// The on-disk log line must match the Python json.dumps spacing exactly.
+	logB, _ := os.ReadFile(filepath.Join(colls, "b", ".collection.log"))
+	if !strings.Contains(string(logB), `, "event": "selected"}`) {
+		t.Errorf("b .collection.log missing well-formed selected event: %q", logB)
+	}
+	if eventCount(t, repo, "b", "selected") != 1 {
+		t.Errorf("events table: want 1 'selected' row for b, got %d", eventCount(t, repo, "b", "selected"))
+	}
+	// Selecting an unregistered name is an error.
+	if err := Select(repo, "nope"); err == nil {
+		t.Error("Select(nope) should error (not registered)")
+	}
+
+	// --- Unselect ---
+	prev, err := Unselect(repo)
+	if err != nil {
+		t.Fatalf("Unselect: %v", err)
+	}
+	if prev != "b" {
+		t.Errorf("Unselect prev=%q, want b", prev)
+	}
+	if st, _ := GetStatus(repo); st.Active != "" {
+		t.Errorf("after Unselect active=%q, want empty", st.Active)
+	}
+	if eventCount(t, repo, "b", "unselected") != 1 {
+		t.Error("events table: want 1 'unselected' row for b")
+	}
+	// Unselect with nothing active is a no-op returning "".
+	if p, err := Unselect(repo); err != nil || p != "" {
+		t.Errorf("Unselect(none) = (%q, %v), want (\"\", nil)", p, err)
+	}
+
+	// --- Unregister ---
+	removed, err := Unregister(repo, "a")
+	if err != nil {
+		t.Fatalf("Unregister(a): %v", err)
+	}
+	if !removed {
+		t.Error("Unregister(a) removed=false, want true")
+	}
+	s, _ := GetState(repo, "a")
+	if s.Registered {
+		t.Error("a still registered after Unregister")
+	}
+	if !s.Exists || !s.Detected {
+		t.Errorf("a after Unregister: exists=%v detected=%v, want both true (dir+evidence remain)", s.Exists, s.Detected)
+	}
+	if isRegularFile(filepath.Join(colls, "a", ".collection")) {
+		t.Error("a .collection marker should be removed")
+	}
+	if !isRegularFile(filepath.Join(colls, "a", ".collection.log")) {
+		t.Error("a .collection.log should be preserved")
+	}
+	if !isRegularFile(filepath.Join(colls, "a", "pcaps", "x.pcap")) {
+		t.Error("a evidence should be preserved")
+	}
+	// Second unregister: no row, no marker => false, no error.
+	if r2, err := Unregister(repo, "a"); err != nil || r2 {
+		t.Errorf("second Unregister(a) = (%v, %v), want (false, nil)", r2, err)
+	}
+	// Unregister a non-existent folder is an error.
+	if _, err := Unregister(repo, "ghost"); err == nil {
+		t.Error("Unregister(ghost) should error (no such collection)")
 	}
 }

--- a/go/internal/collection/collection_test.go
+++ b/go/internal/collection/collection_test.go
@@ -263,3 +263,87 @@ func TestWrites(t *testing.T) {
 		t.Error("Unregister(ghost) should error (no such collection)")
 	}
 }
+
+func containsName(cs []Summary, name string) bool {
+	for _, c := range cs {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSelectMigratesLegacyMarker: a collection present only as a pre-DB
+// .collection marker is migrated into the registry by Select (as Python's _db()
+// does) and then selectable — the regression Copilot flagged.
+func TestSelectMigratesLegacyMarker(t *testing.T) {
+	repo := t.TempDir()
+	colls := filepath.Join(repo, "data_store", "raw", "collections")
+	touch(t, filepath.Join(colls, "other", "pcaps", "o.pcap"))
+	seedRegistry(t, filepath.Join(colls, registryName), map[string]bool{"other": false})
+	// "leg": a marker (with a registered_at) + evidence, but NO registry row.
+	touch(t, filepath.Join(colls, "leg", "memory", "m.raw")) // creates leg/ first
+	if err := os.WriteFile(filepath.Join(colls, "leg", ".collection"),
+		[]byte("name: leg\nregistered_at: 2020-01-02T03:04:05Z\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Precondition: the read path (no migration) sees leg as unregistered.
+	if st, _ := GetStatus(repo); !containsName(st.Unregistered, "leg") {
+		t.Fatal("precondition: leg should read as unregistered before select")
+	}
+	// Select migrates the marker in, then selects it.
+	if err := Select(repo, "leg"); err != nil {
+		t.Fatalf("Select(leg): %v", err)
+	}
+	st, _ := GetStatus(repo)
+	if st.Active != "leg" {
+		t.Errorf("active=%q, want leg", st.Active)
+	}
+	if !containsName(st.Registered, "leg") {
+		t.Errorf("leg should be registered after migrate+select; registered=%+v", st.Registered)
+	}
+	// The migrated row keeps the marker's registered_at and is sourced "migrated".
+	db, _ := sql.Open("sqlite", "file:"+filepath.Join(colls, registryName)+"?mode=ro")
+	defer db.Close()
+	var regAt, source string
+	if err := db.QueryRow("SELECT registered_at, source FROM collections WHERE name='leg'").Scan(&regAt, &source); err != nil {
+		t.Fatal(err)
+	}
+	if regAt != "2020-01-02T03:04:05Z" {
+		t.Errorf("migrated registered_at=%q, want the marker's value", regAt)
+	}
+	if source != "migrated" {
+		t.Errorf("migrated source=%q, want migrated", source)
+	}
+}
+
+// TestSchemaEvolutionAddsSelected: a registry created before the `selected`
+// column exists is evolved by openWriteDB so the UPDATE does not fail with
+// "no such column: selected".
+func TestSchemaEvolutionAddsSelected(t *testing.T) {
+	repo := t.TempDir()
+	colls := filepath.Join(repo, "data_store", "raw", "collections")
+	if err := os.MkdirAll(colls, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(colls, registryName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Legacy schema: no `selected` column.
+	if _, err := db.Exec("CREATE TABLE collections(name TEXT PRIMARY KEY, target_path TEXT, registered_at TEXT, source TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO collections(name,target_path,registered_at,source) VALUES('old','x','t','create')"); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	if err := Select(repo, "old"); err != nil {
+		t.Fatalf("Select(old) on a pre-`selected` registry: %v", err)
+	}
+	if st, _ := GetStatus(repo); st.Active != "old" {
+		t.Errorf("active=%q, want old", st.Active)
+	}
+}

--- a/go/internal/collection/write.go
+++ b/go/internal/collection/write.go
@@ -1,0 +1,217 @@
+package collection
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// This file is the native-Go registry WRITER for the ops that are pure row
+// mutations plus their on-disk shadows — select / unselect / unregister (epic
+// #174, phase 2). It stays byte-compatible with the Python writer
+// (get_sybers_dxdfir.collection): the SQLite registry is authoritative for
+// "registered"/"selected", and every mutation is mirrored to the collection's
+// .collection.log JSONL and (for select/unselect) the events table, exactly as
+// the Python does — so a collection mutated by one side is consistent for the
+// other during the transition. Register/sort/hash and the classification that
+// backs them remain Python for now (later phases).
+//
+// NOTE: unlike Python's _db(), this writer does not run the one-shot legacy
+// ".collection marker -> DB" migration; the read path (registry.go) already
+// treats the DB as the source of truth, and any pre-DB marker is imported the
+// next time the Python register/read path touches the repo.
+
+// schemaDDL mirrors the columns get_sybers_dxdfir.collection._SCHEMA creates. It
+// is applied (IF NOT EXISTS, so a no-op against a Python-created DB) before a
+// write, so a mutation never runs against a half-initialised store.
+const schemaDDL = `
+CREATE TABLE IF NOT EXISTS collections (
+    name          TEXT PRIMARY KEY,
+    target_path   TEXT NOT NULL,
+    registered_at TEXT NOT NULL,
+    source        TEXT NOT NULL,
+    sha1          TEXT,
+    files         INTEGER,
+    selected      INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS events (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    name     TEXT NOT NULL,
+    ts       TEXT NOT NULL,
+    event    TEXT NOT NULL,
+    detail   TEXT,
+    FOREIGN KEY(name) REFERENCES collections(name) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_events_name_ts ON events(name, ts);
+CREATE TABLE IF NOT EXISTS files (
+    collection_name TEXT NOT NULL,
+    path            TEXT NOT NULL,
+    lane            TEXT,
+    detected_by     TEXT NOT NULL,
+    sha1            TEXT,
+    size            INTEGER,
+    added_at        TEXT NOT NULL,
+    PRIMARY KEY (collection_name, path),
+    FOREIGN KEY(collection_name) REFERENCES collections(name) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_files_lane ON files(collection_name, lane);
+`
+
+// Select marks name the active collection, clearing the flag on every other row
+// so exactly one is selected. Errors if name is not registered (mirrors
+// select_collection's ValueError).
+func Select(repoRoot, name string) error {
+	if !ValidName(name) {
+		return fmt.Errorf("invalid collection name %q — use letters/digits then . _ -", name)
+	}
+	reg, err := readRegistry(repoRoot)
+	if err != nil {
+		return err
+	}
+	if !reg.nameSet[name] {
+		return fmt.Errorf("cannot select %q — not registered", name)
+	}
+	db, err := openWriteDB(repoRoot)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if _, err := db.Exec("UPDATE collections SET selected = 0 WHERE selected = 1"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("UPDATE collections SET selected = 1 WHERE name = ?", name); err != nil {
+		return err
+	}
+	ts := now()
+	logEventDB(db, name, ts, "selected")
+	if root, ok := collectionDir(repoRoot, name); ok {
+		logEventFile(root, ts, "selected")
+	}
+	return nil
+}
+
+// Unselect clears the active flag and returns the previously-selected name ("" if
+// none). With nothing selected it is a no-op that does not create or touch the DB.
+func Unselect(repoRoot string) (string, error) {
+	reg, err := readRegistry(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	prev := reg.selected
+	if prev == "" {
+		return "", nil
+	}
+	db, err := openWriteDB(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+	if _, err := db.Exec("UPDATE collections SET selected = 0 WHERE selected = 1"); err != nil {
+		return "", err
+	}
+	ts := now()
+	logEventDB(db, prev, ts, "unselected")
+	if root, ok := collectionDir(repoRoot, prev); ok {
+		logEventFile(root, ts, "unselected")
+	}
+	return prev, nil
+}
+
+// Unregister drops the registry row + .collection marker so name is no longer
+// tracked; the evidence and .collection.log are left in place. Returns true when
+// the collection was actually registered (row or marker present). Errors if the
+// collection folder does not exist (mirrors unregister's ValueError). Deleting
+// the row cascades its events (foreign_keys ON), so — like the Python — the
+// "unregistered" event is written only to the on-disk log, not the DB.
+func Unregister(repoRoot, name string) (bool, error) {
+	root, ok := collectionDir(repoRoot, name)
+	if !ok {
+		return false, fmt.Errorf("invalid collection name %q — use letters/digits then . _ -", name)
+	}
+	// is_dir() (follows a symlinked collection) OR is_symlink() (incl. a dangling one).
+	li, lerr := os.Lstat(root)
+	isLink := lerr == nil && li.Mode()&os.ModeSymlink != 0
+	if !isDir(root) && !isLink {
+		return false, fmt.Errorf("no such collection %q", name)
+	}
+	reg, err := readRegistry(repoRoot)
+	if err != nil {
+		return false, err
+	}
+	wasInDB := reg.nameSet[name]
+	marker := filepath.Join(root, markerName)
+	hadMarker := isRegularFile(marker)
+	if !wasInDB && !hadMarker {
+		return false, nil
+	}
+	ts := now()
+	logEventFile(root, ts, "unregistered")
+	if wasInDB {
+		db, err := openWriteDB(repoRoot)
+		if err != nil {
+			return false, err
+		}
+		defer db.Close()
+		if _, err := db.Exec("DELETE FROM collections WHERE name = ?", name); err != nil {
+			return false, err
+		}
+	}
+	if hadMarker {
+		_ = os.Remove(marker)
+	}
+	return true, nil
+}
+
+// --- helpers ---
+
+// openWriteDB opens the registry read-write with foreign keys enforced (so a
+// row delete cascades its events, as the Python's PRAGMA foreign_keys=ON does)
+// and ensures the schema exists.
+func openWriteDB(repoRoot string) (*sql.DB, error) {
+	if err := os.MkdirAll(collectionsRoot(repoRoot), 0o755); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", "file:"+registryPath(repoRoot)+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.Exec(schemaDDL); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// logEventDB appends one detail-less event row; best-effort, like the on-disk log.
+func logEventDB(db *sql.DB, name, ts, event string) {
+	_, _ = db.Exec("INSERT INTO events(name, ts, event, detail) VALUES(?, ?, ?, NULL)", name, ts, event)
+}
+
+// logEventFile appends one JSONL record to the collection's .collection.log,
+// byte-for-byte as the Python's _log_event_file does: json.dumps default
+// separators (a space after ':' and ','), key order ts then event. Best-effort
+// (a read-only symlinked target is silently skipped, matching the Python).
+func logEventFile(root, ts, event string) {
+	f, err := os.OpenFile(filepath.Join(root, logName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	tsB, _ := json.Marshal(ts)
+	evB, _ := json.Marshal(event)
+	_, _ = fmt.Fprintf(f, "{\"ts\": %s, \"event\": %s}\n", tsB, evB)
+}
+
+// now is the registry timestamp format: UTC, second precision, trailing Z —
+// matching get_sybers_dxdfir.collection._now().
+func now() string {
+	return time.Now().UTC().Format("2006-01-02T15:04:05Z")
+}
+
+func isRegularFile(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.Mode().IsRegular()
+}

--- a/go/internal/collection/write.go
+++ b/go/internal/collection/write.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -19,10 +20,10 @@ import (
 // other during the transition. Register/sort/hash and the classification that
 // backs them remain Python for now (later phases).
 //
-// NOTE: unlike Python's _db(), this writer does not run the one-shot legacy
-// ".collection marker -> DB" migration; the read path (registry.go) already
-// treats the DB as the source of truth, and any pre-DB marker is imported the
-// next time the Python register/read path touches the repo.
+// Like Python's _db(), opening the registry for a write also (a) evolves an
+// older schema that predates the `selected` column and (b) imports any pre-DB
+// ".collection" markers (+ their JSONL logs) into the registry, so a legacy
+// collection is registered — and selectable — exactly as it is under Python.
 
 // schemaDDL mirrors the columns get_sybers_dxdfir.collection._SCHEMA creates. It
 // is applied (IF NOT EXISTS, so a no-op against a Python-created DB) before a
@@ -62,27 +63,41 @@ CREATE INDEX IF NOT EXISTS idx_files_lane ON files(collection_name, lane);
 
 // Select marks name the active collection, clearing the flag on every other row
 // so exactly one is selected. Errors if name is not registered (mirrors
-// select_collection's ValueError).
+// select_collection's ValueError). openWriteDB migrates any legacy .collection
+// markers into the registry first, so a pre-DB collection is registered — and
+// thus selectable — exactly as the Python's _db() path makes it.
 func Select(repoRoot, name string) error {
 	if !ValidName(name) {
 		return fmt.Errorf("invalid collection name %q — use letters/digits then . _ -", name)
-	}
-	reg, err := readRegistry(repoRoot)
-	if err != nil {
-		return err
-	}
-	if !reg.nameSet[name] {
-		return fmt.Errorf("cannot select %q — not registered", name)
 	}
 	db, err := openWriteDB(repoRoot)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
-	if _, err := db.Exec("UPDATE collections SET selected = 0 WHERE selected = 1"); err != nil {
+	var one int
+	switch err := db.QueryRow("SELECT 1 FROM collections WHERE name = ?", name).Scan(&one); err {
+	case nil: // registered (possibly just migrated in)
+	case sql.ErrNoRows:
+		return fmt.Errorf("cannot select %q — not registered", name)
+	default:
 		return err
 	}
-	if _, err := db.Exec("UPDATE collections SET selected = 1 WHERE name = ?", name); err != nil {
+	// Both flag updates in ONE transaction: a crash between them must not leave
+	// the registry with nothing selected (parity with the Python's single txn).
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec("UPDATE collections SET selected = 0 WHERE selected = 1"); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if _, err := tx.Exec("UPDATE collections SET selected = 1 WHERE name = ?", name); err != nil {
+		tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
 		return err
 	}
 	ts := now()
@@ -160,7 +175,12 @@ func Unregister(repoRoot, name string) (bool, error) {
 		}
 	}
 	if hadMarker {
-		_ = os.Remove(marker)
+		// Surface a marker-removal failure rather than swallowing it (parity with
+		// the Python's marker.unlink()): the row is already gone, so a silent
+		// failure would leave the on-disk shadow inconsistent under a "success".
+		if err := os.Remove(marker); err != nil {
+			return true, fmt.Errorf("unregistered %q but could not remove its .collection marker: %w", name, err)
+		}
 	}
 	return true, nil
 }
@@ -168,8 +188,9 @@ func Unregister(repoRoot, name string) (bool, error) {
 // --- helpers ---
 
 // openWriteDB opens the registry read-write with foreign keys enforced (so a
-// row delete cascades its events, as the Python's PRAGMA foreign_keys=ON does)
-// and ensures the schema exists.
+// row delete cascades its events, as the Python's PRAGMA foreign_keys=ON does),
+// ensures the schema exists, evolves an older schema missing the `selected`
+// column, and imports any legacy .collection markers — mirroring Python's _db().
 func openWriteDB(repoRoot string) (*sql.DB, error) {
 	if err := os.MkdirAll(collectionsRoot(repoRoot), 0o755); err != nil {
 		return nil, err
@@ -182,7 +203,121 @@ func openWriteDB(repoRoot string) (*sql.DB, error) {
 		db.Close()
 		return nil, err
 	}
+	// Schema evolution: CREATE TABLE IF NOT EXISTS won't add a column to an
+	// existing table, so an older registry created before `selected` existed
+	// would fail every UPDATE with "no such column: selected".
+	if !hasColumn(db, "collections", "selected") {
+		if _, err := db.Exec("ALTER TABLE collections ADD COLUMN selected INTEGER NOT NULL DEFAULT 0"); err != nil {
+			db.Close()
+			return nil, err
+		}
+	}
+	migrateMarkers(db, repoRoot)
 	return db, nil
+}
+
+// hasColumn reports whether table has a column named col.
+func hasColumn(db *sql.DB, table, col string) bool {
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt any
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err == nil && name == col {
+			return true
+		}
+	}
+	return false
+}
+
+// migrateMarkers imports pre-DB ".collection" markers (and their .collection.log
+// JSONL) into the registry, mirroring get_sybers_dxdfir.collection._migrate_
+// markers so upgrading to the SQLite registry keeps every existing case. It only
+// touches markers not already represented by a row, so it is idempotent and a
+// no-op on an already-migrated store. Best-effort throughout.
+func migrateMarkers(db *sql.DB, repoRoot string) {
+	root := collectionsRoot(repoRoot)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() || strings.HasPrefix(name, ".") {
+			continue
+		}
+		marker := filepath.Join(root, name, markerName)
+		if !isRegularFile(marker) {
+			continue
+		}
+		var one int
+		if db.QueryRow("SELECT 1 FROM collections WHERE name = ?", name).Scan(&one) == nil {
+			continue // already in the registry
+		}
+		regAt := now()
+		if data, err := os.ReadFile(marker); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				if strings.HasPrefix(line, "registered_at:") {
+					if v := strings.TrimSpace(line[len("registered_at:"):]); v != "" {
+						regAt = v
+					}
+					break
+				}
+			}
+		}
+		target := filepath.Join(root, name)
+		if rp, err := filepath.EvalSymlinks(target); err == nil {
+			target = rp
+		} else if ap, err := filepath.Abs(target); err == nil {
+			target = ap
+		}
+		if _, err := db.Exec(
+			"INSERT INTO collections(name, target_path, registered_at, source) VALUES(?, ?, ?, ?)",
+			name, target, regAt, "migrated"); err != nil {
+			continue
+		}
+		importEventLog(db, name, filepath.Join(root, name, logName))
+	}
+}
+
+// importEventLog folds a collection's .collection.log JSONL into the events
+// table (ts/event promoted to columns, the rest kept as the detail JSON).
+func importEventLog(db *sql.DB, name, logPath string) {
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if json.Unmarshal([]byte(line), &rec) != nil {
+			continue
+		}
+		ts, _ := rec["ts"].(string)
+		ev, _ := rec["event"].(string)
+		delete(rec, "ts")
+		delete(rec, "event")
+		if ts == "" {
+			ts = now()
+		}
+		if ev == "" {
+			ev = "?"
+		}
+		var detail any
+		if len(rec) > 0 {
+			if b, err := json.Marshal(rec); err == nil {
+				detail = string(b)
+			}
+		}
+		_, _ = db.Exec("INSERT INTO events(name, ts, event, detail) VALUES(?, ?, ?, ?)", name, ts, ev, detail)
+	}
 }
 
 // logEventDB appends one detail-less event row; best-effort, like the on-disk log.


### PR DESCRIPTION
Phase 2 of epic #174.

## What
Ports the pure-mutation registry writes off the Python module — `select`, `unselect`, `unregister` are now native Go (`internal/collection/write.go`). The front-end no longer shells `python -m get_sybers_dxdfir.collection {select,unselect,unregister}`.

## Byte-compatible with the Python writer
A collection mutated by either side stays consistent for the other during the transition:
- Registry opened read-write with **`foreign_keys` ON** (a row delete cascades its `events`, as Python's `PRAGMA` does); schema applied `IF NOT EXISTS` so a mutation never hits a half-initialised store.
- **select** — clear every `selected` flag, set it on the target (errors if not registered); logs a `selected` event to the `events` table **and** `.collection.log`.
- **unselect** — clear the flag, return the previous name (`""` if none); a no-op that never creates/touches the DB when nothing is selected.
- **unregister** — drop the row (+ cascade events) and the `.collection` marker, leave evidence and the log in place; the `unregistered` event goes only to the on-disk log (the DB events are about to cascade away), matching Python.
- `.collection.log` lines use Python's `json.dumps` default spacing: `{"ts": "...", "event": "..."}`.

## Verification
- New write-path unit test: select/unselect/unregister incl. `events` rows, shadow-file upkeep, log-line spacing, and the error cases (select-unregistered, unregister-missing, second-unregister no-op).
- **Cross-tool round-trip** in a throwaway repo: Python `register` c1/c2 → Go `select c2` (Python then sees active `c2`) → Go `unregister c1` (Python's registered list drops it, marker gone). The shared `c2` `.collection.log` carries Python's `created` line and Go's `selected` line; every line parses as JSON.
- `go build`/`vet`/`test`/`gofmt` clean.

## Scope
Register/sort/hash and the classification behind them stay Python (Phases 3–4); `collQuery` remains only for the register write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJ7qymdmkEqM4YszuRWi1T