### PR TITLE
feat(collection): native Go SHA-1 manifest hashing (Phase 3 of #174)

### DIFF
--- a/go/internal/collect/collect.go
+++ b/go/internal/collect/collect.go
@@ -1,8 +1,9 @@
-// Package collect drives the collection-creation flows by shelling
-// `python -m get_sybers_dxdfir.collection` (the magic-byte classify + SHA-1 hash
-// stay the Python detectors, the source of truth) and translating its
-// ::dxdfir:: progress sentinels into the shared model.Update stream both
-// presenters consume.
+// Package collect drives the collection-creation flows. The classify phase
+// (register/sort) still shells `python -m get_sybers_dxdfir.collection` — the
+// magic-byte detectors are the source of truth — and its ::dxdfir:: progress
+// sentinels are folded into the shared model.Update stream. The SHA-1 hash
+// phase is now native Go (internal/collection, epic #174 phase 3): its progress
+// callbacks feed the SAME stream, so both presenters render identically.
 package collect
 
 import (
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/get-sybers/dx_dfir/go/internal/collection"
 	"github.com/get-sybers/dx_dfir/go/internal/model"
 	"github.com/get-sybers/dx_dfir/go/internal/repo"
 	"github.com/get-sybers/dx_dfir/go/internal/run"
@@ -71,7 +73,7 @@ func (r *Runner) Sort(ctx context.Context, name string, dryRun, doHash bool) <-c
 		moved := jsonInt(sortRes, "moved_count")
 		if doHash && !dryRun && moved > 0 {
 			st.phase = "hash"
-			hashRes, err = r.streamOp(ctx, updates, st, []string{"hash", name, "--progress"})
+			hashRes, err = r.hashNative(ctx, updates, st, name)
 		}
 		r.finish(ctx, updates, st, r.sortSummary(sortRes, hashRes, dryRun), err)
 	}()
@@ -98,7 +100,7 @@ func (r *Runner) Register(ctx context.Context, name, fromPath string, doHash boo
 		var hashRes map[string]any
 		if doHash {
 			st.phase = "hash"
-			hashRes, err = r.streamOp(ctx, updates, st, []string{"hash", name, "--progress"})
+			hashRes, err = r.hashNative(ctx, updates, st, name)
 		}
 		r.finish(ctx, updates, st, r.registerSummary(regRes, hashRes), err)
 	}()
@@ -127,6 +129,49 @@ func (r *Runner) streamOp(ctx context.Context, updates chan<- model.Update, st *
 		}
 	}
 	return result, <-done
+}
+
+// hashNative runs the SHA-1 manifest hash in-process (internal/collection —
+// epic #174 phase 3) instead of shelling `collection hash`, folding the native
+// progress callbacks into the SAME model.Update stream the ::dxdfir:: hash
+// sentinels used to drive, so both presenters render identically. Returns the
+// {sha1, files, bytes} map the summary builders expect (files/bytes as float64,
+// matching the JSON the subprocess used to return).
+func (r *Runner) hashNative(ctx context.Context, updates chan<- model.Update, st *state, name string) (map[string]any, error) {
+	var emitted int64
+	prog := collection.HashProgress{
+		OnStart: func(files int, total int64) {
+			st.hFileN = files
+			st.hTotal = total
+			st.send(ctx, updates)
+		},
+		OnFile: func(rel string, _ int64, idx, _ int) {
+			st.hFileIdx = idx + 1
+			if rel != "" && rel != st.hCur {
+				st.hCur = rel
+				st.files = appendCap(st.files, "RUN  "+rel)
+			}
+			st.send(ctx, updates)
+		},
+		OnChunk: func(n int64) {
+			st.hDone += n
+			// Throttle snapshots to ~8 MiB of progress (same cadence the Python
+			// --progress sentinels used), so a large file doesn't flood the channel.
+			if st.hDone-emitted >= (8 << 20) {
+				emitted = st.hDone
+				st.send(ctx, updates)
+			}
+		},
+	}
+	rollup, files, total, err := collection.WriteManifest(r.Repo.Root, name, prog)
+	if err != nil {
+		return nil, err
+	}
+	// One truthful terminal snapshot: hashing complete (done == total, all files).
+	st.hDone = total
+	st.hFileIdx = files
+	st.send(ctx, updates)
+	return map[string]any{"sha1": rollup, "files": float64(files), "bytes": float64(total)}, nil
 }
 
 func (st *state) fold(s run.Sentinel) {

--- a/go/internal/collection/collection_test.go
+++ b/go/internal/collection/collection_test.go
@@ -1,9 +1,12 @@
 package collection
 
 import (
+	"crypto/sha1"
 	"database/sql"
+	"encoding/hex"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -345,5 +348,140 @@ func TestSchemaEvolutionAddsSelected(t *testing.T) {
 	}
 	if st, _ := GetStatus(repo); st.Active != "old" {
 		t.Errorf("active=%q, want old", st.Active)
+	}
+}
+
+func TestHash(t *testing.T) {
+	repo := t.TempDir()
+	colls := filepath.Join(repo, "data_store", "raw", "collections")
+	write := func(rel string, data []byte) {
+		p := filepath.Join(colls, "h", rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("pcaps/a.pcap", []byte("AAAA"))     // 4 bytes
+	write("memory/m.raw", []byte("BBBBBB"))   // 6 bytes
+	write(".collection", []byte("name: h\n")) // control file — must NOT be hashed
+	seedRegistry(t, filepath.Join(colls, registryName), map[string]bool{"h": true})
+
+	sh := func(b []byte) string { s := sha1.Sum(b); return hex.EncodeToString(s[:]) }
+	hA, hM := sh([]byte("AAAA")), sh([]byte("BBBBBB"))
+	ds := []string{hA, hM}
+	sort.Strings(ds)
+	rr := sha1.Sum([]byte(strings.Join(ds, "")))
+	wantRollup := hex.EncodeToString(rr[:])
+
+	var startedTotal, chunkSum int64
+	var startedFiles, onFileCalls int
+	prog := HashProgress{
+		OnStart: func(files int, total int64) { startedFiles, startedTotal = files, total },
+		OnFile:  func(rel string, size int64, idx, total int) { onFileCalls++ },
+		OnChunk: func(n int64) { chunkSum += n },
+	}
+	rollup, files, total, err := WriteManifest(repo, "h", prog)
+	if err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+	if rollup != wantRollup {
+		t.Errorf("rollup=%s want %s", rollup, wantRollup)
+	}
+	if files != 2 || total != 10 {
+		t.Errorf("files=%d total=%d want 2/10", files, total)
+	}
+	if startedFiles != 2 || startedTotal != 10 || onFileCalls != 2 || chunkSum != 10 {
+		t.Errorf("progress: start(%d,%d) onFile=%d chunkSum=%d want 2/10/2/10", startedFiles, startedTotal, onFileCalls, chunkSum)
+	}
+
+	man, _ := os.ReadFile(filepath.Join(colls, "h", manifestName))
+	ms := string(man)
+	for _, want := range []string{
+		"# DX_DFIR collection manifest\n", "# collection: h\n",
+		"# collection_sha1: " + wantRollup + "\n", "# files: 2\n", "# columns: sha1  path\n",
+	} {
+		if !strings.Contains(ms, want) {
+			t.Errorf("manifest missing %q", want)
+		}
+	}
+	// body is path-sorted (memory/m.raw < pcaps/a.pcap) as "sha1  path"
+	wantBody := hM + "  memory/m.raw\n" + hA + "  pcaps/a.pcap\n"
+	if !strings.HasSuffix(ms, wantBody) {
+		t.Errorf("manifest body mismatch:\n%q\nwant suffix:\n%q", ms, wantBody)
+	}
+	if strings.Contains(ms, "  .collection\n") {
+		t.Error(".collection control file must not be hashed into the manifest")
+	}
+	if r := manifestRollup(filepath.Join(colls, "h")); r == nil || *r != wantRollup {
+		t.Errorf("manifestRollup reader = %v, want %s", r, wantRollup)
+	}
+
+	db, _ := sql.Open("sqlite", "file:"+filepath.Join(colls, registryName)+"?mode=ro")
+	defer db.Close()
+	var dsha string
+	var dfiles int
+	if err := db.QueryRow("SELECT sha1, files FROM collections WHERE name='h'").Scan(&dsha, &dfiles); err != nil {
+		t.Fatal(err)
+	}
+	if dsha != wantRollup || dfiles != 2 {
+		t.Errorf("collections row: sha1=%s files=%d", dsha, dfiles)
+	}
+	var lane string
+	if err := db.QueryRow("SELECT lane FROM files WHERE collection_name='h' AND path='pcaps/a.pcap'").Scan(&lane); err != nil {
+		t.Fatalf("files row for pcaps/a.pcap missing: %v", err)
+	}
+	if lane != "pcaps" {
+		t.Errorf("pcaps/a.pcap lane=%q want pcaps", lane)
+	}
+	var detail string
+	if err := db.QueryRow("SELECT detail FROM events WHERE name='h' AND event='hashed'").Scan(&detail); err != nil {
+		t.Fatalf("no hashed event: %v", err)
+	}
+	if !strings.Contains(detail, `"collection_sha1": "`+wantRollup+`"`) || !strings.Contains(detail, `"files": 2`) {
+		t.Errorf("hashed event detail=%s", detail)
+	}
+	logb, _ := os.ReadFile(filepath.Join(colls, "h", logName))
+	if !strings.Contains(string(logb), `"event": "hashed"`) || !strings.Contains(string(logb), `"files": 2}`) {
+		t.Errorf("log missing well-formed hashed event: %s", logb)
+	}
+}
+
+// TestHashUnregistered: hashing a collection not in the registry writes the
+// manifest but records NO files rows and NO "hashed" event (mirrors the
+// _record_file_hash / write_manifest guards).
+func TestHashUnregistered(t *testing.T) {
+	repo := t.TempDir()
+	colls := filepath.Join(repo, "data_store", "raw", "collections")
+	p := filepath.Join(colls, "u", "pcaps", "x.pcap")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("zzz"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedRegistry(t, filepath.Join(colls, registryName), map[string]bool{}) // DB exists, "u" not in it
+
+	rollup, files, _, err := WriteManifest(repo, "u", HashProgress{})
+	if err != nil {
+		t.Fatalf("WriteManifest(unregistered): %v", err)
+	}
+	if files != 1 || rollup == "" {
+		t.Errorf("files=%d rollup=%q", files, rollup)
+	}
+	if !isRegularFile(filepath.Join(colls, "u", manifestName)) {
+		t.Error("manifest should still be written for an unregistered collection")
+	}
+	db, _ := sql.Open("sqlite", "file:"+filepath.Join(colls, registryName)+"?mode=ro")
+	defer db.Close()
+	var n int
+	db.QueryRow("SELECT COUNT(*) FROM files WHERE collection_name='u'").Scan(&n)
+	if n != 0 {
+		t.Errorf("unregistered collection must record no files rows, got %d", n)
+	}
+	db.QueryRow("SELECT COUNT(*) FROM events WHERE name='u'").Scan(&n)
+	if n != 0 {
+		t.Errorf("unregistered collection must record no events, got %d", n)
 	}
 }

--- a/go/internal/collection/hash.go
+++ b/go/internal/collection/hash.go
@@ -1,0 +1,203 @@
+package collection
+
+import (
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// This file is the native-Go SHA-1 manifest hasher (epic #174, phase 3), a
+// byte-for-byte port of get_sybers_dxdfir.collection.{hash_collection,
+// write_manifest}: every evidence file is SHA-1'd, the collection rollup is the
+// SHA-1 of every file's hex digest sorted and concatenated (order-independent
+// change detection, NOT cryptographic integrity), the .collection.hashes
+// manifest is rewritten, and the registry (collections.sha1/files + the per-file
+// files rows + a "hashed" event) is updated exactly as the Python does.
+
+// HashProgress carries optional progress hooks so a front-end can render a
+// hashing gauge without reimplementing the read loop. Any field may be nil.
+type HashProgress struct {
+	OnStart func(files int, totalBytes int64)            // once, before hashing
+	OnFile  func(rel string, size int64, idx, total int) // before each file
+	OnChunk func(n int64)                                // per read chunk
+}
+
+// WriteManifest (re)computes a collection's hash manifest, persists it to
+// .collection.hashes, updates the per-file registry rows + collections.sha1/
+// files, and logs a "hashed" event (when registered). Returns the rollup, the
+// file count, and the total bytes hashed. Mirrors write_manifest.
+func WriteManifest(repoRoot, name string, p HashProgress) (rollup string, files int, totalBytes int64, err error) {
+	root, ok := collectionDir(repoRoot, name)
+	if !ok {
+		return "", 0, 0, fmt.Errorf("invalid collection name %q — use letters/digits then . _ -", name)
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return "", 0, 0, err
+	}
+
+	rels, sizes, total, err := evidenceRelpaths(root)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	if p.OnStart != nil {
+		p.OnStart(len(rels), total)
+	}
+
+	type fileHash struct{ rel, sum string }
+	perFile := make([]fileHash, 0, len(rels))
+	for idx, rel := range rels {
+		if p.OnFile != nil {
+			p.OnFile(rel, sizes[rel], idx, len(rels))
+		}
+		sum, herr := hashFile(filepath.Join(root, rel), p.OnChunk)
+		if herr != nil {
+			return "", 0, 0, herr
+		}
+		perFile = append(perFile, fileHash{rel, sum})
+	}
+	// rels are already path-sorted (manifest order). The rollup sorts the hex
+	// digests (NOT the paths) and concatenates them, so it is order-independent.
+	digests := make([]string, len(perFile))
+	for i, f := range perFile {
+		digests[i] = f.sum
+	}
+	sort.Strings(digests)
+	rh := sha1.Sum([]byte(strings.Join(digests, "")))
+	rollup = hex.EncodeToString(rh[:])
+
+	ts := now()
+	var b strings.Builder
+	fmt.Fprintf(&b, "# DX_DFIR collection manifest\n# collection: %s\n# collection_sha1: %s\n# files: %d\n# generated: %s\n# columns: sha1  path\n",
+		name, rollup, len(perFile), ts)
+	for _, f := range perFile {
+		fmt.Fprintf(&b, "%s  %s\n", f.sum, f.rel)
+	}
+	if err := os.WriteFile(filepath.Join(root, manifestName), []byte(b.String()), 0o644); err != nil {
+		return "", 0, 0, err
+	}
+
+	db, err := openWriteDB(repoRoot)
+	if err != nil {
+		return "", 0, 0, err
+	}
+	defer db.Close()
+	// UPDATE runs regardless (a no-op 0-row update for an unregistered collection).
+	if _, err := db.Exec("UPDATE collections SET sha1 = ?, files = ? WHERE name = ?", rollup, len(perFile), name); err != nil {
+		return "", 0, 0, err
+	}
+	// Per-file rows and the "hashed" event are written only for a registered
+	// collection (matching _record_file_hash / write_manifest's guard; also
+	// avoids a files→collections foreign-key violation for an unregistered one).
+	if registeredIn(db, name) {
+		for _, f := range perFile {
+			recordFileHash(db, name, f.rel, f.sum, sizes[f.rel], ts)
+		}
+		logEvent(db, root, name, ts, "hashed", [][2]any{
+			{"collection_sha1", rollup},
+			{"files", len(perFile)},
+		})
+	}
+	return rollup, len(perFile), total, nil
+}
+
+// evidenceRelpaths returns the collection's evidence files as root-relative
+// paths (sorted), their sizes, and the total byte count — the same set
+// evidence_files() hashes: regular non-symlink files, symlinked dirs not
+// followed, the three control files excluded. The root symlink (external
+// --from collections) is resolved so the walk descends into the real tree,
+// exactly as Python's os.walk on a symlinked root does.
+func evidenceRelpaths(root string) (rels []string, sizes map[string]int64, total int64, err error) {
+	walkRoot := root
+	if resolved, e := filepath.EvalSymlinks(root); e == nil {
+		walkRoot = resolved
+	}
+	control := map[string]bool{markerName: true, logName: true, manifestName: true}
+	sizes = map[string]int64{}
+	err = filepath.WalkDir(walkRoot, func(path string, d fs.DirEntry, e error) error {
+		if e != nil {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		rel, re := filepath.Rel(walkRoot, path)
+		if re != nil {
+			return nil
+		}
+		if control[rel] { // only the top-level control files (rel has no separator)
+			return nil
+		}
+		var sz int64
+		if info, ie := d.Info(); ie == nil {
+			sz = info.Size()
+		}
+		rels = append(rels, rel)
+		sizes[rel] = sz
+		total += sz
+		return nil
+	})
+	sort.Strings(rels)
+	return rels, sizes, total, err
+}
+
+// hashFile returns the SHA-1 hex digest of a file, read in 1 MiB chunks (the
+// same chunk size as _hash_file), invoking onChunk with each chunk's length.
+func hashFile(path string, onChunk func(int64)) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha1.New()
+	buf := make([]byte, 1<<20)
+	for {
+		n, rerr := f.Read(buf)
+		if n > 0 {
+			h.Write(buf[:n])
+			if onChunk != nil {
+				onChunk(int64(n))
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return "", rerr
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// laneFromRelpath infers the lane a path lives under (mirrors _lane_from_relpath);
+// "" means it maps to no lane (stored as NULL).
+func laneFromRelpath(rel string) string {
+	for _, sub := range laneSubdirs {
+		if rel == sub || strings.HasPrefix(rel, sub+"/") {
+			return sub
+		}
+	}
+	return ""
+}
+
+// recordFileHash upserts one files-table row with its fresh SHA-1 + size,
+// preserving an existing detected_by and defaulting new rows to 'manual'
+// (mirrors _record_file_hash). Best-effort.
+func recordFileHash(db *sql.DB, name, rel, sha1hex string, size int64, ts string) {
+	var lane any
+	if l := laneFromRelpath(rel); l != "" {
+		lane = l
+	}
+	_, _ = db.Exec(
+		"INSERT INTO files(collection_name, path, lane, detected_by, sha1, size, added_at) "+
+			"VALUES(?, ?, ?, 'manual', ?, ?, ?) "+
+			"ON CONFLICT(collection_name, path) DO UPDATE SET "+
+			"  lane = excluded.lane, sha1 = excluded.sha1, size = excluded.size",
+		name, rel, lane, sha1hex, size, ts)
+}

--- a/go/internal/collection/write.go
+++ b/go/internal/collection/write.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -101,9 +102,9 @@ func Select(repoRoot, name string) error {
 		return err
 	}
 	ts := now()
-	logEventDB(db, name, ts, "selected")
+	logEventDB(db, name, ts, "selected", nil)
 	if root, ok := collectionDir(repoRoot, name); ok {
-		logEventFile(root, ts, "selected")
+		logEventFile(root, ts, "selected", nil)
 	}
 	return nil
 }
@@ -128,9 +129,9 @@ func Unselect(repoRoot string) (string, error) {
 		return "", err
 	}
 	ts := now()
-	logEventDB(db, prev, ts, "unselected")
+	logEventDB(db, prev, ts, "unselected", nil)
 	if root, ok := collectionDir(repoRoot, prev); ok {
-		logEventFile(root, ts, "unselected")
+		logEventFile(root, ts, "unselected", nil)
 	}
 	return prev, nil
 }
@@ -163,7 +164,7 @@ func Unregister(repoRoot, name string) (bool, error) {
 		return false, nil
 	}
 	ts := now()
-	logEventFile(root, ts, "unregistered")
+	logEventFile(root, ts, "unregistered", nil)
 	if wasInDB {
 		db, err := openWriteDB(repoRoot)
 		if err != nil {
@@ -320,24 +321,62 @@ func importEventLog(db *sql.DB, name, logPath string) {
 	}
 }
 
-// logEventDB appends one detail-less event row; best-effort, like the on-disk log.
-func logEventDB(db *sql.DB, name, ts, event string) {
-	_, _ = db.Exec("INSERT INTO events(name, ts, event, detail) VALUES(?, ?, ?, NULL)", name, ts, event)
+// jsonVal renders a value as JSON the way Python's json.dumps default does — no
+// HTML escaping (Python does not escape <, >, &), scalar form for strings/ints.
+func jsonVal(v any) string {
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(v)
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// pyObj renders ordered key/value pairs as a JSON object with Python's
+// json.dumps default separators (", " and ": "), key order preserved.
+func pyObj(pairs [][2]any) string {
+	parts := make([]string, len(pairs))
+	for i, kv := range pairs {
+		parts[i] = jsonVal(fmt.Sprint(kv[0])) + ": " + jsonVal(kv[1])
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
+
+// logEventDB appends one event row; detail is a JSON object (Python spacing) or
+// NULL when empty. Best-effort, like the on-disk log.
+func logEventDB(db *sql.DB, name, ts, event string, detail [][2]any) {
+	var d any
+	if len(detail) > 0 {
+		d = pyObj(detail)
+	}
+	_, _ = db.Exec("INSERT INTO events(name, ts, event, detail) VALUES(?, ?, ?, ?)", name, ts, event, d)
 }
 
 // logEventFile appends one JSONL record to the collection's .collection.log,
-// byte-for-byte as the Python's _log_event_file does: json.dumps default
-// separators (a space after ':' and ','), key order ts then event. Best-effort
-// (a read-only symlinked target is silently skipped, matching the Python).
-func logEventFile(root, ts, event string) {
+// byte-for-byte as _log_event_file does: {"ts": .., "event": .., <detail..>}
+// with Python's json.dumps default spacing, key order ts, event, then detail.
+// Best-effort (a read-only symlinked target is silently skipped).
+func logEventFile(root, ts, event string, detail [][2]any) {
 	f, err := os.OpenFile(filepath.Join(root, logName), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return
 	}
 	defer f.Close()
-	tsB, _ := json.Marshal(ts)
-	evB, _ := json.Marshal(event)
-	_, _ = fmt.Fprintf(f, "{\"ts\": %s, \"event\": %s}\n", tsB, evB)
+	pairs := append([][2]any{{"ts", ts}, {"event", event}}, detail...)
+	_, _ = fmt.Fprintln(f, pyObj(pairs))
+}
+
+// logEvent writes an event to BOTH the events table and the on-disk
+// .collection.log (mirrors log_event): the DB is queryable, the JSONL is the
+// forensic shadow.
+func logEvent(db *sql.DB, root, name, ts, event string, detail [][2]any) {
+	logEventDB(db, name, ts, event, detail)
+	logEventFile(root, ts, event, detail)
+}
+
+// registeredIn reports whether name has a row in the given open registry DB.
+func registeredIn(db *sql.DB, name string) bool {
+	var one int
+	return db.QueryRow("SELECT 1 FROM collections WHERE name = ?", name).Scan(&one) == nil
 }
 
 // now is the registry timestamp format: UTC, second precision, trailing Z —


### PR DESCRIPTION
Phase 3 of epic #174. Ports the collection **hash** off Python — the hash phase of `register`/`sort` now runs in-process (`internal/collection/hash.go`) instead of shelling `python -m get_sybers_dxdfir.collection hash`.

## What
`WriteManifest` is a byte-for-byte port of `write_manifest`/`hash_collection`:
- SHA-1 each evidence file (1 MiB chunks); the collection **rollup** is the SHA-1 of every file's hex digest **sorted + concatenated** (order-independent change detection).
- Rewrite `.collection.hashes` with the exact header + `sha1␠␠path` body (path-sorted), control files excluded, symlinked-root (`--from`) collections resolved.
- Update `collections.sha1/files`, upsert the per-file `files` rows (lane inferred, `detected_by` preserved / `manual` for new), and log a `hashed` event — all **guarded to registered collections** (matches Python; avoids a `files→collections` FK violation for unregistered ones).

The event-log helpers now carry **ordered detail with Python's `json.dumps` spacing** (the `hashed` event is the first detail-bearing one); `select`/`unselect`/`unregister` keep emitting detail-less events unchanged.

`collect.Runner` feeds the native hash's progress callbacks into the **same `model.Update` stream** the `::dxdfir::` hash sentinels used to drive, so the TUI/plain presenters render identically. `register`/`sort` classify stays Python (Phase 4).

## Verified
- **Unit tests**: manifest header/body format, rollup, `files` rows + lane inference, `hashed` event detail, progress callbacks, and the unregistered no-op.
- **Cross-tool parity**: a Python-hashed vs Go-hashed collection with identical evidence produce **byte-identical `.collection.hashes`** (rollup + body) and **identical registry rows + `hashed`-event detail** (`{"collection_sha1": "…", "files": 2}`).
- `go build`/`vet`/`test`/`gofmt` clean.

## Scope
`register`/`sort` classification (magic-byte detectors) and its promote/link mechanics remain Python — Phase 4 (which keeps the log2timeline/plaso detector in Python per the epic carve-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJ7qymdmkEqM4YszuRWi1T