### PR TITLE
feat(collection): native classify + sort/register/promote/link (Phase 4 of #174)

### DIFF
--- a/go/internal/collect/collect.go
+++ b/go/internal/collect/collect.go
@@ -1,15 +1,15 @@
-// Package collect drives the collection-creation flows. The classify phase
-// (register/sort) still shells `python -m get_sybers_dxdfir.collection` — the
-// magic-byte detectors are the source of truth — and its ::dxdfir:: progress
-// sentinels are folded into the shared model.Update stream. The SHA-1 hash
-// phase is now native Go (internal/collection, epic #174 phase 3): its progress
-// callbacks feed the SAME stream, so both presenters render identically.
+// Package collect drives the collection-creation flows (register / promote /
+// link / sort, then the SHA-1 hash) entirely in native Go via internal/collection
+// (epic #174 phases 1-4) — no `python -m get_sybers_dxdfir.collection` subprocess.
+// Each op's progress callbacks are folded into the shared model.Update stream, so
+// the termui and plain presenters render identically.
 package collect
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -17,7 +17,6 @@ import (
 	"github.com/get-sybers/dx_dfir/go/internal/collection"
 	"github.com/get-sybers/dx_dfir/go/internal/model"
 	"github.com/get-sybers/dx_dfir/go/internal/repo"
-	"github.com/get-sybers/dx_dfir/go/internal/run"
 )
 
 const tailCap = 300
@@ -52,35 +51,38 @@ func newState(title string) *state {
 	return &state{title: title, start: time.Now(), tally: map[string]int{}}
 }
 
-// Sort runs `collection sort` (classify phase), then hashes when asked.
+// Sort classifies the dropzone into the collection's lanes (native), then hashes.
 func (r *Runner) Sort(ctx context.Context, name string, dryRun, doHash bool) <-chan model.Update {
 	updates := make(chan model.Update, 64)
 	go func() {
 		defer close(updates)
 		st := newState(r.Title)
 		st.phase = "classify"
-		st.send(ctx, updates)
-		args := []string{"sort", name, "--progress"}
-		if dryRun {
-			args = append(args, "--dry-run")
+		// denominator: the loose (non-dot) entries in the dropzone.
+		if entries, err := os.ReadDir(filepath.Join(r.Repo.Root, "data_store", "raw", "sort")); err == nil {
+			for _, e := range entries {
+				if !strings.HasPrefix(e.Name(), ".") {
+					st.cTotal++
+				}
+			}
 		}
-		sortRes, err := r.streamOp(ctx, updates, st, args)
+		st.send(ctx, updates)
+		sr, err := collection.SortInto(r.Repo.Root, name, dryRun, r.classifyItem(ctx, updates, st))
 		if err != nil {
-			r.finish(ctx, updates, st, r.sortSummary(sortRes, nil, dryRun), err)
+			r.finish(ctx, updates, st, r.sortSummary(sr, nil, dryRun), err)
 			return
 		}
 		var hashRes map[string]any
-		moved := jsonInt(sortRes, "moved_count")
-		if doHash && !dryRun && moved > 0 {
+		if doHash && !dryRun && sr.MovedCount() > 0 {
 			st.phase = "hash"
 			hashRes, err = r.hashNative(ctx, updates, st, name)
 		}
-		r.finish(ctx, updates, st, r.sortSummary(sortRes, hashRes, dryRun), err)
+		r.finish(ctx, updates, st, r.sortSummary(sr, hashRes, dryRun), err)
 	}()
 	return updates
 }
 
-// Register runs `collection register` (create/promote), then hashes when asked.
+// Register creates/promotes/links the collection (native), then hashes.
 func (r *Runner) Register(ctx context.Context, name, fromPath string, doHash bool) <-chan model.Update {
 	updates := make(chan model.Update, 64)
 	go func() {
@@ -88,13 +90,10 @@ func (r *Runner) Register(ctx context.Context, name, fromPath string, doHash boo
 		st := newState(r.Title)
 		st.phase = "classify"
 		st.send(ctx, updates)
-		args := []string{"register", name, "--progress"}
-		if fromPath != "" {
-			args = append(args, "--from", fromPath)
-		}
-		regRes, err := r.streamOp(ctx, updates, st, args)
+		// "manual" matches the retired CLI's --source default for a plain register.
+		rr, err := collection.Register(r.Repo.Root, name, fromPath, "manual", r.classifyItem(ctx, updates, st))
 		if err != nil {
-			r.finish(ctx, updates, st, r.registerSummary(regRes, nil), err)
+			r.finish(ctx, updates, st, r.registerSummary(rr, nil), err)
 			return
 		}
 		var hashRes map[string]any
@@ -102,33 +101,29 @@ func (r *Runner) Register(ctx context.Context, name, fromPath string, doHash boo
 			st.phase = "hash"
 			hashRes, err = r.hashNative(ctx, updates, st, name)
 		}
-		r.finish(ctx, updates, st, r.registerSummary(regRes, hashRes), err)
+		r.finish(ctx, updates, st, r.registerSummary(rr, hashRes), err)
 	}()
 	return updates
 }
 
-// streamOp runs one collection subcommand, folds its sentinels into st (emitting
-// a snapshot per sentinel), and returns the final JSON result printed on stdout.
-func (r *Runner) streamOp(ctx context.Context, updates chan<- model.Update, st *state, args []string) (map[string]any, error) {
-	full := append([]string{"-m", "get_sybers_dxdfir.collection", "--repo-root", r.Repo.Root}, args...)
-	plan := run.Plan{Bin: r.Python, Args: full, Dir: r.Repo.Root}
-	lines, done := run.Stream(ctx, plan)
-
-	var result map[string]any
-	for ln := range lines {
-		if s, ok := run.ParseSentinel(ln.Text); ok {
-			st.fold(s)
-			st.send(ctx, updates)
-			continue
-		}
-		if ln.Stream == "out" {
-			var m map[string]any
-			if json.Unmarshal([]byte(strings.TrimSpace(ln.Text)), &m) == nil {
-				result = m
+// classifyItem folds one native classify decision into st and emits a snapshot —
+// the same shape the retired ::dxdfir:: classify sentinels produced, so the
+// presenters render identically.
+func (r *Runner) classifyItem(ctx context.Context, updates chan<- model.Update, st *state) collection.ItemFn {
+	return func(item, subdir, how, action string) {
+		st.cDone++
+		if action == "moved" {
+			if _, seen := st.tally[subdir]; !seen {
+				st.tallyOrder = append(st.tallyOrder, subdir)
 			}
+			st.tally[subdir]++
+			st.decisions = appendCap(st.decisions, item+"  -> "+subdir+"/   ["+how+"]")
+		} else {
+			st.skips++
+			st.decisions = appendCap(st.decisions, item+"  -> SKIP   ("+how+")")
 		}
+		st.send(ctx, updates)
 	}
-	return result, <-done
 }
 
 // hashNative runs the SHA-1 manifest hash in-process (internal/collection —
@@ -172,47 +167,6 @@ func (r *Runner) hashNative(ctx context.Context, updates chan<- model.Update, st
 	st.hFileIdx = files
 	st.send(ctx, updates)
 	return map[string]any{"sha1": rollup, "files": float64(files), "bytes": float64(total)}, nil
-}
-
-func (st *state) fold(s run.Sentinel) {
-	switch s.Phase {
-	case "classify":
-		if s.Total > 0 {
-			st.cTotal = s.Total
-		}
-		if s.Action != "" {
-			st.cDone = s.Done
-			line := s.File + "  -> "
-			if s.Action == "moved" {
-				line += s.Lane + "/   [" + s.How + "]"
-				if _, seen := st.tally[s.Lane]; !seen {
-					st.tallyOrder = append(st.tallyOrder, s.Lane)
-				}
-				st.tally[s.Lane]++
-			} else {
-				st.skips++
-				line += "SKIP   (" + s.How + ")"
-			}
-			st.decisions = appendCap(st.decisions, line)
-		}
-	case "hash":
-		if s.TotalBytes > 0 {
-			st.hTotal = s.TotalBytes
-		}
-		if s.FileTotal > 0 {
-			st.hFileN = s.FileTotal
-		}
-		if s.DoneBytes > 0 {
-			st.hDone = s.DoneBytes
-		}
-		if s.File != "" && s.FileDone > 0 {
-			st.hFileIdx = s.FileDone
-			if s.File != st.hCur {
-				st.hCur = s.File
-				st.files = appendCap(st.files, fmt.Sprintf("RUN  %s", s.File))
-			}
-		}
-	}
 }
 
 func (st *state) send(ctx context.Context, updates chan<- model.Update) {
@@ -267,44 +221,36 @@ func (r *Runner) finish(ctx context.Context, updates chan<- model.Update, st *st
 	sendUpdate(ctx, updates, model.Update{Snapshot: final, Done: true, Err: err})
 }
 
-func (r *Runner) sortSummary(sortRes, hashRes map[string]any, dryRun bool) []string {
+func (r *Runner) sortSummary(sr collection.SortResult, hashRes map[string]any, dryRun bool) []string {
 	var b []string
 	verb := "moved"
 	if dryRun {
 		verb = "would move"
 	}
 	b = append(b, fmt.Sprintf("-- %s --", r.Title))
-	if sortRes != nil {
-		if moved, ok := sortRes["moved"].(map[string]any); ok && len(moved) > 0 {
-			b = append(b, fmt.Sprintf("  %s:", verb))
-			for _, lane := range sortedKeys(moved) {
-				if arr, ok := moved[lane].([]any); ok {
-					b = append(b, fmt.Sprintf("    %-14s %d file(s)", lane, len(arr)))
-				}
-			}
-		} else {
-			b = append(b, "  nothing to sort (dropzone empty or all skipped)")
+	if sr.MovedCount() > 0 {
+		b = append(b, fmt.Sprintf("  %s:", verb))
+		for _, lane := range sortedKeysSS(sr.Moved) {
+			b = append(b, fmt.Sprintf("    %-14s %d file(s)", lane, len(sr.Moved[lane])))
 		}
-		if sk, ok := sortRes["skipped"].([]any); ok && len(sk) > 0 {
-			b = append(b, fmt.Sprintf("  skipped in dropzone (%d):", len(sk)))
-			for _, e := range sk {
-				if pair, ok := e.([]any); ok && len(pair) == 2 {
-					b = append(b, fmt.Sprintf("    %v  (%v)", pair[0], pair[1]))
-				}
-			}
+	} else {
+		b = append(b, "  nothing to sort (dropzone empty or all skipped)")
+	}
+	if len(sr.Skipped) > 0 {
+		b = append(b, fmt.Sprintf("  skipped in dropzone (%d):", len(sr.Skipped)))
+		for _, sk := range sr.Skipped {
+			b = append(b, fmt.Sprintf("    %s  (%s)", sk[0], sk[1]))
 		}
 	}
 	b = append(b, hashLine(hashRes)...)
 	return b
 }
 
-func (r *Runner) registerSummary(regRes, hashRes map[string]any) []string {
+func (r *Runner) registerSummary(rr collection.RegisterResult, hashRes map[string]any) []string {
 	var b []string
 	b = append(b, fmt.Sprintf("-- %s --", r.Title))
-	if regRes != nil {
-		if root, ok := regRes["root"].(string); ok {
-			b = append(b, "  registered at "+root)
-		}
+	if rr.Root != "" {
+		b = append(b, "  registered at "+rr.Root)
 	}
 	b = append(b, hashLine(hashRes)...)
 	return b
@@ -348,7 +294,7 @@ func tailOf(s []string) []string {
 	return append([]string(nil), s...)
 }
 
-func sortedKeys(m map[string]any) []string {
+func sortedKeysSS(m map[string][]string) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)

--- a/go/internal/collection/classify.go
+++ b/go/internal/collection/classify.go
@@ -1,0 +1,221 @@
+package collection
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// This file ports the collection classifier (epic #174, phase 4): where a raw
+// evidence file sorts to, magic-first, reusing the processors' own detectors —
+// pcap magic (zeek), disk-image/VM magic + extension (the plaso module's
+// detect_format/ext_format, which are pure header/extension sniffing, NOT the
+// log2timeline PROCESSOR, which stays in Docker/Ansible), memory-dump and
+// EVTX extensions. Content beats extension, so a mislabelled image is filed by
+// its real type.
+
+// pcapMagic mirrors zeek._PCAP_MAGIC (4-byte header hex).
+var pcapMagic = map[string]bool{
+	"a1b2c3d4": true, "d4c3b2a1": true, "a1b23c4d": true, "4d3cb2a1": true, "0a0d0d0a": true,
+}
+
+var pcapExts = []string{".pcap", ".pcapng", ".cap"}
+
+// memoryExts mirrors volatility._MEMORY_EXTS (plus the "*dramimage" suffix).
+var memoryExts = []string{".raw", ".mem", ".dmp", ".lime", ".vmem", ".bin", ".dump", ".vmsn", ".crash"}
+
+// diskFormats / vmFormats mirror _DISK_FORMATS / _VM_FORMATS.
+var diskFormats = map[string]bool{"ewf1": true, "ewf2": true, "ewf-cont": true, "qcow2": true, "aff": true, "raw": true}
+var vmFormats = map[string]bool{"vmdk": true, "vmdk-extent": true, "vhd": true, "vhdx": true}
+
+var vmdkExtentRe = regexp.MustCompile(`-flat\.vmdk$|-delta\.vmdk$|-s[0-9]+\.vmdk$`)
+
+// headHex reads the first n bytes of a file and returns them lower-hex.
+func headHex(path string, n int) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	buf := make([]byte, n)
+	m, _ := f.Read(buf)
+	return hexLower(buf[:m])
+}
+
+func hexLower(b []byte) string {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, len(b)*2)
+	for i, c := range b {
+		out[2*i] = hexdigits[c>>4]
+		out[2*i+1] = hexdigits[c&0x0f]
+	}
+	return string(out)
+}
+
+// isPcap mirrors zeek.is_pcap: content magic first, extension fallback.
+func isPcap(path string) bool {
+	if pcapMagic[headHex(path, 4)] {
+		return true
+	}
+	low := strings.ToLower(path)
+	for _, e := range pcapExts {
+		if strings.HasSuffix(low, e) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMemoryImage mirrors volatility.is_memory_image (extension-based).
+func isMemoryImage(name string) bool {
+	low := strings.ToLower(name)
+	for _, e := range memoryExts {
+		if strings.HasSuffix(low, e) {
+			return true
+		}
+	}
+	return strings.HasSuffix(low, "dramimage")
+}
+
+// detectFormat mirrors plaso.detect_format: identify a disk-image/VM file by
+// content (a few header bytes + a VHD footer) → ewf1|ewf-cont|ewf2|vmdk|qcow2|
+// vhdx|vhd, "" when no signature matches.
+func detectFormat(path string) string {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return ""
+	}
+	h := headHex(path, 8)
+	switch {
+	case h == "455646090d0aff00": // EWF "EVF\x09\x0d\x0a\xff\x00"
+		// segment number: uint16 LE at offset 9; only segment 1 heads the set.
+		segno := 0
+		if f, e := os.Open(path); e == nil {
+			seg := make([]byte, 2)
+			if _, e := f.ReadAt(seg, 9); e == nil {
+				segno = int(seg[0]) | int(seg[1])<<8
+			}
+			f.Close()
+		}
+		if segno == 1 {
+			return "ewf1"
+		}
+		return "ewf-cont"
+	case h == "455646320d0a8100": // EWF2
+		return "ewf2"
+	case strings.HasPrefix(h, "4b444d56"): // "KDMV" monolithic sparse VMDK
+		return "vmdk"
+	case strings.HasPrefix(h, "514649fb"): // "QFI\xfb"
+		return "qcow2"
+	case h == "7668647866696c65": // "vhdxfile"
+		return "vhdx"
+	case h == "636f6e6563746978": // "conectix" (dynamic VHD header)
+		return "vhd"
+	}
+	// VMDK text descriptor.
+	if f, e := os.Open(path); e == nil {
+		d := make([]byte, 64)
+		n, _ := f.Read(d)
+		f.Close()
+		if strings.HasPrefix(string(d[:n]), "# Disk DescriptorFile") {
+			return "vmdk"
+		}
+	}
+	// A fixed-format VHD carries "conectix" only in its 512-byte footer.
+	if fi.Size() >= 512 {
+		if f, e := os.Open(path); e == nil {
+			foot := make([]byte, 8)
+			if _, e := f.ReadAt(foot, fi.Size()-512); e == nil && hexLower(foot) == "636f6e6563746978" {
+				f.Close()
+				return "vhd"
+			}
+			f.Close()
+		}
+	}
+	return ""
+}
+
+// extFormat mirrors plaso.ext_format: the format implied by the file name.
+func extFormat(name string) string {
+	n := strings.ToLower(filepath.Base(name))
+	switch {
+	case vmdkExtentRe.MatchString(n):
+		return "vmdk-extent"
+	case strings.HasSuffix(n, ".e01"):
+		return "ewf1"
+	case regexp.MustCompile(`\.e[0-9][0-9]$`).MatchString(n):
+		return "ewf-cont"
+	case strings.HasSuffix(n, ".vmdk"):
+		return "vmdk"
+	case strings.HasSuffix(n, ".vhd"):
+		return "vhd"
+	case strings.HasSuffix(n, ".vhdx"):
+		return "vhdx"
+	case strings.HasSuffix(n, ".aff"):
+		return "aff"
+	case strings.HasSuffix(n, ".raw"), strings.HasSuffix(n, ".img"), strings.HasSuffix(n, ".dd"):
+		return "raw"
+	}
+	return ""
+}
+
+// contentSubdir mirrors _content_subdir: the lane subdir from magic bytes alone.
+func contentSubdir(path string) string {
+	if pcapMagic[headHex(path, 4)] {
+		return "pcaps"
+	}
+	switch f := detectFormat(path); {
+	case diskFormats[f]:
+		return "disk_images"
+	case vmFormats[f]:
+		return "VM_files"
+	}
+	return ""
+}
+
+// extSubdirs mirrors _ext_subdirs: the lane subdirs claiming a file by name.
+func extSubdirs(path string) map[string]bool {
+	claims := map[string]bool{}
+	if isPcap(path) {
+		claims["pcaps"] = true
+	}
+	switch f := extFormat(path); {
+	case diskFormats[f]:
+		claims["disk_images"] = true
+	case vmFormats[f]:
+		claims["VM_files"] = true
+	}
+	if isMemoryImage(filepath.Base(path)) {
+		claims["memory"] = true
+	}
+	if strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".evtx") {
+		claims["logs/winevt"] = true
+	}
+	return claims
+}
+
+// Classify mirrors classify(): (subdir, detectedBy). subdir is "" for
+// ambiguous/unknown. detectedBy is "magic" | "ext" | "ambiguous:a,b" | "unknown".
+func Classify(path string) (subdir, detectedBy string) {
+	if magic := contentSubdir(path); magic != "" {
+		return magic, "magic"
+	}
+	claims := extSubdirs(path)
+	if len(claims) == 0 {
+		return "", "unknown"
+	}
+	if len(claims) > 1 {
+		keys := make([]string, 0, len(claims))
+		for k := range claims {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return "", "ambiguous:" + strings.Join(keys, ",")
+	}
+	for k := range claims {
+		return k, "ext"
+	}
+	return "", "unknown"
+}

--- a/go/internal/collection/collection_test.go
+++ b/go/internal/collection/collection_test.go
@@ -485,3 +485,123 @@ func TestHashUnregistered(t *testing.T) {
 		t.Errorf("unregistered collection must record no events, got %d", n)
 	}
 }
+
+func TestClassify(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(name string, data []byte) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	ewf := append([]byte{0x45, 0x56, 0x46, 0x09, 0x0d, 0x0a, 0xff, 0x00, 0x00}, []byte{0x01, 0x00}...) // EVF hdr + seg=1
+	cases := []struct {
+		file       string
+		data       []byte
+		wantSubdir string
+		wantBy     string
+	}{
+		{"cap.bin", []byte{0xa1, 0xb2, 0xc3, 0xd4, 0x00}, "pcaps", "magic"},   // pcap magic
+		{"img.e01", ewf, "disk_images", "magic"},                              // EWF magic (seg 1)
+		{"vm.kdmv", []byte("KDMV____"), "VM_files", "magic"},                  // VMDK sparse magic
+		{"log.evtx", []byte("ElfFile\x00"), "logs/winevt", "ext"},             // evtx by ext
+		{"dump.mem", []byte("no magic here"), "memory", "ext"},                // memory by ext
+		{"disk.e01x", []byte("no magic"), "", "unknown"},                      // .e01x: no magic, no ext claim
+		{"raw.raw", []byte("headerless"), "", "ambiguous:disk_images,memory"}, // .raw: disk (ext) + memory (ext)
+		{"notes.txt", []byte("hello"), "", "unknown"},                         // nothing recognises it
+	}
+	for _, c := range cases {
+		sub, by := Classify(mk(c.file, c.data))
+		if sub != c.wantSubdir || by != c.wantBy {
+			t.Errorf("Classify(%s) = (%q, %q), want (%q, %q)", c.file, sub, by, c.wantSubdir, c.wantBy)
+		}
+	}
+}
+
+func TestSortRegisterPromoteLink(t *testing.T) {
+	repo := t.TempDir()
+	colls := filepath.Join(repo, "data_store", "raw", "collections")
+	dz := filepath.Join(repo, "data_store", "raw", "sort")
+	stage := func(p string, data []byte) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pcap := []byte{0xa1, 0xb2, 0xc3, 0xd4, 0x01, 0x02}
+
+	// --- promote: a dropzone folder with a loose pcap + a hand-staged memory file ---
+	stage(filepath.Join(dz, "promoted", "capture.bin"), pcap)              // loose, classifies to pcaps by magic
+	stage(filepath.Join(dz, "promoted", "memory", "m.mem"), []byte("mem")) // already in a lane
+	rr, err := Register(repo, "promoted", filepath.Join(dz, "promoted"), "manual", nil)
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if !rr.Promoted {
+		t.Error("promote: Promoted=false")
+	}
+	if !isRegularFile(filepath.Join(colls, "promoted", "pcaps", "capture.bin")) {
+		t.Error("promote: loose pcap not moved into pcaps/")
+	}
+	db, _ := sql.Open("sqlite", "file:"+filepath.Join(colls, registryName)+"?mode=ro")
+	assertRow := func(q string, args ...any) int {
+		var n int
+		if err := db.QueryRow(q, args...).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		return n
+	}
+	if assertRow("SELECT COUNT(*) FROM collections WHERE name='promoted' AND source='promote'") != 1 {
+		t.Error("promote: no registry row with source=promote")
+	}
+	if assertRow("SELECT COUNT(*) FROM files WHERE collection_name='promoted'") != 2 {
+		t.Error("promote: expected 2 files rows (moved pcap + hand-staged memory)")
+	}
+	if assertRow("SELECT COUNT(*) FROM events WHERE name='promoted' AND event='registered'") != 1 {
+		t.Error("promote: no 'registered' event")
+	}
+	db.Close()
+
+	// --- sort: drop a loose evtx into the dropzone, sort into the registered coll ---
+	stage(filepath.Join(dz, "win.evtx"), []byte("ElfFile\x00"))
+	sr, err := SortInto(repo, "promoted", false, nil)
+	if err != nil {
+		t.Fatalf("sort: %v", err)
+	}
+	if len(sr.Moved["logs/winevt"]) != 1 {
+		t.Errorf("sort: evtx not moved to logs/winevt; moved=%v", sr.Moved)
+	}
+	if !isRegularFile(filepath.Join(colls, "promoted", "logs/winevt", "win.evtx")) {
+		t.Error("sort: evtx not on disk in logs/winevt/")
+	}
+	db, _ = sql.Open("sqlite", "file:"+filepath.Join(colls, registryName)+"?mode=ro")
+	if assertRow("SELECT COUNT(*) FROM events WHERE name='promoted' AND event='sorted'") != 1 {
+		t.Error("sort: no 'sorted' event")
+	}
+	db.Close()
+
+	// --- link: register an external dir via symlink ---
+	ext := filepath.Join(repo, "external_evidence")
+	stage(filepath.Join(ext, "pcaps", "e.pcap"), pcap)
+	if _, err := Register(repo, "linked", ext, "manual", nil); err != nil {
+		t.Fatalf("link: %v", err)
+	}
+	if !isSymlink(filepath.Join(colls, "linked")) {
+		t.Error("link: collections/linked is not a symlink")
+	}
+	db, _ = sql.Open("sqlite", "file:"+filepath.Join(colls, registryName)+"?mode=ro")
+	defer db.Close()
+	var src, target string
+	if err := db.QueryRow("SELECT source, target_path FROM collections WHERE name='linked'").Scan(&src, &target); err != nil {
+		t.Fatal(err)
+	}
+	if src != "link" {
+		t.Errorf("link: source=%q want link", src)
+	}
+	if assertRow("SELECT COUNT(*) FROM files WHERE collection_name='linked'") != 1 {
+		t.Error("link: external evidence not recorded")
+	}
+}

--- a/go/internal/collection/sortreg.go
+++ b/go/internal/collection/sortreg.go
@@ -1,0 +1,391 @@
+package collection
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This file ports the collection sort + register/promote/link mechanics (epic
+// #174, phase 4): moving classified evidence into a collection's lane subdirs,
+// promoting a dropzone folder, symlinking an external tree, and the registry +
+// on-disk-shadow bookkeeping around each — all native Go, byte-compatible with
+// get_sybers_dxdfir.collection. The magic-byte classifier lives in classify.go;
+// the SHA-1 manifest (the trailing hash pass) lives in hash.go.
+
+// ItemFn streams one classification decision as it happens: action is "moved",
+// "skip", or "directory". subdir/detectedBy match classify()'s outputs.
+type ItemFn func(item, subdir, detectedBy, action string)
+
+// SortResult mirrors SortResult: which files moved into which lane subdir, and
+// what was skipped (filename, reason).
+type SortResult struct {
+	Moved   map[string][]string
+	Skipped [][2]string
+}
+
+// MovedCount is the total files moved across all lanes.
+func (s SortResult) MovedCount() int {
+	n := 0
+	for _, v := range s.Moved {
+		n += len(v)
+	}
+	return n
+}
+
+// RegisterResult mirrors the register JSON: the collection name/root and whether
+// it was promoted (a --from that resolved to the dropzone or an external dir).
+type RegisterResult struct {
+	Name       string
+	Root       string
+	Registered bool
+	Promoted   bool
+}
+
+// SortInto classifies each loose file in the dropzone and moves it into the
+// named collection's matching lane subdir (mirrors sort_into). onItem may be nil.
+func SortInto(repoRoot, name string, dryRun bool, onItem ItemFn) (SortResult, error) {
+	res := SortResult{Moved: map[string][]string{}}
+	root, ok := collectionDir(repoRoot, name)
+	if !ok {
+		return res, fmt.Errorf("invalid collection name %q — use letters/digits then . _ -", name)
+	}
+	if !isDir(root) {
+		return res, fmt.Errorf("no such collection %q — create it first: dxdfir collection create --name %s", name, name)
+	}
+	dz := dropzoneRoot(repoRoot)
+	_ = os.MkdirAll(dz, 0o755)
+
+	// Only touch the registry when the collection is registered (recordFile /
+	// the "sorted" event are no-ops otherwise) — and never on a dry run.
+	var db *sql.DB
+	if !dryRun {
+		if reg, err := readRegistry(repoRoot); err == nil && reg.nameSet[name] {
+			if db, err = openWriteDB(repoRoot); err != nil {
+				return res, err
+			}
+			defer db.Close()
+		}
+	}
+
+	note := func(item, subdir, how, action string) {
+		if onItem != nil {
+			onItem(item, subdir, how, action)
+		}
+	}
+	entries, err := os.ReadDir(dz) // sorted by name
+	if err != nil {
+		return res, err
+	}
+	for _, e := range entries {
+		nm := e.Name()
+		if strings.HasPrefix(nm, ".") {
+			continue
+		}
+		p := filepath.Join(dz, nm)
+		if e.IsDir() {
+			reason := "directory — register as its own collection or move its files up"
+			res.Skipped = append(res.Skipped, [2]string{nm + "/", reason})
+			note(nm+"/", "", "directory", "skip")
+			continue
+		}
+		subdir, how := Classify(p)
+		if subdir == "" {
+			res.Skipped = append(res.Skipped, [2]string{nm, how})
+			note(nm, "", how, "skip")
+			continue
+		}
+		dest := filepath.Join(root, subdir, nm)
+		if pathExists(dest) {
+			res.Skipped = append(res.Skipped, [2]string{nm, "already in " + subdir + "/"})
+			note(nm, subdir, how, "skip")
+			continue
+		}
+		if !dryRun {
+			if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+				return res, err
+			}
+			if err := moveFile(p, dest); err != nil {
+				return res, err
+			}
+			if db != nil {
+				recordFile(db, name, root, dest, how)
+			}
+		}
+		res.Moved[subdir] = append(res.Moved[subdir], nm)
+		note(nm, subdir, how, "moved")
+	}
+	if !dryRun && res.MovedCount() > 0 && db != nil {
+		logEvent(db, root, name, now(), "sorted", [][2]any{{"moved", res.MovedCount()}, {"skipped", len(res.Skipped)}})
+	}
+	return res, nil
+}
+
+// Register is the unified register entry point (mirrors register): from=""
+// ensures + registers the collection dir; from==dropzone/<name> promotes it;
+// from==elsewhere symlinks an external tree. source labels the plain-register
+// path (the CLI default is "manual"). onItem streams the promote classify.
+func Register(repoRoot, name, fromPath, source string, onItem ItemFn) (RegisterResult, error) {
+	if !ValidName(name) {
+		return RegisterResult{}, fmt.Errorf("invalid collection name %q — use letters/digits then . _ -", name)
+	}
+	root, _ := collectionDir(repoRoot, name)
+	db, err := openWriteDB(repoRoot)
+	if err != nil {
+		return RegisterResult{}, err
+	}
+	defer db.Close()
+
+	if fromPath != "" {
+		fp := resolvePath(fromPath)
+		dzT := ""
+		if isDir(dropzoneRoot(repoRoot)) {
+			dzT = resolvePath(filepath.Join(dropzoneRoot(repoRoot), name))
+		}
+		if dzT != "" && fp == dzT {
+			return promote(db, repoRoot, name, onItem)
+		}
+		if !isDir(fp) {
+			return RegisterResult{}, fmt.Errorf("--from path is not an existing directory: %s", fp)
+		}
+		return linkExternal(db, repoRoot, name, fp)
+	}
+
+	if isDir(root) || isSymlink(root) {
+		already := registeredIn(db, name)
+		if !isRegularFile(filepath.Join(root, markerName)) {
+			writeMarker(root, name)
+		}
+		if !already {
+			upsertCollection(db, repoRoot, name, source, "")
+			logEvent(db, root, name, now(), "registered", [][2]any{{"source", source}})
+		}
+		_ = os.MkdirAll(dropzoneRoot(repoRoot), 0o755)
+		return RegisterResult{Name: name, Root: root, Registered: true}, nil
+	}
+	return create(db, repoRoot, name)
+}
+
+// create mirrors _create: make the lane subdirs and register (idempotent).
+func create(db *sql.DB, repoRoot, name string) (RegisterResult, error) {
+	root, _ := collectionDir(repoRoot, name)
+	dirExisted := isDir(root)
+	hadMarker := isRegularFile(filepath.Join(root, markerName))
+	for _, sub := range laneSubdirs {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o755); err != nil {
+			return RegisterResult{}, err
+		}
+	}
+	if !hadMarker {
+		writeMarker(root, name)
+		// Match _create exactly, quirk included: registering an already-existing
+		// dir logs "registered" with detail {source:"create"} while the row's
+		// source is "register"; a fresh create logs "created" with no detail.
+		if dirExisted {
+			upsertCollection(db, repoRoot, name, "register", "")
+			logEvent(db, root, name, now(), "registered", [][2]any{{"source", "create"}})
+		} else {
+			upsertCollection(db, repoRoot, name, "create", "")
+			logEvent(db, root, name, now(), "created", nil)
+		}
+	}
+	_ = os.MkdirAll(dropzoneRoot(repoRoot), 0o755)
+	return RegisterResult{Name: name, Root: root, Registered: true}, nil
+}
+
+// promote mirrors _promote: move dropzone/<name> into collections/<name>,
+// register it, classify loose files at the root into lanes, and record every
+// evidence file (including those hand-staged into lane subdirs).
+func promote(db *sql.DB, repoRoot, name string, onItem ItemFn) (RegisterResult, error) {
+	dest, _ := collectionDir(repoRoot, name)
+	src := filepath.Join(dropzoneRoot(repoRoot), name)
+	if !isDir(src) {
+		return RegisterResult{}, fmt.Errorf("no dropzone folder at data_store/raw/sort/%s/", name)
+	}
+	if pathExists(dest) || isSymlink(dest) {
+		return RegisterResult{}, fmt.Errorf("collections/%s/ already exists — cannot promote over it", name)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return RegisterResult{}, err
+	}
+	if err := os.Rename(src, dest); err != nil { // dropzone + collections share a filesystem
+		return RegisterResult{}, err
+	}
+	for _, sub := range laneSubdirs {
+		_ = os.MkdirAll(filepath.Join(dest, sub), 0o755)
+	}
+	writeMarker(dest, name)
+	upsertCollection(db, repoRoot, name, "promote", "")
+	logEvent(db, dest, name, now(), "registered", [][2]any{{"source", "promote"}})
+
+	control := map[string]bool{markerName: true, logName: true, manifestName: true}
+	entries, _ := os.ReadDir(dest) // sorted
+	for _, e := range entries {
+		nm := e.Name()
+		if e.IsDir() || control[nm] || strings.HasPrefix(nm, ".") {
+			continue
+		}
+		p := filepath.Join(dest, nm)
+		subdir, how := Classify(p)
+		if subdir != "" {
+			target := filepath.Join(dest, subdir, nm)
+			if !pathExists(target) {
+				if err := moveFile(p, target); err != nil {
+					return RegisterResult{}, err
+				}
+				recordFile(db, name, dest, target, how)
+			}
+			if onItem != nil {
+				onItem(nm, subdir, how, "moved")
+			}
+		} else if onItem != nil {
+			onItem(nm, "", how, "skip")
+		}
+	}
+	// Every file already in a lane subdir counts as classified too.
+	if rels, _, _, err := evidenceRelpaths(dest); err == nil {
+		for _, rel := range rels {
+			if !fileRowExists(db, name, rel) {
+				recordFile(db, name, dest, filepath.Join(dest, rel), "manual")
+			}
+		}
+	}
+	return RegisterResult{Name: name, Root: dest, Registered: true, Promoted: true}, nil
+}
+
+// linkExternal mirrors _link_external: register a collection whose evidence
+// lives outside the repo via a directory symlink collections/<name> → target.
+func linkExternal(db *sql.DB, repoRoot, name, target string) (RegisterResult, error) {
+	if !isDir(target) {
+		return RegisterResult{}, fmt.Errorf("target path %s is not an existing directory", target)
+	}
+	dest, _ := collectionDir(repoRoot, name)
+	if pathExists(dest) || isSymlink(dest) {
+		return RegisterResult{}, fmt.Errorf("collections/%s/ already exists — remove or rename it first", name)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return RegisterResult{}, err
+	}
+	if err := os.Symlink(target, dest); err != nil {
+		return RegisterResult{}, err
+	}
+	for _, sub := range laneSubdirs {
+		_ = os.MkdirAll(filepath.Join(target, sub), 0o755)
+	}
+	writeMarker(target, name)
+	upsertCollection(db, repoRoot, name, "link", target)
+	logEvent(db, target, name, now(), "registered", [][2]any{{"source", "link"}, {"target", target}})
+	if rels, _, _, err := evidenceRelpaths(target); err == nil {
+		for _, rel := range rels {
+			recordFile(db, name, target, filepath.Join(target, rel), "manual")
+		}
+	}
+	_ = os.MkdirAll(dropzoneRoot(repoRoot), 0o755)
+	return RegisterResult{Name: name, Root: dest, Registered: true, Promoted: true}, nil
+}
+
+// --- helpers ---
+
+// recordFile upserts one files-table row at classify time (sha1 left NULL for
+// the hash pass), preserving nothing on conflict but lane/detected_by/size
+// (mirrors _record_file). No-op for an unregistered collection.
+func recordFile(db *sql.DB, name, root, path, detectedBy string) {
+	if !registeredIn(db, name) {
+		return
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return
+	}
+	var size any
+	if fi, e := os.Stat(path); e == nil {
+		size = fi.Size()
+	}
+	var lane any
+	if l := laneFromRelpath(rel); l != "" {
+		lane = l
+	}
+	_, _ = db.Exec(
+		"INSERT INTO files(collection_name, path, lane, detected_by, size, added_at) "+
+			"VALUES(?, ?, ?, ?, ?, ?) "+
+			"ON CONFLICT(collection_name, path) DO UPDATE SET "+
+			"  lane = excluded.lane, detected_by = excluded.detected_by, size = excluded.size",
+		name, rel, lane, detectedBy, size, now())
+}
+
+func fileRowExists(db *sql.DB, name, rel string) bool {
+	var one int
+	return db.QueryRow("SELECT 1 FROM files WHERE collection_name = ? AND path = ?", name, rel).Scan(&one) == nil
+}
+
+// upsertCollection mirrors _upsert_collection: insert the row or refresh its
+// target_path. target defaults to the collection dir; resolve() it as Python does.
+func upsertCollection(db *sql.DB, repoRoot, name, source, targetPath string) {
+	target := targetPath
+	if target == "" {
+		target, _ = collectionDir(repoRoot, name)
+	}
+	target = resolvePath(target)
+	_, _ = db.Exec(
+		"INSERT INTO collections(name, target_path, registered_at, source) VALUES(?, ?, ?, ?) "+
+			"ON CONFLICT(name) DO UPDATE SET target_path = excluded.target_path",
+		name, target, now(), source)
+}
+
+// writeMarker writes the .collection shadow (best-effort; a read-only symlinked
+// target is silently skipped, as the DB is authoritative — mirrors _write_marker).
+func writeMarker(root, name string) {
+	_ = os.WriteFile(filepath.Join(root, markerName),
+		[]byte("name: "+name+"\nregistered_at: "+now()+"\n"), 0o644)
+}
+
+// resolvePath mirrors Path.resolve(): absolute + symlinks resolved, tolerant of
+// a non-existent path (still absolutised).
+func resolvePath(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	if rp, err := filepath.EvalSymlinks(p); err == nil {
+		return rp
+	}
+	return p
+}
+
+// moveFile renames src→dst, falling back to copy+remove across filesystems.
+func moveFile(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		in.Close()
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		in.Close()
+		out.Close()
+		return err
+	}
+	in.Close()
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Remove(src)
+}
+
+func pathExists(p string) bool {
+	_, err := os.Lstat(p)
+	return err == nil
+}
+
+func isSymlink(p string) bool {
+	fi, err := os.Lstat(p)
+	return err == nil && fi.Mode()&os.ModeSymlink != 0
+}


### PR DESCRIPTION
Phase 4 of epic #174 — the last code phase. Classification and the sort/register/promote/link mechanics are native Go now (`classify.go`, `sortreg.go`), so `collect.Runner` drives register/sort/hash with **no `python -m get_sybers_dxdfir.collection` subprocess at all**.

## What
- **classify.go** — ports the processors' own detectors: pcap magic (zeek), memory-dump + EVTX extensions, and the disk-image/VM format sniffing (EWF/VMDK/VHD/VHDX/QCOW2 **magic** + a VHD footer + extension regex). These are pure header/extension checks — **not** the log2timeline PROCESSOR (which stays in Docker/Ansible, untouched). "Content beats extension" is preserved.
- **sortreg.go** — `SortInto` + `Register` (create / promote / link), the classify-time `files`-row upsert, marker/log/registry bookkeeping, and dropzone→collection moves, reusing the Phase 2/3 registry writer + hasher.
- **collect.go** — folds native classify + hash progress into the same `model.Update` stream the `::dxdfir::` sentinels drove; removes the now-dead `streamOp`/`fold` sentinel machinery.

## Verified
- Unit tests: the full **classify decision matrix** (magic pcap/EWF/VMDK, ext evtx/memory/disk, `ambiguous:`, `unknown`); **sort + promote + link** end-to-end (files rows, lanes, `detected_by`, `registered`/`sorted` events, symlink).
- **Cross-tool parity**: Python promote+hash vs native promote+hash on an identical mixed dropzone → **identical file layout, identical `files` rows (path/lane/detected_by), identical events, byte-identical manifest rollup**.
- `go build`/`vet`/`test`/`gofmt` clean.

## One intentional difference
`collections.source` is `promote` (Go) vs `migrated` (Python) on the promote path — a Python quirk where `_upsert_collection`'s `_db()` re-migrates the just-written marker *before* the upsert (whose `ON CONFLICT` leaves `source` untouched). The column is informational (nothing reads it for behavior); Go records the accurate value and rows stay fully interoperable.

## Remaining
Phase 5: retire the Python `collection` module (the one remaining shell is `resolveCollection`'s auto-register on `process`; then delete `collection.py` and keep a parity fixture test). STIX + the tool-wrapping processors are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJ7qymdmkEqM4YszuRWi1T