### PR TITLE
chore: drop dead progress-sentinel code + refresh stale collection docs

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -105,9 +105,10 @@ internal/
   cli/                 cobra verb tree, one file per verb group
   model/               shared types (Update/Snapshot/Lane) + the Presenter interface
   repo/                repo + interpreter/tool discovery
-  run/                 subprocess engine (passthrough, stream, capture, sentinels)
+  run/                 subprocess engine (passthrough, stream, capture)
   lanes/               `process` orchestration: lane specs, output-glob watching, the Job
-  collect/             collection orchestration: drives `python -m …collection`, parses sentinels
+  collect/             collection orchestration: native register/sort/promote/link + SHA-1 hash (internal/collection), no subprocess
+  collection/          native collection layer: SQLite registry, classify, sort/register, hashing
   tui/                 termui presenter (process + collection dashboards, event loop)
   plain/               non-TTY presenter (same channel contract)
   termdetect/          TTY detection + opt-outs

--- a/go/internal/run/marker.go
+++ b/go/internal/run/marker.go
@@ -1,15 +1,9 @@
 package run
 
 import (
-	"encoding/json"
 	"regexp"
 	"strings"
 )
-
-// SentinelPrefix marks a machine-readable progress line the Python helpers emit
-// on stderr, e.g.  ::dxdfir:: {"phase":"hash","done_bytes":123,...}
-// Everything else on the stream is treated as human log text.
-const SentinelPrefix = "::dxdfir::"
 
 var ansiRE = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
 
@@ -25,37 +19,4 @@ func Sanitize(line string) string {
 	line = ansiRE.ReplaceAllString(line, "")
 	line = strings.ReplaceAll(line, "](", "] (")
 	return strings.TrimRight(line, " \t")
-}
-
-// Sentinel is a decoded ::dxdfir:: progress line. Fields are optional; a consumer
-// reads the ones relevant to the phase it drives. (The collection layer that
-// emitted these is native Go now; retained as the shared progress-line schema.)
-type Sentinel struct {
-	Phase      string `json:"phase"`       // "classify" | "move" | "hash" | "summary" | "note"
-	File       string `json:"file"`        // current file basename
-	Lane       string `json:"lane"`        // destination lane / bucket
-	How        string `json:"how"`         // classify decision: magic|ext|ambiguous:..|unknown
-	Action     string `json:"action"`      // moved|skip
-	Reason     string `json:"reason"`      // skip reason
-	Done       int    `json:"done"`        // items completed
-	Total      int    `json:"total"`       // items total
-	DoneBytes  int64  `json:"done_bytes"`  // bytes hashed so far
-	TotalBytes int64  `json:"total_bytes"` // bytes to hash
-	FileDone   int    `json:"file_done"`   // file index (hash phase)
-	FileTotal  int    `json:"file_total"`  // file count (hash phase)
-	Text       string `json:"text"`        // free-form note / summary text
-}
-
-// ParseSentinel returns the decoded sentinel if line is one, else ok=false.
-func ParseSentinel(line string) (Sentinel, bool) {
-	s := strings.TrimSpace(line)
-	if !strings.HasPrefix(s, SentinelPrefix) {
-		return Sentinel{}, false
-	}
-	payload := strings.TrimSpace(strings.TrimPrefix(s, SentinelPrefix))
-	var out Sentinel
-	if err := json.Unmarshal([]byte(payload), &out); err != nil {
-		return Sentinel{}, false
-	}
-	return out, true
 }


### PR DESCRIPTION
Post-epic-#174 tidy-up (the two loose ends noted when Phase 5 landed).

## What
- **Remove the orphaned `::dxdfir::` sentinel machinery** from `internal/run/marker.go` — `SentinelPrefix`, the `Sentinel` struct, `ParseSentinel`, and the now-unused `encoding/json` import. Its only consumer was `collect`'s `streamOp`/`fold`, deleted when the collection layer went native in Phase 4. `run.Sanitize` + `ansiRE` are **kept** — they're the canonical display sanitizer the `lanes`/`tui` local copies mirror (comments point at it).
- **Refresh `go/README.md`'s module-layout section**: `run/` no longer lists "sentinels", `collect/` is described as native (no `python -m …collection` subprocess), and the new `internal/collection` package is listed.

## Verification
No behaviour change. `go build`/`vet`/`test`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJ7qymdmkEqM4YszuRWi1T